### PR TITLE
cqn4sql: fixes for selects on top of anonymous subqueries

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1086,11 +1086,12 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           if (token.ref) {
             const tableAlias = getQuerySourceName(token, $baseLink)
             if (!$baseLink && token.isJoinRelevant) {
-              // t.push(...flatColumns)
               result.ref = [tableAlias, getFullName(token.$refLinks[token.$refLinks.length - 1].definition)]
-            } else {
-              // revisit: can we get rid of flatName?
+            } else if (tableAlias) {
               result.ref = [tableAlias, token.flatName]
+            } else {
+              // if there is no table alias, we might select from an anonymous subquery
+              result.ref = [token.flatName]
             }
           } else if (token.SELECT) {
             result = transformSubquery(token)

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -565,10 +565,7 @@ describe('table alias access', () => {
       )
     })
     it('wildcard expansion of subquery in from ignores assocs', () => {
-      let query = cqn4sql(
-        CQL`SELECT from ( SELECT from bookshop.Orders ) as O`,
-        model,
-      )
+      let query = cqn4sql(CQL`SELECT from ( SELECT from bookshop.Orders ) as O`, model)
       expect(query).to.deep.equal(
         CQL`SELECT from (
           SELECT from bookshop.Orders as Orders {
@@ -576,6 +573,25 @@ describe('table alias access', () => {
           }
         ) as O {
           O.ID,
+        }`,
+      )
+    })
+    it('no alias for function args or expressions on top of anonymous subquery', () => {
+      let query = cqn4sql(
+        CQL`SELECT from ( SELECT from bookshop.Orders ) {
+          sum(ID) as foo,
+          ID + 42 as anotherFoo
+        }`,
+        model,
+      )
+      expect(query).to.deep.equal(
+        CQL`SELECT from (
+          SELECT from bookshop.Orders as Orders {
+            Orders.ID
+          }
+        ) {
+          sum(ID) as foo,
+          ID + 42 as anotherFoo
         }`,
       )
     })


### PR DESCRIPTION
- for a wildcard -> ignore unmanaged assocs, replace managed with foreign keys
- for function `args` and `xpr` omit alias