### PR TITLE
feat: enable azure pg connectivity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BobdenOs @David-Kunz @patricebender @danjoa @gregorwolf @johannes-vogel @vobu @stewsk
+* @BobdenOs @David-Kunz @patricebender @danjoa @gregorwolf @johannes-vogel @vobu @stewsk @sebastianesch

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Version x.x.x - yyyy-MM-dd
+
+### Added
+
+- connectivity to Azure PostGreSQL
+
 ## Version 1.0.1 - 2023-07-03
 
 ### Added

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- connectivity to Azure PostGreSQL
+- connectivity to Azure PostgreSQL
 
 ## Version 1.0.1 - 2023-07-03
 

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -36,10 +36,14 @@ class PostgresService extends SQLService {
           database: cr.dbname || cr.database,
           schema: cr.schema,
           sslRequired: cr.sslrootcert && (cr.sslrootcert ?? true),
-          ssl: cr.sslrootcert && {
-            rejectUnauthorized: false,
-            ca: cr.sslrootcert,
-          },
+          // from pg driver docs:
+          // passed directly to node.TLSSocket, supports all tls.connect options
+          ssl:
+            cr.ssl /* enable pg module setting to connect to Azure postgres */ ||
+            (cr.sslrootcert && {
+              rejectUnauthorized: false,
+              ca: cr.sslrootcert,
+            }),
         }
         const dbc = new Client(credentials)
         await dbc.connect()

--- a/postgres/test/connect.test.js
+++ b/postgres/test/connect.test.js
@@ -1,0 +1,41 @@
+const { Client } = require('pg')
+const PgService = require('../lib/PostgresService')
+const { expect } = require('chai')
+
+const cds = require('../../test/cds.js')
+
+process.env.DEBUG && jest.setTimeout(100000)
+
+// fake the manifestation of the db connection
+Client.prototype.connect = jest.fn(() => Promise.resolve({}))
+
+describe('connect to pg db', () => {
+  test('in docker', async () => {
+    cds.env.requires.db = require('@cap-js/postgres/test/service.json')
+    const pgService = new PgService()
+    pgService.options.credentials = cds.env.requires.db.credentials
+    const con = await pgService.factory.create()
+    expect(con.host).to.equal(cds.env.requires.db.credentials.host)
+    expect(con.user).to.equal(cds.env.requires.db.credentials.user)
+    expect(con.database).to.equal(cds.env.requires.db.credentials.database)
+    expect(con.ssl).to.equal(false)
+  })
+  test('for btp pg hyperscaler', async () => {
+    cds.env.requires.db = require('@cap-js/postgres/test/service-btp.json')
+    const pgService = new PgService()
+    pgService.options.credentials = cds.env.requires.db.credentials
+    const con = await pgService.factory.create()
+    expect(con.host).to.equal(cds.env.requires.db.credentials.hostname)
+    expect(con.user).to.equal(cds.env.requires.db.credentials.username)
+    expect(con.database).to.equal(cds.env.requires.db.credentials.dbname)
+    expect(con.ssl.ca).to.equal(cds.env.requires.db.credentials.sslrootcert)
+    expect(con.ssl.rejectUnauthorized).to.be.false
+  })
+  test('with azure pg compatible settings', async () => {
+    cds.env.requires.db = require('@cap-js/postgres/test/service-az.json')
+    const pgService = new PgService()
+    pgService.options.credentials = cds.env.requires.db.credentials
+    const con = await pgService.factory.create()
+    expect(con.ssl).to.equal(true)
+  })
+})

--- a/postgres/test/service-az.json
+++ b/postgres/test/service-az.json
@@ -1,0 +1,12 @@
+{
+  "credentials": {
+    "host": "some-azure-postgres.postgres.database.azure.com",
+    "port": "5432",
+    "database": "some-db",
+    "user": "wannaberoot",
+    "password": "notimportant",
+    "ssl": true
+  },
+  "dialect": "postgres",
+  "impl": "@cap-js/postgres"
+}

--- a/postgres/test/service-btp.json
+++ b/postgres/test/service-btp.json
@@ -1,0 +1,12 @@
+{
+  "credentials": {
+    "hostname": "some-btp-postgres.cf10.eu.ondemand.com",
+    "port": "4711",
+    "dbname": "some-db",
+    "username": "btpuser",
+    "password": "notimportant",
+    "sslrootcert": { "who": "cares" }
+  },
+  "dialect": "postgres",
+  "impl": "@cap-js/postgres"
+}


### PR DESCRIPTION
enhancing the `credentials` obj by a boolean value to be able to properly connect to a pg db running on azure.

also added tests for major connectivity scenarios (docker, btp, azure).