### PR TITLE
Fix upsert managed data

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -270,7 +270,7 @@ class CQN2SQLRenderer {
     const extractions = this.managed(
       columns.map(c => ({ name: c })),
       elements,
-      !!q.UPSERT,
+      false,
     )
     const extraction = extractions
       .map(c => {
@@ -365,10 +365,11 @@ class CQN2SQLRenderer {
     if (!keys) return (this.sql = sql) // REVISIT: We should converge q.target and q._target
     keys = Object.keys(keys).filter(k => !keys[k].isAssociation)
 
-    let updateColumns = q.UPSERT.entries ? Object.keys(q.UPSERT.entries[0]) : this.columns
-    updateColumns = updateColumns
-      .filter(c => !keys.includes(c))
-      .map(c => `${this.quote(c)} = excluded.${this.quote(c)}`)
+    const updateColumns = this.managed(
+      this.columns.filter(c => !keys.includes(c)).map(c => ({ name: c, sql: `excluded.${this.quote(c)}` })),
+      q.elements || q.target?.elements,
+      true,
+    ).map(c => `${this.quote(c.name)}=${c.sql}`)
 
     keys = keys.map(k => this.quote(k))
     const conflict = updateColumns.length

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -68,12 +68,19 @@ class CQN2SQLRenderer {
   }
 
   CREATE_elements(elements) {
+    const keys = []
     let sql = ''
     for (let e in elements) {
       const definition = elements[e]
       if (definition.isAssociation) continue
+      if (definition.key) {
+        keys.push(e)
+      }
       const s = this.CREATE_element(definition)
       if (s) sql += `${s}, `
+    }
+    if (keys.length) {
+      sql += `PRIMARY KEY(${keys}), `
     }
     return sql.slice(0, -2)
   }


### PR DESCRIPTION
Currently `UPSERT` queries will insert the `@cds.on.update` properties, but did not consider the `@cds.on.insert` properties.

With this change it will consider `@cds.on.insert` for the insert, but on conflict it will only consider only the `@cds.on.udpate` managed columns.

Additionally this enhances the table definitions with primary keys when using `CREATE` queries. For tests to be able to use `UPSERT` queries.