### PR TITLE
Fallback to anonymous if not user.id is defined

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -563,7 +563,7 @@ class CQN2SQLRenderer {
       switch (managed) {
         case '$user.id':
         case '$user':
-          managed = this.string(this.context.user.id)
+          managed = this.string(this.context.user.id || 'anonymous')
           break
         case '$now':
           managed = this.string(this.context.timestamp.toISOString().slice(0, -1) + '0000Z')


### PR DESCRIPTION
`user.id` happened to be `undefined` inside the `change-tracking` tests. Looks like this might be a side effect from an error somewhere else ?