### PR TITLE
Remove output converters for Date | Time types from SQLite

### DIFF
--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -85,10 +85,6 @@ class SQLiteService extends SQLService {
     // Used for INSERT statements
     static InputConverters = {
       ...super.InputConverters,
-      Date: e => `strftime('%Y-%m-%d',${e})`,
-      Time: e => `strftime('%H:%M:%S',${e})`,
-      DateTime: e => `strftime('%Y-%m-%dT%H:%M:%SZ',${fixTimeZone(e)})`,
-      Timestamp: e => highPrecisionTimestamps(e),
     }
 
     static OutputConverters = {
@@ -100,7 +96,6 @@ class SQLiteService extends SQLService {
       Double: expr => `nullif(quote(${expr}),'NULL')->'$'`,
       struct: expr => `${expr}->'$'`, // Association + Composition inherits from struct
       array: expr => `${expr}->'$'`,
-      // REVISIT: Timestamp should not loos precision
       Date: e => `strftime('%Y-%m-%d',${e})`,
       Time: e => `strftime('%H:%M:%S',${e})`,
       DateTime: e => `strftime('%Y-%m-%dT%H:%M:%SZ',${fixTimeZone(e)})`,


### PR DESCRIPTION
## Summary

Before the `Date` | `Time` types where processed when writing and reading. Now they are only processed on writing. The main concern the output converters where covering was to prevent `computed` / `cast` queries to return in consistent formatting.

## follow up

Add proper type casting to `SQLite` converting `Date` | `Time` types properly between each others formats.
Also require explicit type casting in `SQLite` and `HANA` to provide stable results. When implicit "casting" is used the behavior is `undefined`. This is as `SQLite` does not support implicit type casting. While `HANA` does support implicit type casting, but it comes with a major potential for a negative performance impact as the optimizer has to consider additional options ([docs](https://help.sap.com/docs/SAP_HANA_PLATFORM/9de0171a6027400bb3b9bee385222eff/221db27eab06494fa5aad41a3898b21b.html)).
