### PR TITLE
[PARKED:] feat: deploy only tables

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -555,9 +555,7 @@ class CQN2SQLRenderer {
         if (Buffer.isBuffer(val)) val = val.toString('base64')
         else val = this.regex(val) || this.json(val)
     }
-    if (!this.values) return this.string(val)
-    this.values.push(val)
-    return '?'
+    return this.string(val)
   }
 
   static Functions = require('./cql-functions')

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -246,7 +246,7 @@ class CQN2SQLRenderer {
             ],
           })
         }
-        if (col?.element?.['@Core.MediaType']) {
+        if (col?.element?.type === 'cds.LargeBinary') {
           subQuery.SELECT.columns.push(col)
         }
       })

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -250,13 +250,9 @@ class CQN2SQLRenderer {
           subQuery.SELECT.columns.push(col)
         }
       })
-      try {
-        // REVISIT: ensure to call cqn4sql with the correct model
-        return `(${this.SELECT(cqn4sql(subQuery))}) as ${this.quote(alias)}`
-      } catch (e) {
-        subQuery
-        debugger
-      }
+
+      // REVISIT: ensure to call cqn4sql with the correct model
+      return `(${this.SELECT(cqn4sql(subQuery))}) as ${this.quote(alias)}`
     }
     if (from.SELECT) return _aliased(`(${this.SELECT(from)})`)
     if (from.join) {

--- a/db-service/test/cqn2sql/__snapshots__/expression.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/expression.test.js.snap
@@ -2,10 +2,8 @@
 
 exports[`expressions ref is between two range 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x regexp ?",
-  "values": [
-    "/\\d/",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x regexp '/\\d/'",
+  "values": [],
 }
 `;
 
@@ -18,10 +16,8 @@ exports[`expressions ref is in list of sub select 1`] = `
 
 exports[`expressions ref is like pattern 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x like ?",
-  "values": [
-    "%123",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x like '%123'",
+  "values": [],
 }
 `;
 

--- a/db-service/test/cqn2sql/__snapshots__/function.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/function.test.js.snap
@@ -2,10 +2,8 @@
 
 exports[`function contains complex 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE ifnull(instr((Foo.a,Foo.b),?),0)",
-  "values": [
-    "5",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE ifnull(instr((Foo.a,Foo.b),'5'),0)",
+  "values": [],
 }
 `;
 

--- a/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
@@ -42,23 +42,19 @@ exports[`cqn2sql WHERE where with partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,
 
 exports[`cqn2sql WHERE where with two partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x + 9) = 9"`;
 
-exports[`cqn2sql WHERE with contains with multiple arguments 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.a = 0 and ifnull(instr((Foo.a,Foo.b,Foo.c,Foo.x),?),0)"`;
+exports[`cqn2sql WHERE with contains with multiple arguments 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.a = 0 and ifnull(instr((Foo.a,Foo.b,Foo.c,Foo.x),'z'),0)"`;
 
 exports[`cqn2sql WHERE with contains with one column in where clause 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE ifnull(instr((Foo.b),?),0)",
-  "values": [
-    "5",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE ifnull(instr((Foo.b),'5'),0)",
+  "values": [],
 }
 `;
 
 exports[`cqn2sql WHERE with list of values 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.a,Foo.b,1) = (Foo.c,?,Foo.x)",
-  "values": [
-    "d",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.a,Foo.b,1) = (Foo.c,'d',Foo.x)",
+  "values": [],
 }
 `;
 
@@ -76,12 +72,8 @@ exports[`cqn2sql complex combinations AS, sub query 1`] = `"SELECT Foo.a,Foo.b a
 
 exports[`cqn2sql complex combinations Exists in object mode in complex where 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id is not ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name is not ?) )",
-  "values": [
-    "123",
-    "",
-    "",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = '123' and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id is not '') or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name is not '') )",
+  "values": [],
 }
 `;
 
@@ -89,10 +81,8 @@ exports[`cqn2sql complex combinations WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, 
 
 exports[`cqn2sql functions new notation in filter with 1 arg new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.c) = ?",
-  "values": [
-    "name",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.c) = 'name'",
+  "values": [],
 }
 `;
 
@@ -100,11 +90,8 @@ exports[`cqn2sql functions new notation in filter with 2 arg new notation 1`] = 
 
 exports[`cqn2sql functions new notation in filter with 3 arg new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c = ?||Foo.a||?",
-  "values": [
-    "Existing",
-    "!",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c = 'Existing'||Foo.a||'!'",
+  "values": [],
 }
 `;
 
@@ -112,11 +99,8 @@ exports[`cqn2sql functions new notation in filter with asterisk as arg new notat
 
 exports[`cqn2sql functions new notation in filter with nested functions new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.a) = lower(upper(trim(?))) and length(trim(?)) = Foo.b",
-  "values": [
-    "   existing name  ",
-    "  name",
-  ],
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.a) = lower(upper(trim('   existing name  '))) and length(trim('  name')) = Foo.b",
+  "values": [],
 }
 `;
 
@@ -130,10 +114,8 @@ exports[`cqn2sql quoted column aliases select with subselect in exists and colum
 
 exports[`cqn2sql quoted column aliases select with subselect with in and column aliases 1`] = `
 {
-  "sql": "SELECT Foo.a as A,? as ABC,Foo.x + 1 as Xpr1 FROM Foo as Foo WHERE ( Foo.x + 1 ) < 9 AND Foo.x IN (SELECT Foo.a as B,Foo.x - 4 as Xpr2 FROM Foo as Foo WHERE Foo.x < 9)",
-  "values": [
-    "abc",
-  ],
+  "sql": "SELECT Foo.a as A,'abc' as ABC,Foo.x + 1 as Xpr1 FROM Foo as Foo WHERE ( Foo.x + 1 ) < 9 AND Foo.x IN (SELECT Foo.a as B,Foo.x - 4 as Xpr2 FROM Foo as Foo WHERE Foo.x < 9)",
+  "values": [],
 }
 `;
 

--- a/db-service/test/cqn2sql/__snapshots__/update.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/update.test.js.snap
@@ -9,46 +9,36 @@ exports[`.update data alone still works 1`] = `
 
 exports[`.update set enhances data 1`] = `
 {
-  "sql": "UPDATE Foo2 AS Foo2 SET a=2,ID=1,name=?",
-  "values": [
-    "'asd'",
-  ],
+  "sql": "UPDATE Foo2 AS Foo2 SET a=2,ID=1,name='''asd'''",
+  "values": [],
 }
 `;
 
 exports[`.update set overwrites data 1`] = `
 {
-  "sql": "UPDATE Foo2 AS Foo2 SET a=2,ID=1,name=?,a=6",
-  "values": [
-    "'asd'",
-  ],
+  "sql": "UPDATE Foo2 AS Foo2 SET a=2,ID=1,name='''asd''',a=6",
+  "values": [],
 }
 `;
 
 exports[`.update test with entity and values with operators 1`] = `
 {
-  "sql": "UPDATE Foo2 AS Foo2 SET ID=42,name=?,a=Foo2.a - 1",
-  "values": [
-    "'asd'",
-  ],
+  "sql": "UPDATE Foo2 AS Foo2 SET ID=42,name='''asd''',a=Foo2.a - 1",
+  "values": [],
 }
 `;
 
 exports[`.update test with entity of type string 1`] = `
 {
-  "sql": "UPDATE Foo2 AS Foo2 SET ID=1,name=?,a=2",
-  "values": [
-    "'asd'",
-  ],
+  "sql": "UPDATE Foo2 AS Foo2 SET ID=1,name='''asd''',a=2",
+  "values": [],
 }
 `;
 
 exports[`.update test with entity of type string and where clause 1`] = `
 {
-  "sql": "UPDATE Foo2 AS Foo2 SET ID=1,name=?,a=2 WHERE Foo2.a < 9",
-  "values": [
-    "'asd'",
-  ],
+  "sql": "UPDATE Foo2 AS Foo2 SET ID=1,name='''asd''',a=2 WHERE Foo2.a < 9",
+  "values": [],
 }
 `;
 
@@ -68,10 +58,8 @@ exports[`.update test with subselect - sflight example 1`] = `
 
 exports[`.update virtual and non-existing fields filtered out from with 1`] = `
 {
-  "sql": "UPDATE Foo2 AS Foo2 SET ID=1,name=?",
-  "values": [
-    "'asd'",
-  ],
+  "sql": "UPDATE Foo2 AS Foo2 SET ID=1,name='''asd'''",
+  "values": [],
 }
 `;
 

--- a/db-service/test/cqn2sql/function.test.js
+++ b/db-service/test/cqn2sql/function.test.js
@@ -82,8 +82,8 @@ describe('function', () => {
     }
     const { sql, values } = cqn2sql(cqn)
     expect({ sql, values }).toEqual({
-      sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE not ifnull(instr((Foo.b),?),0)',
-      values: ['5'],
+      sql: `SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE not ifnull(instr((Foo.b),'5'),0)`,
+      values: [],
     })
   })
 

--- a/postgres/lib/func.js
+++ b/postgres/lib/func.js
@@ -1,4 +1,14 @@
+const session = require('./session.json')
+const sessionVariableMap = {}
+Object.keys(session).forEach(k => {
+  sessionVariableMap[`'${k}'`] = `'${session[k]}'`
+})
+
 const StandardFunctions = {
+  session_context: x => {
+    return `current_setting(${sessionVariableMap[x] || x})`
+  },
+
   countdistinct: x => `count(distinct ${x || '*'})`,
   contains: (...args) => `(coalesce(strpos(${args}),0) > 0)`,
   indexof: (x, y) => `strpos(${x},${y}) - 1`, // sqlite instr is 1 indexed

--- a/postgres/lib/session.json
+++ b/postgres/lib/session.json
@@ -1,0 +1,7 @@
+{
+  "$user.id": "CAP.APPLICATIONUSER",
+  "$user.locale": "CAP.LOCALE",
+  "$user.now": "CAP.NOW",
+  "$valid.from": "CAP.VALID_FROM",
+  "$valid.to": "CAP.VALID_TO"
+}

--- a/postgres/lib/session.json
+++ b/postgres/lib/session.json
@@ -1,7 +1,7 @@
 {
-  "$user.id": "CAP.APPLICATIONUSER",
-  "$user.locale": "CAP.LOCALE",
-  "$user.now": "CAP.NOW",
-  "$valid.from": "CAP.VALID_FROM",
-  "$valid.to": "CAP.VALID_TO"
+  "$user.id": "cap.applicationuser",
+  "$user.locale": "cap.locale",
+  "$user.now": "cap.now",
+  "$valid.from": "cap.valid_from",
+  "$valid.to": "cap.valid_to"
 }


### PR DESCRIPTION
## Description

Deploying views takes time. So this PR solves that problem. By not deploying the views.

By not relying on the views it is possible to:

- Use rolling app deployments 
  - (e.g. two versions of the same app using the same persistence)
- Skip deployment when only views are changed
  - (or do schema evolution on tables)
- Host multiple different models in the same app 
  - (e.g. canary tenants)
- Flatten projections
  - (e.g. rename all columns only once)
- Optimize joins away
  - (e.g. SFlight with 7 layers of joins while a single column is selected)
- Cache query optimization in the app layer
  - (removing/reducing execution plan processing times)
- Define more views
