### PR TITLE
feat: allow for port config option

### DIFF
--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -30,8 +30,9 @@ class PostgresService extends SQLService {
           user: cr.username || cr.user,
           password: cr.password,
           // Special handling for:
-          // SAP Cloud Platform - Cloud Foundry - PostgreSQL Hyperscaler Service
+          // BTP - Cloud Foundry - PostgreSQL Hyperscaler Service
           host: cr.hostname || cr.host,
+          port: cr.port || process.env.PGPORT || 5432,
           database: cr.dbname || cr.database,
           schema: cr.schema,
           sslRequired: cr.sslrootcert && (cr.sslrootcert ?? true),


### PR DESCRIPTION
connect options:
- explicit `port` in config (e.g. from BTP service key)
- setting env var `PGPORT` (aligned with node `pg` module option)
- default to pg standard `5432`

fixes #23