### PR TITLE
postgres: Update README.md

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,5 +1,3 @@
 # CDS database service for Postgres
 
 Welcome to the new Postgres database service for [SAP Cloud Application Programming Model](https://cap.cloud.sap) Node.js, based on new, streamlined database architecture and [*pg* driver](https://www.npmjs.com/package/pg) .
-
-Find documentation at https://cap.cloud.sap/docs/guides/databases-postgres.


### PR DESCRIPTION
this link is dead. As soon as we have the new "using database" documentation on the external capire, we can add a link again.