### PR TITLE
PoC: feature based testing

### DIFF
--- a/test/compliance/features/cds.builtin.classes.association.test.js
+++ b/test/compliance/features/cds.builtin.classes.association.test.js
@@ -1,0 +1,79 @@
+const { describe, test } = require('./test')
+
+const cds = require('@sap/cds')
+
+describe('features', () => {
+  test(
+    'cds.builtin.classes.association',
+    (queries, model) => {
+      // Association test requires base data to enhance
+      if (queries.INSERT.length < 1) return false
+
+      // Ensure that there is a key column
+      model.target.elements.$test.key = true
+
+      // Add managed self association
+      model.target.elements.managedAssociation = { type: 'cds.Association', target: 'target' }
+
+      // Add unmanaged self association
+      model.target.elements.unmanagedAssociation = {
+        type: 'cds.Association',
+        target: 'target',
+        cardinality: { src: 1, min: 1, max: 1 },
+        on: [{ ref: ['unmanagedAssociation', '$test'] }, '=', { ref: ['$self', '$test'] }],
+      }
+
+      // Select expand data from managed association
+      queries.SELECT.push(
+        cds.ql
+          .SELECT([
+            { val: 'managed association expand', as: '$test' },
+            { ref: ['managedAssociation'], expand: ['*'] },
+          ])
+          .from('target'),
+      )
+
+      // Select expand data from managed association
+      queries.SELECT.push(
+        cds.ql
+          .SELECT([
+            { val: 'unmanaged association expand', as: '$test' },
+            { ref: ['unmanagedAssociation'], expand: ['*'] },
+          ])
+          .from('target'),
+      )
+
+      // REVISIT: path expressions should also work
+
+      // Update all insert queries to include the associations
+      const addAssoc = entry => {
+        const copy = Object.assign({}, entry)
+        copy.managedAssociation = { $test: entry.$test }
+        copy.unmanagedAssociation = { $test: entry.$test }
+        return copy
+      }
+      queries.INSERT.forEach(q => {
+        q.INSERT.entries = q.INSERT.entries.map(addAssoc)
+      })
+    },
+    (results, queries) => {
+      const errors = []
+
+      const managedQueryIndex = queries.SELECT.findIndex(
+        q => q.SELECT.columns?.[0].val === 'managed association expand',
+      )
+      const unmanagedQueryIndex = queries.SELECT.findIndex(
+        q => q.SELECT.columns?.[0].val === 'unmanaged association expand',
+      )
+
+      // Copy expand result set into flat result set for uniform assert structure
+      results.INSERT[0].push(...results.INSERT[managedQueryIndex].map(r => r.managedAssociation))
+      results.UPDATE[0].push(...results.UPDATE[managedQueryIndex].map(r => r.managedAssociation))
+
+      results.INSERT[0].push(...results.INSERT[unmanagedQueryIndex].map(r => r.unmanagedAssociation))
+      results.UPDATE[0].push(...results.UPDATE[unmanagedQueryIndex].map(r => r.unmanagedAssociation))
+
+      return errors
+    },
+  )
+})

--- a/test/compliance/features/cds.builtin.classes.key.test.js
+++ b/test/compliance/features/cds.builtin.classes.key.test.js
@@ -21,7 +21,7 @@ describe('features', () => {
         queries.UPSERT.push(cds.ql.UPSERT(q.INSERT.entries).into('key'))
       })
     },
-    (results, queries) => {
+    results => {
       const errors = []
 
       if (results.UPSERT.length !== results.INSERT.length) {

--- a/test/compliance/features/cds.builtin.classes.key.test.js
+++ b/test/compliance/features/cds.builtin.classes.key.test.js
@@ -1,0 +1,34 @@
+const { describe, test } = require('./test')
+
+const cds = require('@sap/cds')
+
+describe('features', () => {
+  test(
+    'cds.builtin.classes.key',
+    (queries, model) => {
+      // Key test requires base data to enhance
+      if (queries.INSERT.length < 1) return false
+
+      // Create copy of target with compound key
+      model.key = { kind: 'entity', elements: {} }
+      Object.keys(model.target.elements).forEach(k => {
+        model.key.elements[k] = Object.assign({}, model.target.elements[k], { key: true })
+      })
+
+      queries.SELECT.push(cds.ql.SELECT().from('key'))
+      queries.INSERT.forEach(q => {
+        queries.INSERT.push(cds.ql.INSERT(q.INSERT.entries).into('key'))
+        queries.UPSERT.push(cds.ql.UPSERT(q.INSERT.entries).into('key'))
+      })
+    },
+    (results, queries) => {
+      const errors = []
+
+      if (results.UPSERT.length !== results.INSERT.length) {
+        errors.push(new Error(`# cds.builtin.classes # key # Is not being considered for UPSERT queries`))
+      }
+
+      return errors
+    },
+  )
+})

--- a/test/compliance/features/cds.builtin.classes.struct.test.js
+++ b/test/compliance/features/cds.builtin.classes.struct.test.js
@@ -1,0 +1,50 @@
+const { describe, test } = require('./test')
+
+const cds = require('@sap/cds')
+
+describe('features', () => {
+  test(
+    'cds.builtin.classes.struct',
+    (queries, model) => {
+      // Association test requires base data to enhance
+      if (queries.INSERT.length < 1) return false
+
+      const otherElements = Object.keys(model.target.elements)
+
+      // Add Structured data type
+      model.target.elements.structuredType = { elements: { ...model.target.elements } }
+
+      // Update all insert queries to include the structured type
+
+      const addStruct = entry => {
+        const copy = Object.assign({}, entry)
+        for (let e of otherElements) {
+          copy[`structuredType_${e}`] = copy[e]
+        }
+        return copy
+      }
+
+      queries.INSERT.forEach(q => {
+        q.INSERT.entries = q.INSERT.entries.map(addStruct)
+      })
+    },
+    results => {
+      const prefix = 'structuredType_'
+      const prefixLength = prefix.length
+
+      results.INSERT[0].push(
+        ...results.INSERT[0].map(r => {
+          const ret = {}
+          for (let e of Object.keys(r)) {
+            if (e.startsWith(prefix)) {
+              ret[e.substring(prefixLength)] = ret[e]
+            }
+          }
+          return ret
+        }),
+      )
+
+      return []
+    },
+  )
+})

--- a/test/compliance/features/cds.builtin.classes.struct.test.js
+++ b/test/compliance/features/cds.builtin.classes.struct.test.js
@@ -1,7 +1,5 @@
 const { describe, test } = require('./test')
 
-const cds = require('@sap/cds')
-
 describe('features', () => {
   test(
     'cds.builtin.classes.struct',

--- a/test/compliance/features/cds.builtin.types.cds.DateTime.test.js
+++ b/test/compliance/features/cds.builtin.types.cds.DateTime.test.js
@@ -1,0 +1,58 @@
+const { describe, test } = require('./test')
+
+const cds = require('@sap/cds')
+
+const toDateTime = function (date) {
+  return new Date(date).toISOString().substring(0, 19) + 'Z'
+}
+
+const max = new Date('9999-12-31T23:59:59')
+
+const data = [
+  { $test: 'DateTime 1970-01-01T00:00:00Z', DateTime: toDateTime(new Date(0)) },
+  { $test: 'DateTime 9999-12-31T23:59:59Z', DateTime: toDateTime(max) },
+]
+
+describe('features', () => {
+  test(
+    'cds.builtin.types.cds.DateTime',
+    (queries, model) => {
+      model.target.elements.DateTime = { type: 'cds.DateTime' } // REVISIT: cds.Integer32 type can not deploy
+
+      queries.INSERT.push(...data.map(d => cds.ql.INSERT(d).into('target')))
+      queries.UPDATE.push(
+        ...data.map(d =>
+          cds.ql
+            .UPDATE('target')
+            .where({ $test: d.$test })
+            .with({ DateTime: toDateTime(max ^ new Date(d.DateTime)) }),
+        ),
+      )
+    },
+    results => {
+      const errors = []
+      const inserted = results.INSERT[0]
+      for (let i = 0; i < inserted.length; i++) {
+        const row = inserted[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        if (orgData.DateTime !== row.DateTime)
+          errors.push(new Error(`# cds.builtin.types # cds.DateTime # can not store value "${orgData.DateTime}"`))
+      }
+
+      const updated = results.UPDATE[0]
+      for (let i = 0; i < updated.length; i++) {
+        const row = updated[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        const expected = toDateTime(max ^ new Date(orgData.DateTime))
+        if (expected !== row.DateTime)
+          errors.push(new Error(`# cds.builtin.types # cds.DateTime # can not store value "${expected}"`))
+      }
+
+      return errors
+    },
+  )
+})

--- a/test/compliance/features/cds.builtin.types.cds.Integer32.test.js
+++ b/test/compliance/features/cds.builtin.types.cds.Integer32.test.js
@@ -1,0 +1,57 @@
+const { describe, test } = require('./test')
+
+const cds = require('@sap/cds')
+
+// Max binary value for a signed 32-bit int
+const max = -0b1111111111111111111111111111111
+
+const data = [{ $test: 'Integer32 Zero', Integer32: 0 }]
+
+// Add all data to be test with up to 32 bit
+for (let i = 0; i < 31; i++) {
+  data.push({ $test: `Integer32 1 << ${i}`, Integer32: 1 << i })
+}
+
+describe('features', () => {
+  test(
+    'cds.builtin.types.cds.Integer32',
+    (queries, model) => {
+      model.target.elements.Integer32 = { type: 'cds.Integer' } // REVISIT: cds.Integer32 type can not deploy
+
+      queries.INSERT.push(...data.map(d => cds.ql.INSERT(d).into('target')))
+      queries.UPDATE.push(
+        ...data.map(d =>
+          cds.ql
+            .UPDATE('target')
+            .where({ $test: d.$test })
+            .with({ Integer32: max ^ d.Integer32 }),
+        ),
+      )
+    },
+    results => {
+      const errors = []
+      const inserted = results.INSERT[0]
+      for (let i = 0; i < inserted.length; i++) {
+        const row = inserted[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        if (orgData.Integer32 !== row.Integer32)
+          errors.push(new Error(`# cds.builtin.types # cds.Integer32 # can not store value "${orgData.Integer32}"`))
+      }
+
+      const updated = results.UPDATE[0]
+      for (let i = 0; i < updated.length; i++) {
+        const row = updated[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        const expected = max ^ orgData.Integer32
+        if (expected !== row.Integer32)
+          errors.push(new Error(`# cds.builtin.types # cds.Integer32 # can not store value "${expected}"`))
+      }
+
+      return errors
+    },
+  )
+})

--- a/test/compliance/features/cds.builtin.types.cds.Integer64.test.js
+++ b/test/compliance/features/cds.builtin.types.cds.Integer64.test.js
@@ -11,9 +11,9 @@ const data = [{ $test: 'Integer64 Zero', Integer64: '0' }]
 let bin = '0b'
 for (let i = 0; i < 63; i++) {
   bin += '1'
-  data.push({ $test: `Integer64 1 << ${i}`, Integer64: BigInt(bin).toString() })
+  data.push({ $test: `Integer64 1 << ${i}`, Integer64: global.BigInt(bin).toString() })
 }
-data.push({ $test: `Integer64 1 << 64`, Integer64: (BigInt(bin) * -1n).toString() })
+data.push({ $test: `Integer64 1 << 64`, Integer64: (global.BigInt(bin) * -1n).toString() })
 
 describe('features', () => {
   test(
@@ -28,7 +28,7 @@ describe('features', () => {
             .UPDATE('target')
             .where({ $test: d.$test })
             .with({
-              Integer64: (max ^ BigInt(d.Integer64)).toString(),
+              Integer64: (max ^ global.BigInt(d.Integer64)).toString(),
             }),
         ),
       )
@@ -51,7 +51,7 @@ describe('features', () => {
         const testName = row.$test
         const orgData = data.find(d => d.$test === testName)
         if (!orgData) continue
-        const expected = (max ^ BigInt(orgData.Integer64)).toString()
+        const expected = (max ^ global.BigInt(orgData.Integer64)).toString()
         if (expected !== row.Integer64)
           errors.push(new Error(`# cds.builtin.types # cds.Integer64 # can not store value "${expected}"`))
       }

--- a/test/compliance/features/cds.builtin.types.cds.Integer64.test.js
+++ b/test/compliance/features/cds.builtin.types.cds.Integer64.test.js
@@ -1,0 +1,62 @@
+const { describe, test } = require('./test')
+
+const cds = require('@sap/cds')
+
+// Max binary value for a signed 64-bit int
+const max = -0b111111111111111111111111111111111111111111111111111111111111111n
+
+const data = [{ $test: 'Integer64 Zero', Integer64: '0' }]
+
+// Add all data to be test with up to 32 bit
+let bin = '0b'
+for (let i = 0; i < 63; i++) {
+  bin += '1'
+  data.push({ $test: `Integer64 1 << ${i}`, Integer64: BigInt(bin).toString() })
+}
+data.push({ $test: `Integer64 1 << 64`, Integer64: (BigInt(bin) * -1n).toString() })
+
+describe('features', () => {
+  test(
+    'cds.builtin.types.cds.Integer64',
+    (queries, model) => {
+      model.target.elements.Integer64 = { type: 'cds.Integer64' }
+
+      queries.INSERT.push(...data.map(d => cds.ql.INSERT(d).into('target')))
+      queries.UPDATE.push(
+        ...data.map(d =>
+          cds.ql
+            .UPDATE('target')
+            .where({ $test: d.$test })
+            .with({
+              Integer64: (max ^ BigInt(d.Integer64)).toString(),
+            }),
+        ),
+      )
+    },
+    results => {
+      const errors = []
+      const inserted = results.INSERT[0]
+      for (let i = 0; i < inserted.length; i++) {
+        const row = inserted[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        if (orgData.Integer64 !== row.Integer64)
+          errors.push(new Error(`# cds.builtin.types # cds.Integer64 # can not store value "${orgData.Integer64}"`))
+      }
+
+      const updated = results.UPDATE[0]
+      for (let i = 0; i < updated.length; i++) {
+        const row = updated[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        const expected = (max ^ BigInt(orgData.Integer64)).toString()
+        if (expected !== row.Integer64)
+          errors.push(new Error(`# cds.builtin.types # cds.Integer64 # can not store value "${expected}"`))
+      }
+
+      return errors
+    },
+  )
+})

--- a/test/compliance/features/cds.builtin.types.cds.Timestamp.test.js
+++ b/test/compliance/features/cds.builtin.types.cds.Timestamp.test.js
@@ -1,0 +1,59 @@
+const { describe, test } = require('./test')
+
+const cds = require('@sap/cds')
+
+const toTimestamp = function (date) {
+  return new Date(date).toISOString().substring(0, 23) + '0000Z'
+}
+
+const maxString = '9999-12-31T23:59:59.1234567Z'
+const max = new Date(maxString)
+
+const data = [
+  { $test: 'Timestamp 1970-01-01T00:00:00.0000000Z', Timestamp: toTimestamp(new Date(0)) },
+  { $test: 'Timestamp 9999-12-31T23:59:59.1234567Z', Timestamp: maxString },
+]
+
+describe('features', () => {
+  test(
+    'cds.builtin.types.cds.Timestamp',
+    (queries, model) => {
+      model.target.elements.Timestamp = { type: 'cds.Timestamp' } // REVISIT: cds.Integer32 type can not deploy
+
+      queries.INSERT.push(...data.map(d => cds.ql.INSERT(d).into('target')))
+      queries.UPDATE.push(
+        ...data.map(d =>
+          cds.ql
+            .UPDATE('target')
+            .where({ $test: d.$test })
+            .with({ Timestamp: toTimestamp(max ^ new Date(d.Timestamp)) }),
+        ),
+      )
+    },
+    results => {
+      const errors = []
+      const inserted = results.INSERT[0]
+      for (let i = 0; i < inserted.length; i++) {
+        const row = inserted[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        if (orgData.Timestamp !== row.Timestamp)
+          errors.push(new Error(`# cds.builtin.types # cds.Timestamp # can not store value "${orgData.Timestamp}"`))
+      }
+
+      const updated = results.UPDATE[0]
+      for (let i = 0; i < updated.length; i++) {
+        const row = updated[i]
+        const testName = row.$test
+        const orgData = data.find(d => d.$test === testName)
+        if (!orgData) continue
+        const expected = toTimestamp(max ^ new Date(orgData.Timestamp))
+        if (expected !== row.Timestamp)
+          errors.push(new Error(`# cds.builtin.types # cds.Timestamp # can not store value "${expected}"`))
+      }
+
+      return errors
+    },
+  )
+})

--- a/test/compliance/features/index.test.js
+++ b/test/compliance/features/index.test.js
@@ -1,0 +1,17 @@
+const { describe } = require('./test')
+
+describe('features', () => {
+  // Require all features
+  // Require order is important to allow for a sorted matrix relation
+
+  // All data types
+  require('./cds.builtin.types.cds.Integer32.test')
+  require('./cds.builtin.types.cds.Integer64.test')
+  require('./cds.builtin.types.cds.DateTime.test')
+  require('./cds.builtin.types.cds.Timestamp.test')
+
+  // Complex tests that require other features to be tested
+  require('./cds.builtin.classes.struct.test')
+  require('./cds.builtin.classes.key.test')
+  require('./cds.builtin.classes.association.test')
+})

--- a/test/compliance/features/test.js
+++ b/test/compliance/features/test.js
@@ -76,6 +76,7 @@ test('features', async () => {
 
     report[tests.join(' + ')] = errors
   }
+  // eslint-disable-next-line no-console
   console.log(
     Object.keys(report)
       .map(k => {

--- a/test/compliance/features/test.js
+++ b/test/compliance/features/test.js
@@ -1,0 +1,125 @@
+// process.env.DEBUG = 'sql'
+
+const cds = require('@sap/cds')
+
+const features = {}
+
+test('features', async () => {
+  const report = {}
+  const matrix = fullMatrix(Object.keys(features))
+
+  tests: for (let i = 0; i < matrix.length; i++) {
+    const model = {
+      target: {
+        kind: 'entity',
+        elements: {
+          $test: { type: 'cds.String', notNull: true },
+        },
+      },
+    }
+    const queries = {
+      SELECT: [cds.ql.SELECT().from('target')],
+      INSERT: [],
+      UPDATE: [],
+      DELETE: [],
+      UPSERT: [],
+      STREAM: [],
+    }
+
+    const results = {}
+    const errors = []
+
+    const tests = matrix[i]
+    try {
+      for (let x = 0; x < tests.length; x++) {
+        const applicable = await features[tests[x]].setup(queries, model)
+        if (applicable === false) {
+          continue tests
+        }
+      }
+
+      cds.env.requires.db = { kind: 'better-sqlite' }
+      await cds.deploy({ $sources: [], definitions: model })
+
+      results.DEPLOY = await Promise.all(queries.SELECT.map(q => q.clone()))
+      await Promise.all(queries.INSERT.map(q => q.clone()))
+      results.INSERT = await Promise.all(queries.SELECT.map(q => q.clone()))
+      await Promise.all(queries.UPDATE.map(q => q.clone()))
+      results.UPDATE = await Promise.all(queries.SELECT.map(q => q.clone()))
+      await Promise.all(queries.DELETE.map(q => q.clone()))
+      results.DELETE = await Promise.all(queries.SELECT.map(q => q.clone()))
+      await Promise.all(queries.UPSERT.map(q => q.clone()))
+      results.UPSERT = await Promise.all(queries.SELECT.map(q => q.clone()))
+      await Promise.all(queries.STREAM.map(q => q.clone()))
+      results.STREAM = await Promise.all(queries.SELECT.map(q => q.clone()))
+
+      // Run assert in reverse
+      for (let x = tests.length - 1; x > -1; x--) {
+        try {
+          errors.push(...(await features[tests[x]].assert(results, queries, model)))
+        } catch (err) {
+          errors.push(err)
+        }
+      }
+    } catch (err) {
+      errors.push(err)
+    }
+
+    // Clean database connection pool
+    await cds.db?.disconnect?.()
+
+    // Clean cache
+    delete cds.services._pending.db
+    delete cds.services.db
+    delete cds.db
+    delete cds.model
+
+    report[tests.join(' + ')] = errors
+  }
+  console.log(
+    Object.keys(report)
+      .map(k => {
+        const errors = report[k]
+        if (errors.length) {
+          return `FAIL ${k}:\n    ${errors.map(e => e.message).join('\n    ')}`
+        }
+        return `PASS ${k}`
+      })
+      .join('\n') || cds.error`No tests found`,
+  )
+})
+
+const fullMatrix = function (names) {
+  const tests = []
+
+  for (let i = 0; i < names.length; i++) {
+    tests.push(...dimensionMatrix(names, i + 1))
+  }
+
+  return tests
+}
+
+const dimensionMatrix = function (names, dimensions) {
+  const tests = []
+
+  const end = names.length - (dimensions - 1)
+  for (let i = 0; i < end; i++) {
+    if (dimensions === 1) {
+      tests.push([names[i]])
+    } else {
+      tests.push(...dimensionMatrix(names.slice(i + 1), dimensions - 1).map(t => [names[i], ...t]))
+    }
+  }
+
+  return tests
+}
+
+module.exports = {
+  describe,
+  test: function (name, setup, assert) {
+    features[name] = {
+      setup,
+      assert,
+    }
+  },
+}

--- a/test/compliance/index.js
+++ b/test/compliance/index.js
@@ -1,5 +1,5 @@
 require('./features/index.test')
- 
+
 require('./CREATE.test')
 require('./DELETE.test')
 require('./DROP.test')

--- a/test/compliance/index.js
+++ b/test/compliance/index.js
@@ -1,3 +1,5 @@
+require('./features/index.test')
+ 
 require('./CREATE.test')
 require('./DELETE.test')
 require('./DROP.test')


### PR DESCRIPTION
## description

Instead of writing out every possible combination of `CSN` features that the database should support. This PoC takes the approach of generically specifying a feature and how to verify correct functionality. To then combine every feature test together to cover all possible / applicable combinations.

## example

Taking the following 3 feature test:

```
cds.Integer32.test.js
cds.Integer64.test.js
cds.Association.test.js
```

Will run the following test combinations

```
cds.Integer32.test.js
cds.Integer64.test.js
cds.Integer32.test.js + cds.Integer64.test.js
cds.Integer32.test.js + cds.Association.test.js
cds.Integer64.test.js + cds.Association.test.js
cds.Integer32.test.js + cds.Integer64.test.js + cds.Association.test.js
```

There is no stand alone `cds.Association.test.js` test being executed as this feature requires other features to function and therefor checks whether the required features are ran before and if not it will skip the combination.

## issues

To reduce the total number of feature combinations the feature tests are defined in order. This way not every possible order of features is tested instead just each possible combination of features is tested. To prevent combinations like:

```
cds.Integer32.test.js + cds.Integer64.test.js
cds.Integer64.test.js + cds.Integer32.test.js
cds.Integer32.test.js + cds.Integer64.test.js + cds.Association.test.js
cds.Integer32.test.js + cds.Association.test.js + cds.Integer64.test.js
cds.Association.test.js + cds.Integer32.test.js + cds.Integer64.test.js
```

Where some of these combinations might make sense they most likely will test the exact same combination multiple times.

Also to prevent an unreasonable amount of combinations interpolation might be used to verify combinations of features. like:

```
{type n}.test.js + key.test.js
... for each type
{type n}.test.js + {type n}.test.js + key.test.js
... for each type pair
{type n}.test.js + {type n}.test.js + {type n}.test.js + key.test.js
... for each type tripled
...
```

Instead it would be possible to just run each individual type and then all types combined in a single test. Assuming that each possible combination of compound keys would work in between the two extremes.

```
{type n}.test.js + key.test.js
... for each type
{type 0}.test.js + {type 1}.test.js  + ... + key.test.js
```