### PR TITLE
Postgres: schema_evolution = 'auto' by default

### DIFF
--- a/postgres/package.json
+++ b/postgres/package.json
@@ -46,7 +46,8 @@
               "user": "postgres",
               "password": "postgres",
               "database": "postgres"
-            }
+            },
+            "schema_evolution": "auto"
           }
         },
         "postgres": {

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -35,7 +35,6 @@
       "kinds": {
         "sql": {
           "[production]": {
-            "schema_evolution": "auto",
             "kind": "postgres"
           },
           "[pg!]": {
@@ -46,8 +45,7 @@
               "user": "postgres",
               "password": "postgres",
               "database": "postgres"
-            },
-            "schema_evolution": "auto"
+            }
           }
         },
         "postgres": {

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -35,6 +35,7 @@
       "kinds": {
         "sql": {
           "[production]": {
+            "schema_evolution": "auto",
             "kind": "postgres"
           },
           "[pg!]": {
@@ -53,7 +54,8 @@
           "dialect": "postgres",
           "vcap": {
             "label": "postgresql-db"
-          }
+          },
+          "schema_evolution": "auto"
         }
       },
       "db": "sql"


### PR DESCRIPTION
Currently, we do this in a hacky way in `cds deploy` - we should instead do it more centrally in the plugin.

Should fix https://github.com/cap-js/cds-dbs/issues/100