### PR TITLE
Include columnOffset for jest Script creation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,10 @@ const enable = process.argv
   })
   .filter(a => a)
 
+require('./test/jest')
+
 module.exports = {
+  transform: {},
   reporters: process.env.CI ? ['github-actions', 'summary'] : ['default'],
   testPathIgnorePatterns: [
     // Exclude compliance tests without database context

--- a/test/jest.js
+++ b/test/jest.js
@@ -27,9 +27,9 @@ const createScriptFromCode = function (scriptSource, filename) {
 }
 jestRuntime.default.prototype.createScriptFromCode = createScriptFromCode
 
-const runtimeSupportsVmModules = typeof require('vm').SyntheticModule === 'function';
+const runtimeSupportsVmModules = typeof require('vm').SyntheticModule === 'function'
 function invariant(condition, message) {
   if (!condition) {
-    throw new Error(message);
+    throw new Error(message)
   }
 }

--- a/test/jest.js
+++ b/test/jest.js
@@ -1,0 +1,35 @@
+const jestRuntime = require('jest-runtime')
+
+const vm = require('vm')
+const transform = require('@jest/transform')
+const createScriptFromCode = function (scriptSource, filename) {
+  try {
+    const scriptFilename = this._resolver.isCoreModule(filename) ? `jest-nodejs-core-${filename}` : filename
+    return new vm.Script(this.wrapCodeInModuleWrapper(scriptSource), {
+      displayErrors: true,
+      filename: scriptFilename,
+      columnOffset: this._fileTransforms.get(filename)?.wrapperLength, // Adding this one liner to make debugging as expected again
+      // @ts-expect-error: Experimental ESM API
+      importModuleDynamically: async specifier => {
+        invariant(
+          runtimeSupportsVmModules,
+          'You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/ecmascript-modules',
+        )
+        const context = this._environment.getVmContext?.()
+        invariant(context, 'Test environment has been torn down')
+        const module = await this.resolveModule(specifier, scriptFilename, context)
+        return this.linkAndEvaluateModule(module)
+      },
+    })
+  } catch (e) {
+    throw (0, transform.handlePotentialSyntaxError)(e)
+  }
+}
+jestRuntime.default.prototype.createScriptFromCode = createScriptFromCode
+
+const runtimeSupportsVmModules = typeof require('vm').SyntheticModule === 'function';
+function invariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
When Jest compiles a file it does not forward the size of the module wrapper to node. This causes issue in the node debugger source map logic. As it cannot resolve the source file as the filesystem contains different code then the compiled Script. By adding the offset the contents match up again and the editor will not open an read only window anymore.

Using the normal Jest babel configuration breaks a lot of debugging information all values on hover and inside the debug console are not the actual value they should be. Which means that it is not possible to copy a line from the source file and run it directly in the debug console. As the moment a property is selected the root value has become the value of the property.

Also tried to make a PR to Jest directly, but not certain about the Corporate relation between SAP and Facebook. https://github.com/jestjs/jest/pull/14148