### PR TITLE
Adding acquireTimeoutMillis Pool Parameter

### DIFF
--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -20,7 +20,7 @@ class PostgresService extends SQLService {
         ...this.options.pool,
         min: 0,
         testOnBorrow: true,
-        acquireTimeoutMillis: 1000,
+        acquireTimeoutMillis: (this.options.pool && this.options.pool.acquireTimeoutMillis ) ? this.options.pool.acquireTimeoutMillis:1000,
         destroyTimeoutMillis: 1000,
       },
       create: async () => {

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -17,11 +17,11 @@ class PostgresService extends SQLService {
   get factory() {
     return {
       options: {
-        ...this.options.pool,
         min: 0,
         testOnBorrow: true,
-        acquireTimeoutMillis: (this.options.pool && this.options.pool.acquireTimeoutMillis ) ? this.options.pool.acquireTimeoutMillis:1000,
+        acquireTimeoutMillis: 1000,
         destroyTimeoutMillis: 1000,
+        ...this.options.pool
       },
       create: async () => {
         const cr = this.options.credentials || {}

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -21,7 +21,7 @@ class PostgresService extends SQLService {
         testOnBorrow: true,
         acquireTimeoutMillis: 1000,
         destroyTimeoutMillis: 1000,
-        ...this.options.pool
+        ...this.options.pool,
       },
       create: async () => {
         const cr = this.options.credentials || {}


### PR DESCRIPTION
Adding support for acquireTimeoutMillis pool setting to resolve the ResourceRequest timed out problem. 

More information about the problem and a solution is available at the following URL, but they are not part of PostgresService. 
https://cap.cloud.sap/docs/advanced/troubleshooting#why-are-requests-occasionally-rejected-with-acquiring-client-from-pool-timed-out-or-resourcerequest-timed-out

