### PR TITLE
actions: Use compiler v4^ in `package-lock.json`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,5 @@ jobs:
           git add -A &&
           git commit -m "✨prettier✨" &&
           git push
+      - run: cds --version
       - run: npm run test:all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,5 +46,4 @@ jobs:
           git add -A &&
           git commit -m "✨prettier✨" &&
           git push
-      - run: cds --version
       - run: npm run test:all

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -22,11 +22,9 @@
     "test": "npx jest --silent",
     "lint": "npx eslint . && npx prettier --check . "
   },
+  "dependencies": {},
   "peerDependencies": {
     "@sap/cds": ">=7"
   },
-  "license": "SEE LICENSE",
-  "devDependencies": {
-    "@sap/cds-compiler": "^4.0.2"
-  }
+  "license": "SEE LICENSE"
 }

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -22,7 +22,6 @@
     "test": "npx jest --silent",
     "lint": "npx eslint . && npx prettier --check . "
   },
-  "dependencies": {},
   "peerDependencies": {
     "@sap/cds": ">=7"
   },

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -22,9 +22,11 @@
     "test": "npx jest --silent",
     "lint": "npx eslint . && npx prettier --check . "
   },
-  "dependencies": {},
   "peerDependencies": {
     "@sap/cds": ">=7"
   },
-  "license": "SEE LICENSE"
+  "license": "SEE LICENSE",
+  "devDependencies": {
+    "@sap/cds-compiler": "^4.0.2"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cds-dbs",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cds-dbs",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "license": "SEE LICENSE",
       "workspaces": [
         "db-service",
@@ -27,11 +27,8 @@
     },
     "db-service": {
       "name": "@cap-js/db-service",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "license": "SEE LICENSE",
-      "devDependencies": {
-        "@sap/cds-compiler": "^4.0.2"
-      },
       "engines": {
         "node": ">=16",
         "npm": ">=8"
@@ -1264,9 +1261,8 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.0.2.tgz",
-      "integrity": "sha512-d2S7LpV0xL/v0Pdw7CUN21WdE1FY4VKt44FnpiFJP/FF3upRjk0wS9BhQ2a1NT1Z2piNOWvAN6I8vJW171zjcQ==",
+      "version": "3.9.2",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "antlr4": "4.9.3"
       },
@@ -1276,7 +1272,7 @@
         "cdsse": "bin/cdsse.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@sap/cds-fiori": {
@@ -5722,10 +5718,10 @@
     },
     "postgres": {
       "name": "@cap-js/postgres",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1.0.1",
+        "@cap-js/db-service": "^1",
         "pg": "^8"
       },
       "engines": {
@@ -5738,10 +5734,10 @@
     },
     "sqlite": {
       "name": "@cap-js/sqlite",
-      "version": "1.0.1",
+      "version": "1.0.0",
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1.0.1",
+        "@cap-js/db-service": "^1",
         "better-sqlite3": "^8"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cds-dbs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cds-dbs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
       "workspaces": [
         "db-service",
@@ -27,8 +27,11 @@
     },
     "db-service": {
       "name": "@cap-js/db-service",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
+      "dependencies": {
+        "@sap/cds-compiler": "^4.0.2"
+      },
       "engines": {
         "node": ">=16",
         "npm": ">=8"
@@ -1261,8 +1264,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "3.9.2",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.0.2.tgz",
+      "integrity": "sha512-d2S7LpV0xL/v0Pdw7CUN21WdE1FY4VKt44FnpiFJP/FF3upRjk0wS9BhQ2a1NT1Z2piNOWvAN6I8vJW171zjcQ==",
       "dependencies": {
         "antlr4": "4.9.3"
       },
@@ -1272,7 +1276,7 @@
         "cdsse": "bin/cdsse.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@sap/cds-fiori": {
@@ -5718,10 +5722,10 @@
     },
     "postgres": {
       "name": "@cap-js/postgres",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1",
+        "@cap-js/db-service": "^1.0.1",
         "pg": "^8"
       },
       "engines": {
@@ -5734,10 +5738,10 @@
     },
     "sqlite": {
       "name": "@cap-js/sqlite",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1",
+        "@cap-js/db-service": "^1.0.1",
         "better-sqlite3": "^8"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cds-dbs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cds-dbs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
       "workspaces": [
         "db-service",
@@ -27,8 +27,11 @@
     },
     "db-service": {
       "name": "@cap-js/db-service",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
+      "devDependencies": {
+        "@sap/cds-compiler": "^4.0.2"
+      },
       "engines": {
         "node": ">=16",
         "npm": ">=8"
@@ -1261,8 +1264,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "3.9.2",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.0.2.tgz",
+      "integrity": "sha512-d2S7LpV0xL/v0Pdw7CUN21WdE1FY4VKt44FnpiFJP/FF3upRjk0wS9BhQ2a1NT1Z2piNOWvAN6I8vJW171zjcQ==",
       "dependencies": {
         "antlr4": "4.9.3"
       },
@@ -1272,7 +1276,7 @@
         "cdsse": "bin/cdsse.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@sap/cds-fiori": {
@@ -5718,10 +5722,10 @@
     },
     "postgres": {
       "name": "@cap-js/postgres",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1",
+        "@cap-js/db-service": "^1.0.1",
         "pg": "^8"
       },
       "engines": {
@@ -5734,10 +5738,10 @@
     },
     "sqlite": {
       "name": "@cap-js/sqlite",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1",
+        "@cap-js/db-service": "^1.0.1",
         "better-sqlite3": "^8"
       },
       "engines": {

--- a/postgres/test/__snapshots__/csn2postgres.test.js.snap
+++ b/postgres/test/__snapshots__/csn2postgres.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CSN to PostgreSQL Create Statements should return PostgreSQL compatible statements for beershop-admin-service 1`] = `
 "
 CREATE TABLE BeershopAdminService_UserScopes (
-  username VARCHAR(5000) NOT NULL,
+  username VARCHAR(255) NOT NULL,
   is_admin BOOLEAN,
   PRIMARY KEY(username)
 );
@@ -42,7 +42,7 @@ CREATE TABLE csw_TypeChecks (
   type_Time TIME,
   type_DateTime TIMESTAMP,
   type_Timestamp TIMESTAMP,
-  type_String VARCHAR(5000),
+  type_String VARCHAR(255),
   type_Binary BYTEA,
   type_LargeBinary BYTEA,
   type_LargeString TEXT,
@@ -108,7 +108,7 @@ CREATE TABLE csw_TypeChecks (
   type_Time TIME,
   type_DateTime TIMESTAMP,
   type_Timestamp TIMESTAMP,
-  type_String VARCHAR(5000),
+  type_String VARCHAR(255),
   type_Binary BYTEA,
   type_LargeBinary BYTEA,
   type_LargeString TEXT,
@@ -138,7 +138,7 @@ CREATE TABLE BeershopService_TypeChecksWithDraft_drafts (
   type_Time TIME NULL,
   type_DateTime TIMESTAMP NULL,
   type_Timestamp TIMESTAMP NULL,
-  type_String VARCHAR(5000) NULL,
+  type_String VARCHAR(255) NULL,
   type_Binary BYTEA NULL,
   type_LargeBinary BYTEA NULL,
   type_LargeString TEXT NULL,


### PR DESCRIPTION
`"@sap/cds": ">=7"` -> leads to `cds@7.0.0` which still depends on `compiler@3.9.2` 