### PR TITLE
Initial PoC for db-service helpers

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1505,7 +1505,7 @@ function cqn4sql(query, model = cds.context?.model || cds.model) {
    * @returns the flat name of the element
    */
   function getFullName(node, name = node.name) {
-    if (node.parent.kind === 'entity') return name
+    if (!node.parent || node.parent.kind === 'entity') return name
 
     return getFullName(node.parent, `${node.parent.name}_${name}`)
   }

--- a/db-service/lib/helpers/computed.js
+++ b/db-service/lib/helpers/computed.js
@@ -1,0 +1,469 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('computed')
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+
+module.exports = (db = cds.db) => {
+  db.Functions = functions
+  db._helpers = db._helpers || {}
+  db._helpers.compute = true
+  db.on('SELECT', computed.bind(db))
+}
+
+const computed = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+  // cqn properties that contain functions
+  // expr columns, groupBy, orderBy
+  // xpr where, having, from.join.on
+  const allRefs = []
+  const alias = cqn.SELECT.from.as
+  // TODO: collect all internal aliases
+  const hasXpr = extract(cqn, alias ? { [alias]: true } : {}, allRefs)
+
+  // If the query does not contain any computations continue
+  if (!hasXpr) {
+    return next()
+  }
+
+  // Re uses the previous processor when available
+  if (cqn._processor) {
+    return cqn._processor(req.data)
+  }
+
+  const rawQuery = cqn.clone ? cqn.clone() : cds.ql.clone(cqn)
+  rawQuery.__internal__ = true
+
+  const additionalRefs = allRefs.filter(
+    r =>
+      (!alias || r.ref[0] === alias) &&
+      !cqn.SELECT.columns.find(c => c.ref?.[c.ref?.length - 1] === r.ref[r.ref.length - 1])
+  )
+
+  // Enhance select columns with calculation relevant references
+  rawQuery.SELECT.columns = [...rawQuery.SELECT.columns, ...additionalRefs]
+
+  // Calculate column processing to determine whether there are aggregate functions used
+  const cols = rawQuery.SELECT.columns
+    .map(c => {
+      const functionCalls = []
+      const columnAlias = c.as || c.val || c.func || c.ref?.[c.ref?.length - 1]
+      const js = `res[${JSON.stringify(columnAlias)}] = ${compile.call(this, c, rawQuery, functionCalls)}${
+        this._helpers.where && columnAlias === '__where__' ? ';if(!res.__where__)continue' : ''
+      }`
+      return {
+        js,
+        alias: columnAlias,
+        hasSubQueries: /this.run\(/.test(js),
+        // If one function is an aggregate function this column has to be calculated after all row level function
+        aggregate: functionCalls.find(fn => fn.aggregate)
+      }
+    })
+    // Sort columns to allow for early filtering
+    .sort((a, b) => {
+      if (a.hasSubQueries && !b.hasSubQueries) return 1
+      if (b.hasSubQueries) return -1
+      const isPriv = /__.*__/
+      if (isPriv.test(a.alias) && !isPriv.test(b.alias)) return 1
+      if (isPriv.test(b.alias)) return -1
+      return 0
+    })
+
+  // Remove all columns containing calculations
+  rawQuery.SELECT.columns = rawQuery.SELECT.columns.filter(
+    c => !('xpr' in c || 'func' in c || 'val' in c || 'list' in c || 'SELECT' in c)
+  )
+
+  const hasAggregate = cols.find(c => c.aggregate)
+  if (hasAggregate) {
+    // Disable groupBy as the full dataset is required for the aggregate functions
+    rawQuery.SELECT.groupBy = undefined
+    // Remove limit and one as the aggregate requires all data
+    rawQuery.SELECT.limit = undefined
+    rawQuery.SELECT.one = undefined
+  }
+
+  const transformations = []
+
+  Array.prototype.push.apply(
+    transformations,
+    cols.filter(c => !c.aggregate).map(c => c.js)
+  )
+
+  if (hasAggregate) {
+    // Calculate groupBy when defined on the query
+    if (rawQuery.SELECT.groupBy) {
+      const groupByFunctions = []
+      transformations.push(
+        `res.__groupBy__ = [${rawQuery.SELECT.groupBy.map(expr =>
+          compile.call(this, expr, rawQuery, groupByFunctions)
+        )}]`
+      )
+      if (groupByFunctions.find(fn => fn.aggregate)) {
+        cds.error`Aggregate functions are note allowed in groupBy clause`
+      }
+    } else {
+      const groupByCols = cols.filter(c => c.alias.startsWith('__groupBy'))
+      if (groupByCols.length) {
+        transformations.push(`res.__groupBy__ = [${groupByCols.map(c => `res[${JSON.stringify(c.alias)}]`)}]`)
+      }
+    }
+  }
+
+  const aggregateTransformations = cols.filter(c => c.aggregate).map(c => c.js)
+
+  const processorDefinition = `
+data = await data
+if(!data || !data.length) {
+  return data
+}
+data = data.slice()
+
+let i
+${hasAggregate ? 'const groups = {}' : 'let pos = 0'}
+for(i = 0; i < data.length; i++) {
+  const row = data[i]
+  const res = {}
+  ${transformations.join('\n')}
+  ${
+    hasAggregate
+      ? `
+  const groupKey = String(res.__groupBy__)
+  delete res.__groupBy__
+  const group = groups[groupKey] = groups[groupKey] || []
+  group.push(res)
+`
+      : 'data[pos++] = res'
+  }
+}
+
+${
+  hasAggregate
+    ? `
+const groupKeys = Object.keys(groups)
+for(i = 0; i < groupKeys.length; i++) {
+  const group = groups[groupKeys[i]]
+  const res = group[0]
+  // TODO: check whether this alias check should be removed as well
+  const row = ${alias ? '{' + JSON.stringify(alias) + ':res}' : 'res'}
+  ${aggregateTransformations.join('\n')}
+  data[i] = res
+}
+
+data.splice(i)`
+    : 'data.splice(pos)'
+}
+
+return data
+`
+
+  const rawData = this.run(rawQuery)
+  const process = new AsyncFunction('data', 'rawQuery', 'params', processorDefinition).bind(this, rawData, rawQuery)
+  process.src = processorDefinition
+
+  let originalQuery = cqn
+  let curLevel = originalQuery
+  while (curLevel.__proto__) {
+    curLevel = curLevel.__proto__
+    if (curLevel.SELECT) {
+      originalQuery = curLevel
+    }
+  }
+  originalQuery._processor = process
+  return process(req.data)
+}
+
+// Extraction
+const extract = function (cqn, aliases, refs) {
+  const SELECT = function ({ SELECT }) {
+    return SELECT
+      ? [
+          SELECT.columns?.map(expr),
+          SELECT.groupBy?.map(expr),
+          SELECT.orderBy?.map(expr),
+          xpr({ xpr: SELECT.where }),
+          xpr({ xpr: SELECT.having }),
+          xpr({ xpr: SELECT.from?.join?.on }),
+          xpr(SELECT.from)
+        ]
+          .flat(Infinity)
+          .filter(a => a)
+          .reduce((l, c) => l || c, false)
+      : []
+  }
+
+  const expr = function (x) {
+    if (x === undefined) return
+    if (typeof x !== 'object') throw cds.error`Unsupported expr: ${x}`
+    if ('param' in x) return true
+    if ('ref' in x) {
+      if (x.ref[0] in aliases) {
+        refs.push(x)
+      }
+      return
+    }
+    if ('val' in x) return true
+    if ('xpr' in x) {
+      xpr(x, refs)
+      return true
+    }
+    if ('func' in x) {
+      expr({ list: x.args }, refs)
+      return true
+    }
+    if ('list' in x) return x.list.reduce((l, c) => expr(c, refs) || l, false)
+    if ('SELECT' in x) return SELECT(x, refs)
+    else throw cds.error`Unsupported expr: ${x}`
+  }
+
+  const xpr = function ({ xpr }) {
+    return (xpr || []).reduce((l, x) => {
+      if (typeof x === 'string') return true
+      else return expr(x, refs) || l
+    }, false)
+  }
+  return SELECT(cqn)
+}
+
+// Compilation
+const compile = function (expr, query, funcs = []) {
+  const columnMap = {}
+  query.SELECT.columns.forEach(c => {
+    if (c.ref) {
+      const path = c.ref
+      columnMap[path] = c.as || c.ref[c.ref.length - 1]
+    }
+  })
+
+  const compExpr = x => {
+    if (typeof x !== 'object') return JSON.stringify(x)
+
+    if ('param' in x) {
+      return `params${x.ref.map(r => `[${JSON.stringify(r)}]`).join('')}`
+    }
+    if ('ref' in x) {
+      const resultName = columnMap[x.ref]
+      // TODO: check whether the resultName can be undefined
+      return !resultName ? JSON.stringify(x) : `row[${JSON.stringify(resultName)}]`
+    }
+    if ('val' in x) {
+      if ('cast' in x) {
+        const inputConverter = x.element[this.constructor._convertInput]
+        if (inputConverter) {
+          return `(${inputConverter})(${compExpr({ val: x.val })},cds.builtin.types[${JSON.stringify(x.element.type)}])`
+        }
+      }
+      if (x.val instanceof RegExp) {
+        return JSON.stringify(x.val.source)
+      }
+      if (typeof x.val === 'function') {
+        cds.error`A val cannot be a function`
+      }
+      return JSON.stringify(x.val ?? null)
+    }
+    if ('xpr' in x) return `(${compXpr(x)})`
+    if ('func' in x) {
+      const func = functions[x.func]
+      if (!func) {
+        cds.error`Unknown function ${x.func}`
+      }
+      funcs.push(func)
+      return `this.Functions[${JSON.stringify(x.func)}].fn${
+        func.aggregate ? `(group,${JSON.stringify(x.args)})` : `(row,[${x.args.map(compExpr)}])`
+      }`
+    }
+    if ('list' in x) {
+      return `[${x.list.map(compExpr)}]`
+    }
+    if ('SELECT' in x)
+      return `(await this.run(
+  cds.ql.SELECT${x.SELECT.one ? '.one' : ''}${
+        x.SELECT.columns ? `.columns(${JSON.stringify(x.SELECT.columns)})` : ''
+      }.from(${JSON.stringify(x.SELECT.from)})${
+        x.SELECT.where ? `.where([${x.SELECT.where.map(w => subSELECT(w, x.SELECT.from.as))}])` : ''
+      }${x.SELECT.groupBy ? `.groupBy(${compExpr({ xpr: x.SELECT.groupBy })})` : ''}${
+        x.SELECT.having ? `.having(${compExpr({ xpr: x.SELECT.having })})` : ''
+      }${x.SELECT.orderBy ? `.orderBy(${compExpr({ xpr: x.SELECT.orderBy })})` : ''}${
+        x.SELECT.limit ? `.limit(${JSON.stringify(x.SELECT.limit)}` : ''
+      },
+  row
+))`
+    // return cds.error`TODO: ADD SUB SELECT SUPPORT`
+    cds.error`UNKNOWN EXPR ${JSON.stringify(x)}`
+  }
+
+  const subSELECT = (x, alias) => {
+    if (alias && x.ref && x.ref.length > 1 && x.ref[0] !== alias) {
+      x = { ref: x.ref.slice(1), param: true }
+    }
+    return JSON.stringify(x)
+  }
+
+  const compXpr = ({ xpr }) => {
+    return (xpr || [])
+      .map((x, i, xpr) => {
+        if (typeof x === 'string') {
+          const ops = x.trim().split(' ')
+          return ops
+            .map(x => {
+              const op = operators[x.toUpperCase()]
+              if (op == null) {
+                cds.error`Unknown operator ${JSON.stringify(x)}`
+              }
+              return typeof op === 'function' ? op(x, i, xpr) : op
+            })
+            .join(' ')
+        }
+        return compExpr(x)
+      })
+      .join(' ')
+  }
+  return compExpr(expr)
+}
+
+// Operators
+String.prototype.like = function (pattern) {
+  return this.match(pattern instanceof RegExp ? pattern : pattern.replace(/%/g, '.*').replace(/_/g, '.'))
+}
+
+const operators = {
+  EXISTS: `'0' in `,
+  IN: 'in',
+  '=': '===',
+  '!=': '!==',
+  '>': '>',
+  '<': '<',
+  '>=': '>=',
+  '<=': '<=',
+  '||': '+',
+  AND: '&&',
+  OR: '||',
+  NOT: '!',
+  LIKE: (e, i, expr) => {
+    // Put brackets around pattern string
+    expr[i + 1] = { xpr: [expr[i + 1]] }
+    return '?.like?.'
+  },
+
+  CASE: '',
+  WHEN: '(',
+  THEN: ')?(',
+  ELSE: '):(',
+  END: (e, i, expr) => {
+    const hasElse = expr.slice(expr.slice(0, i).lastIndexOf('case'), i).lastIndexOf('else') > -1
+    return hasElse ? ')' : ':null)'
+  }
+}
+
+// Functions
+const functions = {
+  count: {
+    aggregate: true,
+    fn: (data /*args*/) => {
+      return data.length
+    }
+  },
+  countdistinct: {
+    aggregate: true,
+    fn: (data, [col]) => {
+      const prop = col.ref[col.ref.length - 1]
+      const found = {}
+      for (let i = 0; i < data.length; i++) {
+        found[data[i][prop]] = true
+      }
+      return Object.keys(found).length
+    }
+  },
+  avg: {
+    aggregate: true,
+    fn: (data, [col]) => {
+      const prop = col.ref[1]
+      let avg = 0
+      const cnt = data.length
+      for (let i = 0; i < data.length; i++) {
+        avg += data[i][prop] / cnt
+      }
+      return avg
+    }
+  },
+  sum: {
+    aggregate: true,
+    fn: (data, [col]) => {
+      const prop = col.ref[1]
+      let total = 0
+      for (let i = 0; i < data.length; i++) {
+        total += data[i][prop]
+      }
+      return total
+    }
+  },
+  max: {
+    aggregate: true,
+    fn: (data, [col]) => {
+      const prop = col.ref[1]
+      let max = data[0][prop] || 0
+      for (let i = 1; i < data.length; i++) {
+        if (data[i][prop] > max) {
+          max = data[i][prop]
+        }
+      }
+      return max
+    }
+  },
+  min: {
+    aggregate: true,
+    fn: (data, [col]) => {
+      const prop = col.ref[1]
+      let min = data[0][prop] || 0
+      for (let i = 1; i < data.length; i++) {
+        if (data[i][prop] < min) {
+          min = data[i][prop]
+        }
+      }
+      return min
+    }
+  },
+
+  search: {
+    // TODO: make sure that args are not compiled, but raw cqn
+    fn: (row, [cols, match]) => {
+      if (!cols?.length) cds.error`SEARCH MISSING COLUMN LIST ARGUMENT`
+      if (!match || !match.length) cds.error`SEARCH MISSING TERM ARGUMENT`
+
+      const regexp = new RegExp(match, 'i')
+
+      // Check all columns references for the sub string
+      for (var i = 0; i < cols.length; i++) {
+        if (cols[i]?.match?.(regexp)) return true
+      }
+      return false
+    }
+  },
+
+  // String functions
+  length: { fn: (row, [str]) => str.length },
+  indexof: { fn: (row, [str, subStr]) => str?.indexOf(subStr) },
+  substring: { fn: (row, [str, s, e]) => str?.slice(s, e === undefined ? undefined : s + e) },
+  trim: { fn: (row, [str]) => str?.trim() },
+  contains: { fn: (row, [str, subStr]) => str?.indexOf(subStr) > -1 },
+  endswith: { fn: (row, [str, subStr]) => str?.endsWith(subStr) || false },
+  startswith: { fn: (row, [str, subStr]) => str?.startsWith(subStr) || false },
+  tolower: { fn: (row, [str]) => str.toLowerCase() },
+  toupper: { fn: (row, [str]) => str.toUpperCase() },
+  concat: { fn: (row, args) => args.join('') },
+
+  // Numbers
+  ceiling: { fn: (row, [nr]) => Math.ceil(nr) },
+  floor: { fn: (row, [nr]) => Math.floor(nr) },
+  round: { fn: (row, [nr]) => Math.round(nr) },
+
+  // Date
+  year: { fn: (row, [date]) => (date instanceof Date ? date : new Date(date)).getUTCFullYear() },
+  month: { fn: (row, [date]) => (date instanceof Date ? date : new Date(date)).getUTCMonth() + 1 },
+  day: { fn: (row, [date]) => (date instanceof Date ? date : new Date(date)).getUTCDate() },
+  hour: { fn: (row, [date]) => (date instanceof Date ? date : new Date(date)).getUTCHours() },
+  minute: { fn: (row, [date]) => (date instanceof Date ? date : new Date(date)).getUTCMinutes() },
+  second: { fn: (row, [date]) => (date instanceof Date ? date : new Date(date)).getUTCSeconds() }
+}
+
+functions.average = functions.avg

--- a/db-service/lib/helpers/count.js
+++ b/db-service/lib/helpers/count.js
@@ -1,0 +1,45 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('count')
+
+module.exports = (db = cds.db) => {
+  db.on('SELECT', count.bind(db))
+}
+
+const count = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.SELECT.count) {
+    return next()
+  }
+
+  const clone = cqn.clone()
+  clone.__internal__ = true
+
+  clone.SELECT.count = undefined
+  const data = await this.run(clone, req.data)
+  data.$count = await requiresCountQuery.call(this, clone, data)
+
+  return data
+}
+
+const requiresCountQuery = async function (query, ret) {
+  if (ret) {
+    const { one, limit: _ } = query.SELECT,
+      n = ret.length
+    const [max, offset = 0] = one ? [1] : _ ? [_.rows?.val, _.offset?.val] : []
+    if (max === undefined || (n < max && (n || !offset))) return n + offset
+  }
+  const cq = cds.ql.clone(query, {
+    columns: [{ func: 'count' }],
+    localized: false,
+    expand: false,
+    one: true,
+    // hide properties
+    limit: undefined,
+    orderBy: undefined,
+    count: undefined
+  })
+  const { count } = await this.run({ query: cq })
+  return count
+}

--- a/db-service/lib/helpers/groupBy.js
+++ b/db-service/lib/helpers/groupBy.js
@@ -1,0 +1,43 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('groupBy')
+
+module.exports = (db = cds.db) => {
+  db.on('SELECT', groupBy.bind(db))
+}
+
+const groupBy = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.SELECT.groupBy) {
+    return next()
+  }
+
+  const clone = cqn.clone()
+  clone.__internal__ = true
+
+  // Remove having clause and moves it into a '__groupBy__' column
+  const groupBy = clone.SELECT.groupBy
+  clone.SELECT.columns = [...clone.SELECT.columns, ...groupBy.map((c, i) => ({ __proto__: c, as: `__groupBy${i}__` }))]
+  clone.SELECT.groupBy = undefined
+
+  const data = await this.run(clone, req.data)
+  if (!data || !data.length) {
+    return data
+  }
+
+  const groups = {}
+  let pos = 0
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i]
+    const key = `${groupBy.map((_, i) => row[`__groupBy${i}__`])}`
+    if (!groups[key]) {
+      data[pos++] = row
+      groups[key] = true
+    }
+  }
+
+  data.splice(pos)
+
+  return data
+}

--- a/db-service/lib/helpers/having.js
+++ b/db-service/lib/helpers/having.js
@@ -1,0 +1,25 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('having')
+
+module.exports = (db = cds.db) => {
+  db.on('SELECT', having.bind(db))
+}
+
+const having = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.SELECT.having) {
+    return next()
+  }
+
+  const clone = cqn.clone()
+  clone.__internal__ = true
+
+  // Remove having clause and moves it into a '__having__' column
+  clone.SELECT.columns = [...clone.SELECT.columns, { xpr: clone.SELECT.having, as: '__having__' }]
+  clone.SELECT.having = undefined
+
+  const data = await this.run(clone, req.data)
+  return data?.filter(r => r.__having__)
+}

--- a/db-service/lib/helpers/join.js
+++ b/db-service/lib/helpers/join.js
@@ -1,0 +1,124 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('groupBy')
+
+const columnMap = require('./projection').columnMap
+
+module.exports = (db = cds.db) => {
+  db.on('SELECT', join.bind(db))
+}
+
+const join = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  const from = cqn.SELECT.from
+  // needs to be a string as sub selects have join as a function
+  if (typeof from.join !== 'string') {
+    return next()
+  }
+
+  const normJoin = {}
+
+  const isRight = from.join === 'right'
+  const isCross = from.join === 'cross'
+  const isInner = from.join === 'inner'
+  normJoin.root = from.args[isRight ? 1 : 0]
+  normJoin.target = from.args[isRight ? 0 : 1]
+
+  // TODO: define columns that are required not just *
+  const rootQuery = cds.ql.SELECT()
+  rootQuery.SELECT.from = normJoin.root
+  rootQuery.__internal__ = true
+
+  const crossQuery = cds.ql.SELECT()
+  crossQuery.SELECT.from = normJoin.target
+  crossQuery.__internal__ = true
+
+  const rootAliases = aliases(normJoin.root)
+  const rootAlias = alias(normJoin.root)
+  const targetAlias = alias(normJoin.target)
+
+  let [rootData, crossData] = await Promise.all([
+    this.run(rootQuery, req.data),
+    isCross ? this.run(crossQuery, req.data) : []
+  ])
+
+  console.log(rootData.length)
+  const subQuery = cds.ql.SELECT.from(normJoin.target).where(on({ xpr: from.on }, rootAliases))
+  subQuery.__internal__ = true
+
+  const data = (
+    await Promise.all(
+      rootData.map(async row => {
+        let targetData
+        if (isCross) {
+          targetData = crossData
+        } else {
+          targetData = await this.run(subQuery, rootAlias ? { [rootAlias]: row } : row)
+        }
+        if (!isInner && targetData.length === 0) {
+          targetData.push({})
+        }
+
+        return targetData.map(
+          rootAlias
+            ? targetRow => ({ [targetAlias]: targetRow, [rootAlias]: row })
+            : targetAlias
+            ? targetRow => ({ [targetAlias]: targetRow, ...row })
+            : targetRow => ({ ...targetRow, ...row })
+        )
+      })
+    )
+  ).flat()
+
+  if (cqn.SELECT.columns) {
+    columnMap(cqn)(data)
+  }
+
+  return data
+}
+
+const aliases = function (from) {
+  const ret = {}
+  const as = alias(from)
+  if (!as) {
+    Object.assign(ret, ...from.args.map(aliases))
+  } else {
+    ret[as] = true
+  }
+  return ret
+}
+
+const alias = function (from) {
+  return from.as || (from.ref && from.ref[from.ref.length - 1])
+}
+
+// Replace all refs to the source with the row data
+const on = function (on, aliases) {
+  const expr = function (x) {
+    if (x === undefined) return
+    if (typeof x === 'string') throw cds.error`Unsupported expr: ${x}`
+    if ('param' in x) return x
+    if ('ref' in x) {
+      if (x.ref[0] in aliases) {
+        x.param = true
+      }
+      return x
+    }
+    if ('val' in x) return x
+    if ('xpr' in x) return xpr(x)
+    if ('func' in x) return { __proto__: x, args: (x.args || []).map(expr) }
+    if ('list' in x) return { list: x.list.map(expr) }
+    if ('SELECT' in x) throw cds.error`SELECT is not supported in on condition ${x}`
+    else throw cds.error`Unsupported expr: ${x}`
+  }
+
+  const xpr = function ({ xpr }) {
+    return (xpr || []).map(x => {
+      if (typeof x === 'string') return x
+      else return expr(x)
+    })
+  }
+
+  return expr(on)
+}

--- a/db-service/lib/helpers/limit.js
+++ b/db-service/lib/helpers/limit.js
@@ -1,0 +1,34 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('limit')
+
+module.exports = (db = cds.db) => {
+  db.on('SELECT', limit.bind(db))
+}
+
+const limit = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.SELECT.limit && !cqn.SELECT.one) {
+    return next()
+  }
+
+  const clone = cqn.clone()
+  clone.__internal__ = true
+
+  const limit = clone.SELECT.limit || { rows: { val: 1 } }
+  clone.SELECT.limit = undefined
+  clone.SELECT.one = undefined
+
+  const data = await this.run(clone, req.data)
+  if (!data || !data.length) {
+    return data
+  }
+  const offset = limit.offset?.val || 0
+
+  // Splice to retain the $count property
+  data.splice(0, offset)
+  data.splice(offset + limit.rows.val)
+
+  return data
+}

--- a/db-service/lib/helpers/managed.js
+++ b/db-service/lib/helpers/managed.js
@@ -1,0 +1,71 @@
+const cds = require('@sap/cds/lib'),
+  DEBUG = cds.log('managed')
+
+module.exports = (db = cds.db) => {
+  for (let entity of db.entities) {
+    const on_insert = Object.values(entity.elements).filter(e => e['@cds.on.insert'])
+    if (on_insert.length) {
+      DEBUG?.('Handling', '@cds.on.insert', 'for entity', entity.name)
+
+      db.before(['INSERT', 'UPSERT'], entity, onINSERT.bind(null, on_insert))
+    }
+
+    const on_update = Object.values(entity.elements).filter(e => e['@cds.on.update'])
+    if (on_update.length) {
+      DEBUG?.('Handling', '@cds.on.update', 'for entity', entity.name)
+
+      db.before('UPSERT', entity, onINSERT.bind(null, on_update))
+      db.before('UPDATE', entity, onUPDATE.bind(null, on_update))
+    }
+  }
+}
+
+function onINSERT(on, req) {
+  const cqn = req.query.INSERT || req.query.UPSERT
+  const ctx = _context()
+  if (cqn.entries)
+    for (let each of cqn.entries) {
+      for (let e of on)
+        if (!(e.name in each)) {
+          each[e.name] = _value4(e, '@cds.on.insert', ctx)
+        }
+    }
+  else {
+    const { columns } = cqn,
+      rows = cqn.rows || [cqn.values]
+    for (let e of on)
+      if (!columns.includes(e.name)) {
+        columns.push(e.name)
+        for (let each of rows) {
+          each.push(_value4(e, '@cds.on.insert', ctx))
+        }
+      }
+  }
+}
+
+function onUPDATE(on, req) {
+  let ctx,
+    { data = {}, with: _with = {} } = req.query.UPDATE
+  for (let e of on) {
+    if (e.name in _with || e.name in data) continue
+    data[e.name] = _value4(e, '@cds.on.update', (ctx ??= _context()))
+  }
+}
+
+function _value4(def, anno, ctx) {
+  const fn = _pseudos[def[anno]['=']]
+  if (fn) return fn(ctx)
+  else throw cds.error`${def.name} ${anno} to be $now or $user, but got ${def[anno]}`
+}
+
+const _pseudos = {
+  $now: ctx => ctx.timestamp,
+  $user: ctx => ctx.user.id
+  // REVISIT: Did we ever officially support anything else?
+}
+
+const _context = () =>
+  cds.context || {
+    user: cds.User.anonymous,
+    timestamp: new Date()
+  }

--- a/db-service/lib/helpers/one.js
+++ b/db-service/lib/helpers/one.js
@@ -1,0 +1,23 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('one')
+
+module.exports = (db = cds.db) => {
+  db.on('SELECT', one.bind(db))
+}
+
+const one = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.SELECT.one) {
+    return next()
+  }
+
+  const clone = cqn.clone()
+  clone.__internal__ = true
+
+  clone.SELECT.one = undefined
+  clone.SELECT.limit = { rows: { val: 1 } }
+  const data = await this.run(clone, req.data)
+  return data?.[0] ?? null
+}

--- a/db-service/lib/helpers/orderBy.js
+++ b/db-service/lib/helpers/orderBy.js
@@ -1,0 +1,64 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('orderBy')
+
+module.exports = (db = cds.db) => {
+  db.on('SELECT', orderBy.bind(db))
+}
+
+const orderBy = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.SELECT.orderBy) {
+    return next()
+  }
+
+  const clone = cqn.clone()
+  clone.__internal__ = true
+
+  // Remove having clause and moves it into a '__groupBy__' column
+  const orderBy = clone.SELECT.orderBy
+  clone.SELECT.columns = [...clone.SELECT.columns, ...orderBy.map((c, i) => ({ __proto__: c, as: `__orderBy${i}__` }))]
+  clone.SELECT.orderBy = undefined
+
+  const data = await this.run(clone, req.data)
+  if (!data) return data
+
+  let sections = [[0, data.length]]
+  let nextSections
+  for (let i = 0; i < orderBy.length; i++) {
+    const key = `__orderBy${i}__`
+    const compare = orderBy[i].sort === 'desc' ? (a, b) => a[key] < b[key] : (a, b) => a[key] > b[key]
+    let changes = true
+    while (changes) {
+      changes = false
+      nextSections = [[0, 1]]
+      for (let s = 0; s < sections.length; s++) {
+        const section = sections[s]
+        for (let x = section[0]; x < section[1] - 1; x++) {
+          const a = data[x]
+          const b = data[x + 1]
+          if (compare(a, b)) {
+            data[x] = b
+            data[x + 1] = a
+            changes = true
+          }
+          if (changes) {
+            continue
+          }
+          if (a[key] === b[key]) {
+            nextSections[nextSections.length - 1][1]++
+          } else {
+            nextSections.push([x, x + 1])
+          }
+        }
+      }
+    }
+    if (nextSections.length === data.length) {
+      break
+    }
+    sections = nextSections
+  }
+
+  return data
+}

--- a/db-service/lib/helpers/projection.js
+++ b/db-service/lib/helpers/projection.js
@@ -1,0 +1,140 @@
+const cds = require('@sap/cds/lib')
+// const DEBUG = cds.log('projection')
+
+// Replaces all view references with the actual cqn query
+module.exports = (db = cds.db) => {
+  db.on('SELECT', projection.bind(db))
+  db.on('INSERT', insertView.bind(db))
+  db.on('UPDATE', updateView.bind(db))
+  db.on('DELETE', deleteView.bind(db))
+}
+
+let cache
+const resetCache = function () {
+  cache = new WeakMap()
+}
+resetCache()
+
+const projection = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+  if (!cqn.target?.query && !cqn.SELECT.from.SELECT) {
+    return next()
+  }
+
+  const src = this.cqn4sql(cqn.target.query || cqn.SELECT.from)
+  src.__internal__ = true
+
+  let dataProm
+
+  // Check view cache
+  if (cqn.target.query) {
+    let currentCache = cache.get(cqn.target.query)
+    if (!currentCache) {
+      currentCache = this.run(src, req.data)
+      // cache.set(cqn.target.query, currentCache)
+    }
+    dataProm = currentCache.then(data => [...data])
+  } else {
+    dataProm = this.run(src, req.data)
+  }
+
+  const data = await dataProm
+  if (!data || !data.length || !cqn.SELECT.from.as) {
+    return data
+  }
+
+  const map = module.exports.columnMap(cqn)
+  map(data)
+  return data
+}
+
+const insertView = async function (req, next) {
+  resetCache()
+  const cqn = this.cqn4sql(req.query)
+  if (!cqn.target?.query) {
+    return next()
+  }
+
+  const select = this.cqn4sql(cqn.target.query)
+  const hasRenames = select.SELECT.columns.find(c => c.as)
+  if (!hasRenames) {
+    // REVISIT: once cqn4sql can be called multiple times remove __normalized__ = false
+    const clone = cqn.clone()
+    clone.__internal__ = true
+    clone.INSERT.into = { ref: [select.target.name] }
+    clone.__normalized__ = false
+    clone.sources = undefined
+    return this.run(clone, req.data)
+  }
+
+  cds.error`TODO: rename data properties according to select.SELECT.columns`
+}
+
+const updateView = async function (req, next) {
+  resetCache()
+  const cqn = this.cqn4sql(req.query)
+  if (!cqn.target?.query) {
+    return next()
+  }
+
+  const select = this.cqn4sql(cqn.target.query)
+  const hasRenames = select.SELECT.columns.find(c => c.as)
+  if (!hasRenames) {
+    // REVISIT: once cqn4sql can be called multiple times remove __normalized__ = false
+    const clone = cqn.clone()
+    clone.__internal__ = true
+    clone.UPDATE.entity = { ref: [select.target.name] }
+    clone.__normalized__ = false
+    clone.sources = undefined
+    return this.run(clone, req.data)
+  }
+
+  cds.error`TODO: rename data properties according to select.SELECT.columns`
+}
+
+const deleteView = async function (req, next) {
+  resetCache()
+  const cqn = this.cqn4sql(req.query)
+  if (!cqn.target?.query) {
+    return next()
+  }
+
+  const select = this.cqn4sql(cqn.target.query)
+  // REVISIT: once cqn4sql can be called multiple times remove __normalized__ = false
+  const clone = cqn.clone()
+  clone.__internal__ = true
+  clone.DELETE.from = { ref: [select.target.name] }
+  clone.__normalized__ = false
+  clone.sources = undefined
+  return this.run(clone, req.data)
+}
+
+module.exports.columnMap = function (cqn) {
+  const alias = cqn.SELECT.from.as
+  const transformations = cqn.SELECT.columns
+    // .filter(alias ? c => c.ref && c.ref.as !== c.ref[1] : c => c.ref)
+    .map(c => {
+      let columnAlias = c.as || c.val || c.func || c.ref?.[c.ref?.length - 1]
+      const assign = `res[${JSON.stringify(columnAlias)}] = `
+      if (!c.ref) {
+        return `${assign}row${alias ? `[${JSON.stringify(alias)}]` : ''}[${JSON.stringify(columnAlias)}]`
+      }
+      if (c.ref.length === 1) {
+        return ''
+      }
+      return `${assign}row${c.ref
+        .map((p, i) => (i === 0 && alias ? `[${JSON.stringify(alias)}]` : `[${JSON.stringify(p)}]`))
+        .join('')}`
+    })
+
+  const mapDefinition = `
+for(i = 0; i < data.length; i++) {
+  const row = ${alias ? '{' + JSON.stringify(alias) + ':data[i]}' : 'data[i]'}
+  const res = {}
+  ${transformations.join('\n')}
+  data[i] = res
+}`
+  const map = new Function('data', mapDefinition)
+  map.src = mapDefinition
+  return map
+}

--- a/db-service/lib/helpers/schema.js
+++ b/db-service/lib/helpers/schema.js
@@ -1,0 +1,43 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('schema')
+
+module.exports = (db = cds.db, converters) => {
+  const _add_mixins = (aspect, mixins) => {
+    const fqn = db.constructor.name + aspect
+    const types = cds.builtin.types
+    for (let each in mixins) {
+      const def = types[each]
+      if (!def) continue
+      Object.defineProperty(def, fqn, { value: mixins[each] })
+    }
+    return fqn
+  }
+
+  db.constructor._convertInput = _add_mixins(':convertInput', converters.InputConverters)
+  db.constructor._convertOutput = _add_mixins(':convertOutput', converters.OutputConverters)
+
+  // TODO: add insert/update schema validation
+  db.after('SELECT', schema.bind(db))
+}
+
+const schema = async function (data, req) {
+  // __internal__ indicates that the query is part of a sub routine for another query
+  // preventing data from being converted multiple times
+  if (!data?.length || req.query.__internal__) {
+    return
+  }
+  const cqn = this.cqn4sql(req.query)
+  const converterKey = this.constructor._convertOutput
+  const converters = Object.keys(cqn.elements)
+    .map(e => ({ prop: e, fn: cqn.elements[e][converterKey] }))
+    .filter(e => e.fn)
+
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i]
+    for (let i = 0; i < converters.length; i++) {
+      const converter = converters[i]
+      row[converter.prop] = converter.fn(row[converter.prop])
+    }
+  }
+}

--- a/db-service/lib/helpers/where.js
+++ b/db-service/lib/helpers/where.js
@@ -1,0 +1,79 @@
+const cds = require('@sap/cds/lib')
+// TODO: add useful debugging information
+// const DEBUG = cds.log('where')
+
+module.exports = (db = cds.db) => {
+  db._helpers = db._helpers || {}
+  db._helpers.where = true
+
+  db.on('SELECT', selectWhere.bind(db))
+  db.on('UPDATE', updateWhere.bind(db))
+  db.on('DELETE', deleteWhere.bind(db))
+}
+
+const selectWhere = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.SELECT.where) {
+    return next()
+  }
+
+  const clone = cds.ql.clone(cqn)
+  clone.__internal__ = true
+
+  // Remove where clause and moves it into a '__where__' column
+  clone.SELECT.columns = [
+    ...clone.SELECT.columns,
+    { xpr: clone.SELECT.where.length ? clone.SELECT.where : [{ val: true }], as: '__where__' }
+  ]
+  clone.SELECT.where = undefined
+
+  const data = await this.run(clone, req.data)
+  return data?.filter(r => r.__where__)
+}
+
+const updateWhere = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.UPDATE.where) {
+    return next()
+  }
+
+  const impactQuery = cds.ql.SELECT().from(cqn.UPDATE.entity).where(cqn.UPDATE.where)
+  impactQuery.__internal__ = true
+  const impacted = await this.run(impactQuery, req.data)
+
+  const upd = cds.ql.UPDATE.entity(cqn.UPDATE.entity).data(cqn.UPDATE.data)
+  const changes = await Promise.all(
+    impacted.map(entry => {
+      const cqn = upd.clone()
+      cqn.UPDATE.entry = entry
+      return this.run(cqn)
+    })
+  )
+
+  return changes.reduce((l, c) => (l += c), 0)
+}
+
+const deleteWhere = async function (req, next) {
+  const cqn = this.cqn4sql(req.query)
+
+  if (!cqn.DELETE.where) {
+    return next()
+  }
+
+  const impactQuery = cds.ql.SELECT().from(cqn.DELETE.from).where(cqn.DELETE.where)
+  impactQuery.__internal__ = true
+  const impacted = await this.run(impactQuery, req.data)
+
+  const del = cds.ql.DELETE.from(cqn.DELETE.from)
+  const changes = await Promise.all(
+    impacted.map(entry => {
+      const cqn = del.clone()
+      cqn.DELETE.entry = entry
+      return this.run(cqn)
+    })
+  )
+
+  return changes.reduce((l, c) => (l += c), 0)
+}

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -221,6 +221,8 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
    * @param {csn.Element} element
    */
   function setElementOnColumns(col, element) {
+    if(col.element) return
+
     Object.defineProperty(col, 'element', {
       value: element,
       writable: true,

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/JSService')

--- a/js/lib/JSService.js
+++ b/js/lib/JSService.js
@@ -1,0 +1,279 @@
+const cds = require('../../../cds'),
+  DEBUG = cds.debug('sql|db')
+const DatabaseService = require('@cap-js/db-service/lib/common/DatabaseService')
+const cqn4sql = require('@cap-js/db-service/lib/cqn4sql')
+
+// Helpers
+// Data generation
+const manage = require('@cap-js/db-service/lib/helpers/managed')
+
+// Data processing
+const one = require('@cap-js/db-service/lib/helpers/one')
+const limit = require('@cap-js/db-service/lib/helpers/limit')
+const count = require('@cap-js/db-service/lib/helpers/count')
+const orderBy = require('@cap-js/db-service/lib/helpers/orderBy')
+const having = require('@cap-js/db-service/lib/helpers/having')
+const groupBy = require('@cap-js/db-service/lib/helpers/groupBy')
+const where = require('@cap-js/db-service/lib/helpers/where')
+const computed = require('@cap-js/db-service/lib/helpers/computed')
+const join = require('@cap-js/db-service/lib/helpers/join')
+const projection = require('@cap-js/db-service/lib/helpers/projection')
+const schema = require('@cap-js/db-service/lib/helpers/schema')
+
+const drivers = require('./driver')
+
+class JSService extends DatabaseService {
+  init() {
+    this.on(['*'], (req, next) => {
+      return next()
+    })
+
+    manage(this)
+
+    one(this)
+    limit(this)
+    count(this)
+    orderBy(this)
+    having(this)
+    groupBy(this)
+    where(this)
+    computed(this)
+    join(this)
+    projection(this)
+    schema(this, {
+      InputConverters: this.constructor.InputConverters,
+      OutputConverters: this.constructor.OutputConverters
+    })
+
+    this.on(['SELECT'], this.onSELECT)
+    this.on(['INSERT'], this.onINSERT)
+    this.on(['UPSERT'], this.onUPSERT)
+    this.on(['UPDATE'], this.onUPDATE)
+    this.on(['DELETE'], this.onDELETE)
+    this.on(['CREATE ENTITY'], this.onCREATE)
+    this.on(['DROP ENTITY'], this.onDROP)
+    this.on(['BEGIN', 'COMMIT', 'ROLLBACK'], this.onEVENT)
+    this.on(['*'], this.onPlainSQL)
+    this.kind = 'js'
+
+    return super.init()
+  }
+
+  get factory() {
+    return {
+      options: { min: 1, ...this.options.pool },
+      create: tenant => {
+        const Driver = drivers[this.options?.driver] || drivers.default
+        return new Driver(tenant)
+      },
+      destroy: dbc => dbc.destroy(),
+      validate: dbc => dbc.validate()
+    }
+  }
+
+  /** Handler for SELECT */
+  async onSELECT({ query }) {
+    const cqn = this.cqn4sql(query)
+    return this.dbc.SELECT(cqn, true)
+  }
+
+  async onINSERT({ query, data }) {
+    const cqn = this.cqn4sql(query)
+    return this.dbc.INSERT(cqn, data)
+  }
+
+  async onUPSERT(/*{ query, data }*/) {}
+
+  async onUPDATE({ query }) {
+    const cqn = this.cqn4sql(query)
+    return this.dbc.UPDATE(cqn)
+  }
+
+  async onDELETE({ query }) {
+    const cqn = this.cqn4sql(query)
+    return this.dbc.DELETE(cqn)
+  }
+
+  async onCREATE({ query }) {
+    const name = query.CREATE.entity
+    const definition = this.model.definitions[name]
+
+    // const isView = definition.query || definition.projection
+    /*
+    if (isView) {
+      // Don't deploy views to the database rely on the projection helper instead
+      return
+    }
+    */
+
+    const elements = ObjectKeys(definition.elements).reduce((l, c) => {
+      const element = definition.elements[c]
+      if (!(element.virtual || element.isAssociation)) {
+        l[c] = {
+          name: c,
+          type: element.type || (element.items ? 'cds.Array' : 'cds.Struct'),
+          mandatory: element._isMandatory,
+          precision: element.precision,
+          scale: element.scale,
+          length: element.length
+        }
+      }
+      return l
+    }, {})
+    this.dbc.CREATE_TABLE(name, elements)
+  }
+
+  async onDROP({ query }) {
+    const name = query.DROP.target
+    this.dbc.DROP(name)
+  }
+
+  /** Handler for BEGIN, COMMIT, ROLLBACK, which don't have any CQN */
+  async onEVENT({ event }) {
+    DEBUG?.(event) // in the other cases above DEBUG happens in cqn2sql
+  }
+
+  /** Handler for SQL statements which don't have any CQN */
+  async onPlainSQL({ query }) {
+    // REVISIT: Should not be needed when deployment supports all types or sends CQNs
+    // Rewrite drop statements
+    if (/^DROP TABLE/i.test(query)) {
+      // Extracts the name from the incoming SQL statment
+      const name = query.match(/^DROP (TABLE|VIEW) IF EXISTS ("[^"]+"|[^\s;]+)/im)[2]
+      // Replaces all '_' with '.' from left to right
+      const split = name.split('_')
+      const options = split.map((_, i) => split.slice(0, i + 1).join('.') + '.' + split.slice(i + 1).join('_'))
+      // Finds the first match inside the model
+      const target = options.find(n => this.model.definitions[n])
+      // If the entity was found in the model it is dropped using CQN
+      return target && this.run(cds.ql.DROP(target))
+    }
+
+    // Rewrite create statements
+    if (/^CREATE TABLE/i.test(query)) {
+      // Extracts the name from the incoming SQL statment
+      const name = query.match(/^CREATE (TABLE|VIEW) ("[^"]+"|[^\s(]+)/im)[2]
+      // Replaces all '_' with '.' from left to right
+      const split = name.split('_')
+      const options = split.map((_, i) => split.slice(0, i + 1).join('.') + '.' + split.slice(i + 1).join('_'))
+      // Finds the first match inside the model
+      const target = options.find(n => this.model.definitions[n])
+      // If the entity was found in the model it is dropped using CQN
+      return target && this.run(cds.ql.CREATE(target))
+    }
+
+    if (/^(CREATE|DROP) VIEW/.test(query)) {
+      return
+    }
+
+    cds.error`This is not a SQL data base: ${query}`
+  }
+
+  set(/*variables*/) {}
+
+  cqn4sql(q) {
+    if (q.__normalized__ || (q.SELECT?.from.args && !q.SELECT.columns)) return q
+    const cqn = cqn4sql(q, this.model)
+    Object.defineProperty(cqn, '__normalized__', { value: true, configurable: true, writable: true })
+    return cqn
+  }
+
+  static InputConverters = {
+    // Globals
+    'cds.Boolean': (x, e) => (typeof x === 'boolean' ? x : x == null || x === 'null' ? null : invalid(x, e)),
+
+    // Numbers
+    'cds.Int16': (x, e) =>
+      typeof x === 'number' ? x : typeof x === 'string' ? Number.parseInt(x, 10) : x == null ? null : invalid(x, e),
+    'cds.Integer': (x, e) =>
+      typeof x === 'number' ? x : typeof x === 'string' ? Number.parseInt(x, 10) : x == null ? null : invalid(x, e),
+    'cds.Integer64': (x, e) =>
+      typeof x === 'bigint' ? x : typeof x === 'string' ? BigInt(x) : x == null ? null : invalid(x, e),
+    'cds.Double': (x, e) =>
+      typeof x === 'number' ? x : typeof x === 'string' ? Number.parseFloat(x, 10) : x == null ? null : invalid(x, e),
+    'cds.Float': (x, e) =>
+      typeof x === 'number' ? x : typeof x === 'string' ? Number.parseFloat(x, 10) : x == null ? null : invalid(x, e),
+    'cds.Decimal': (x, e) =>
+      typeof x === 'number' ? x : typeof x === 'string' ? Number.parseFloat(x, 10) : x == null ? null : invalid(x, e),
+
+    // Strings
+    'cds.String': (x, e) => (typeof x === 'string' ? x : x == null ? null : invalid(x, e)),
+    'cds.LargeString': (x, e) => (typeof x === 'string' ? x : x == null ? null : invalid(x, e)),
+    'cds.LargeBinary': (x, e) => (typeof x === 'string' ? x : x == null ? null : invalid(x, e)),
+
+    // Date time types
+    'cds.Date': (x, e) =>
+      x instanceof Date
+        ? x.toISOString()
+        : typeof x === 'string'
+        ? new Date(x).toISOString()
+        : x == null
+        ? null
+        : invalid(x, e),
+    'cds.Time': (x, e) =>
+      x instanceof Date
+        ? x.toISOString()
+        : typeof x === 'string'
+        ? new Date('1970-01-01T' + x + 'Z').toISOString()
+        : x == null
+        ? null
+        : invalid(x, e),
+    'cds.DateTime': (x, e) => {
+      if (x instanceof Date) return x.toISOString()
+      if (typeof x === 'string') {
+        if (x.indexOf(/\+|-|Z/) < 0) {
+          x += 'Z'
+        }
+        x = x.replace(' ', 'T')
+        return new Date(x).toISOString()
+      }
+      if (x == null || x === 'null') {
+        return null
+      }
+      invalid(x, e)
+    },
+    'cds.Timestamp': (x, e) => {
+      if (x instanceof Date) return x.toISOString()
+      if (typeof x === 'string') {
+        if (x.indexOf(/\+|-|Z/) < 0) {
+          x += 'Z'
+        }
+        x = x.replace(' ', 'T')
+        return new Date(x).toISOString()
+      }
+      if (x == null || x === 'null') {
+        return null
+      }
+      invalid(x, e)
+    },
+    // Structured
+    'cds.Array': (x, e) => (typeof x === 'string' ? JSON.parse(x) : x == null ? null : invalid(x, e))
+  }
+
+  static OutputConverters = {
+    // Globals
+    // 'cds.Boolean': echo,
+
+    // Numbers
+    // 'cds.Integer': echo,
+    // 'cds.Integer64': echo,
+    // 'cds.Double': echo, // TODO: precision
+    // 'cds.Float': echo,
+    // 'cds.Decimal': echo,
+
+    // Strings
+    // 'cds.String': echo,
+    // 'cds.LargeString': echo,
+
+    // Date time types
+    'cds.Date': v => (v == null ? null : new Date(v).toISOString().slice(0, 10)),
+    'cds.Time': v => (v == null ? null : new Date(v).toISOString().slice(11, 19)),
+    'cds.DateTime': v => (v == null ? null : new Date(v).toISOString().slice(0, 19) + 'Z'),
+    'cds.Timestamp': v => (v == null ? null : new Date(v).toISOString())
+  }
+}
+
+const invalid = (x, e) => cds.error`Invalid data ${JSON.stringify(x)} for type ${JSON.stringify(e.type)}`
+const ObjectKeys = o => (o && [...ObjectKeys(o.__proto__), ...Object.keys(o)]) || []
+
+module.exports = JSService

--- a/js/lib/driver/mem.js
+++ b/js/lib/driver/mem.js
@@ -1,0 +1,227 @@
+const cds = require('@sap/cds')
+
+const schema = {}
+const data = {}
+
+module.exports = class JSMemoryDriver {
+  constructor(tenant) {
+    this.tenant = tenant
+
+    // The data
+    this.data = data
+    // The structure definition of the data
+    this.schema = schema
+  }
+
+  destroy() {}
+
+  validate() {
+    return true
+  }
+
+  SELECT(query) {
+    const { from } = query.SELECT
+
+    let data
+
+    if (from.ref?.length === 1) {
+      const name = this.name(from.ref[0])
+      // Copy data array once for in array manipulations
+      data = this.data[name].slice()
+    } else {
+      cds.error`UNKNOWN QUERY SOURCE ${JSON.stringify(from)}`
+    }
+
+    // Copy data objects to prevent outside manipulation
+    /*for(let i = 0; i < data.length; i++) {
+      data[i] = {...data[i]}
+    }*/
+
+    return data
+  }
+
+  INSERT(query, data) {
+    const name = this.name(query.target?.name || query.INSERT.into?.ref?.[0])
+    const schema = this.schema[name]
+
+    data = query.INSERT.rows
+      ? query.INSERT.rows.map(r =>
+          query.INSERT.columns.reduce((l, c, i) => {
+            l[c] = r[i]
+            return l
+          }, {})
+        )
+      : query.INSERT.entries
+      ? query.INSERT.entries
+      : data
+      ? Array.isArray(data)
+        ? data
+        : [data]
+      : []
+
+    console.log(name, data.length)
+    schema.insert.entries(this.data[name], data)
+    return data.length
+  }
+
+  UPDATE(query) {
+    const { entity, entry, data } = query.UPDATE
+
+    const name = this.name(query.target?.name || entity?.ref?.[0])
+
+    const index = this.indexOf(name, entry)
+    if (index < 0) return 0
+
+    const row = this.data[name][index]
+
+    const changes = Object.getOwnPropertyNames(data)
+    for (let i = 0; i < changes.length; i++) {
+      const prop = changes[i]
+      if (prop in row) {
+        row[prop] = data[prop]
+      }
+    }
+
+    return 1
+  }
+
+  DELETE(query) {
+    const name = this.name(query.target?.name || query.DELETE.from?.ref?.[0])
+    const data = this.data[name]
+
+    const index = this.indexOf(name, query.DELETE.entry)
+    if (index < 0) return 0
+    data.splice(index, 1)
+    return 1
+  }
+
+  CREATE_TABLE(name, elements) {
+    const insert = {}
+
+    let inputConverters = ''
+    const columns = Object.keys(elements)
+    for (let i = 0; i < columns.length; i++) {
+      const c = columns[i]
+      inputConverters += typesInput[elements[c].type]?.(elements[c]) || cds.error(`Unknown type "${elements[c].type}"`)
+      inputConverters += '\n'
+    }
+
+    const entries = `
+      let x
+      for(var i = 0; i < entries.length; i++) {
+        const row = entries[i]
+        ${inputConverters}
+        data.push(row)
+      }
+      return data`
+    insert.entries = new Function('data', 'entries', entries)
+
+    name = this.name(name)
+    this.schema[name] = { elements, insert }
+    this.data[name] = this.data[name] || []
+  }
+
+  DROP(name) {
+    delete this.schema[name]
+    delete this.data[name]
+  }
+
+  name(name) {
+    return name.replace(/\./g, '_')
+  }
+
+  indexOf(name, entry) {
+    const schema = this.schema[name]
+    const data = this.data[name]
+
+    const entries = []
+    // Normalize entry to database storage
+    schema.insert.entries(entries, [entry])
+
+    entry = entries[0]
+    root: for (let i = 0; i < data.length; i++) {
+      const row = data[i]
+      const keys = Object.keys(row)
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i]
+        if (
+          (typeof row[key] === 'object' && `${entry[key]}` !== `${row[key]}`) ||
+          (typeof row[key] !== 'object' && entry[key] !== row[key])
+        ) {
+          continue root
+        }
+      }
+      return i
+    }
+  }
+}
+
+const typeAssign = e => `x = row[${JSON.stringify(e.name)}]; row[${JSON.stringify(e.name)}]`
+const invalid = e => `cds.error('Invalid data ' + i + ' ${JSON.stringify(e.name)}')`
+// TODO: move to schema.js
+const typesInput = {
+  // Globals
+  'cds.Boolean': e =>
+    `${typeAssign(e)} = typeof x === 'boolean' ? x : x == null || x === 'null' ? null : ${invalid(e)}`,
+
+  // Numbers
+  'cds.Int16': e =>
+    `${typeAssign(
+      e
+    )} = typeof x === 'number' ? x : typeof x === 'string' ? Number.parseInt(x,10) : x == null ? null : ${invalid(e)}`,
+  'cds.Integer': e =>
+    `${typeAssign(
+      e
+    )} = typeof x === 'number' ? x : typeof x === 'string' ? Number.parseInt(x,10) : x == null ? null : ${invalid(e)}`,
+  'cds.Integer64': e =>
+    `${typeAssign(e)} = typeof x === 'bigint' ? x : typeof x === 'string' ? BigInt(x) : x == null ? null : ${invalid(
+      e
+    )}`,
+  'cds.Double': e =>
+    `${typeAssign(
+      e
+    )} = typeof x === 'number' ? x : typeof x === 'string' ? Number.parseFloat(x,10) : x == null ? null : ${invalid(
+      e
+    )}`,
+  'cds.Float': e =>
+    `${typeAssign(
+      e
+    )} = typeof x === 'number' ? x : typeof x === 'string' ? Number.parseFloat(x,10) : x == null ? null : ${invalid(
+      e
+    )}`,
+  'cds.Decimal': e =>
+    `${typeAssign(
+      e
+    )} = typeof x === 'number' ? x : typeof x === 'string' ? Number.parseFloat(x,10) : x == null ? null : ${invalid(
+      e
+    )}`,
+
+  // Strings
+  'cds.String': e => `${typeAssign(e)} = typeof x === 'string' ? x : x == null ? null : ${invalid(e)}`,
+  'cds.UUID': e => `${typeAssign(e)} = typeof x === 'string' ? x : x == null ? null : ${invalid(e)}`,
+  'cds.LargeString': e => `${typeAssign(e)} = typeof x === 'string' ? x : x == null ? null : ${invalid(e)}`,
+  'cds.LargeBinary': e => `${typeAssign(e)} = typeof x === 'string' ? x : x == null ? null : ${invalid(e)}`,
+
+  // Date time types
+  'cds.Date': e =>
+    `${typeAssign(e)} = x instanceof Date ? x.toISOString() : typeof x === 'string' ? new Date(x).toISOString() : x == null ? null : ${invalid(
+      e
+    )}`,
+  'cds.Time': e =>
+    `${typeAssign(
+      e
+    )} = x instanceof Date ? x.toISOString() : typeof x === 'string' ? new Date('1970-01-01T' + x + 'Z').toISOString() : x == null ? null : ${invalid(
+      e
+    )}`,
+  'cds.DateTime': e =>
+    `${typeAssign(e)} = x instanceof Date ? x.toISOString() : typeof x === 'string' ? new Date(x).toISOString() : x == null ? null : ${invalid(
+      e
+    )}`,
+  'cds.Timestamp': e =>
+    `${typeAssign(e)} = x instanceof Date ? x.toISOString() : typeof x === 'string' ? new Date(x).toISOString() : x == null ? null : ${invalid(
+      e
+    )}`,
+
+  // Structured
+  'cds.Array': e => `${typeAssign(e)} = typeof x === 'string' ? JSON.parse(x) : x == null ? null : ${invalid(e)}`
+}

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@cap-js/nodb",
+  "version": "0.1.0",
+  "description": "CDS database service for NoDB",
+  "homepage": "https://cap.cloud.sap/",
+  "keywords": [
+    "CAP",
+    "CDS",
+    "SQLite"
+  ],
+  "author": "SAP SE (https://www.sap.com)",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "cds-plugin.js",
+    "lib",
+    "CHANGELOG.md"
+  ],
+  "engines": {
+    "node": ">=14",
+    "npm": ">=8"
+  },
+  "scripts": {
+    "test": "jest --silent"
+  },
+  "peerDependencies": {
+    "@sap/cds": ">=6.8.0"
+  },
+  "license": "SEE LICENSE"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "workspaces": [
     "db-service",
     "postgres",
-    "sqlite"
+    "sqlite",
+    "js"
   ],
   "devDependencies": {
     "@capire/sflight": "sap-samples/cap-sflight",


### PR DESCRIPTION
### Concept

`CSN` has a lot of complexity which can make it scary to write a database layer. The idea of the `db-service` helpers is to remove certain requirements to lower the difficulty of writing a db layer. By simply requiring a helper and applying it in the `init` of the service this functionality now no longer needs to be implemented any more.

```js
const one = require('@cap-js/db-service/lib/helpers/one')

class JSService extends DatabaseService {
  init() {
    one(this) // Transforms cqn.SELECT.one -> cqn.SELECT.limit and returns the first row or null
    super.init()
  }
}
```

### Layout

In this PoC the naming scheme of the helpers is as follows:

- the `CQN` property it implements (e.g. count, where, groupBy etc.)
- the general name of the functionality it implements (e.g. computed, projection, schema)

### Capabilities

This PoC has some limited functionality (also is not fully functionally correct), but this PoC is capable of serving the bookshop and mostly sflight. It is able to show the analytics page of sflight, but filters currently result in errors.

![image](https://github.com/cap-js/cds-dbs/assets/108393871/4a45b085-dc15-42e8-a0ed-f969844f8bd7)

### Finding

It might not be very surprising that the performance of the PoC is not very good. It takes ~30 seconds for the sflight joins to be fully calculated. It also shows what is exactly being requested from the database. It is easy to forget the complexity that is being requested. When deploying the view which results in 7 left joins it won't indicate the complexity that the database has to resolve. When we send the SQL statement to the database it will resolve the fastest method to calculate the result for the query. Splitting the where clause, on conditions, potentially even skipping whole joins if the final query does not require their information to be calculated. This is mostly done through static analysis and could be calculated into the CQN query. While using views this cannot be done, because the entity that is being selected from is flat. So it would require to not select from the views, but instead rewrite the query to directly select from the source tables. That way the query would be bigger, but would be pre optimized. Allowing the database to skip the optimization steps and directly start executing the query. With the usual CAP APP executing the same query many times with only slight differences it would be possible to re use the optimized query between sessions. With optimized queries the PoC would be able to run sflight with similar performance to sqlite.