### PR TITLE
infer: correctly merge `inline` columns into join tree

### DIFF
--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -145,8 +145,9 @@ class JoinTree {
         }
         const child = new Node($refLink, node, where)
         if (child.$refLink.definition.isAssociation) {
-          if (child.where) {
-            // always join relevant
+          if (child.where || col.inline) {
+            // filter is always join relevant
+            // if the column ends up in an `inline` -> each assoc step is join relevant
             child.$refLink.onlyForeignKeyAccess = false
           } else {
             child.$refLink.onlyForeignKeyAccess = true

--- a/db-service/test/cqn4sql/inline.test.js
+++ b/db-service/test/cqn4sql/inline.test.js
@@ -47,6 +47,22 @@ describe('inline', () => {
     expect(cqn4sql(inlineQuery, model)).to.eql(longResult).to.eql(expected)
   })
 
+  it('structural inline expansion back and forth', () => {
+    let inlineQuery = CQL`select from Department {
+      head.department.{
+        costCenter
+      }
+    }`
+    let expected = CQL`select from Department as Department
+    left join Employee as head on head.id = Department.head_id
+    left join Department as department2 on department2.id = head.department_id
+    {
+      department2.costCenter,
+    }`
+    const res = cqn4sql(inlineQuery, model)
+    expect(res).to.eql(expected)
+  })
+
   it('mixed with expand', () => {
     let queryInlineNotation = CQL`select from Employee {
           office {


### PR DESCRIPTION
an association which is part of a `ref` which ends up in an `inline` expression, is always join relevant -> need to correctly set the marker