### PR TITLE
[FIX] Make result check for plain SQL queries case insensitive

### DIFF
--- a/db-service/CHANGELOG.md
+++ b/db-service/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - `UPDATE` with path expressions do not end up in a dump anymore. Instead, a proper error message is emitted.
+- `SELECT` with plain SQL statements will return correct result regardless of casing.
 
 ## Version 1.0.1 - 2023-07-03
 

--- a/db-service/lib/SQLService.js
+++ b/db-service/lib/SQLService.js
@@ -137,7 +137,7 @@ class SQLService extends DatabaseService {
 
   /** Override in subclasses to detect more statements to be called with ps.all() */
   hasResults(sql) {
-    return /^(SELECT|WITH|CALL|PRAGMA table_info)/.test(sql)
+    return /^(SELECT|WITH|CALL|PRAGMA table_info)/i.test(sql)
   }
 
   /** Derives and executes a query to fill in `$count` for given query */


### PR DESCRIPTION
# description

`SQL` does not care about the casing of the key words. Therefor it is allowed to do `SELECT`, `select` and `SeLeCt` which will now be properly identified as a reading query.