### PR TITLE
Point links at npmjs to GitHub repository

### DIFF
--- a/db-service/package.json
+++ b/db-service/package.json
@@ -2,7 +2,14 @@
   "name": "@cap-js/db-service",
   "version": "1.0.1",
   "description": "CDS base database service",
-  "homepage": "https://cap.cloud.sap/",
+  "homepage": "https://github.com/cap-js/cds-dbs/tree/main/db-service#cds-base-database-service",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cap-js/cds-dbs"
+  },
+  "bugs": {
+    "url": "https://github.com/cap-js/cds-dbs/issues"
+  },
   "keywords": [
     "CAP",
     "CDS"

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -2,7 +2,7 @@
   "name": "@cap-js/postgres",
   "version": "1.0.1",
   "description": "CDS database service for Postgres",
-  "homepage": "https://github.com/cap-js/cds-dbs/tree/main/postgres#readme",
+  "homepage": "https://github.com/cap-js/cds-dbs/tree/main/postgres#cds-database-service-for-postgres",
   "repository": {
     "type": "git",
     "url": "https://github.com/cap-js/cds-dbs"

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -2,7 +2,14 @@
   "name": "@cap-js/postgres",
   "version": "1.0.1",
   "description": "CDS database service for Postgres",
-  "homepage": "https://cap.cloud.sap/",
+  "homepage": "https://github.com/cap-js/cds-dbs/tree/main/postgres#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cap-js/cds-dbs"
+  },
+  "bugs": {
+    "url": "https://github.com/cap-js/cds-dbs/issues"
+  },
   "keywords": [
     "CAP",
     "CDS",

--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -2,7 +2,14 @@
   "name": "@cap-js/sqlite",
   "version": "1.0.1",
   "description": "CDS database service for SQLite",
-  "homepage": "https://cap.cloud.sap/",
+  "homepage": "https://github.com/cap-js/cds-dbs/tree/main/sqlite#cds-database-service-for-sqlite",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cap-js/cds-dbs"
+  },
+  "bugs": {
+    "url": "https://github.com/cap-js/cds-dbs/issues"
+  },
   "keywords": [
     "CAP",
     "CDS",


### PR DESCRIPTION
The links at https://www.npmjs.com/package/@cap-js/postgres are currently very generic. I think we should point them to the now public GitHub repository.