### PR TITLE
fix: column count limitation in Postgres Service

### DIFF
--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -268,19 +268,24 @@ GROUP BY k
       const queryAlias = this.quote(SELECT.from?.as || (SELECT.expand === 'root' && 'root'))
       const cols = SELECT.columns.map(x => {
         const name = this.column_name(x)
-        let col = `${this.string(name)},${this.output_converter4(x.element, queryAlias + '.' + this.quote(name))}`
+        const outputConverter = this.output_converter4(x.element, `${queryAlias}.${this.quote(name)}`)
+        let col = `${outputConverter} as ${this.doubleQuote(name)}`
 
         if (x.SELECT?.count) {
           // Return both the sub select and the count for @odata.count
           const qc = cds.ql.clone(x, { columns: [{ func: 'count' }], one: 1, limit: 0, orderBy: 0 })
-          col += `, '${name}@odata.count',${this.expr(qc)}`
+          col += `,${this.expr(qc)} as ${this.doubleQuote(`${name}@odata.count`)}`
         }
         return col
       })
-      let obj = `json_build_object(${cols})`
+      let obj = `row_to_json(${queryAlias}.*)`
       return `SELECT ${
         SELECT.one || SELECT.expand === 'root' ? obj : `coalesce(json_agg(${obj}),'[]'::json)`
-      } as _json_ FROM (${sql}) as ${queryAlias}`
+      } as _json_ FROM (SELECT ${cols} FROM (${sql}) as ${queryAlias}) as ${queryAlias}`
+    }
+
+    doubleQuote(name) {
+      return `"${name.replace(/"/g, '""')}"`
     }
 
     INSERT(q, isUpsert = false) {


### PR DESCRIPTION
## Description

In the original implementation `json_build_object` was used to create the json objects. This function requires key value pairs as arguments to create the json object. This has the benefit that the property names are strings, but comes with the limitation that it is a function call with a maximum of 100 arguments.

This fix switches to using `row_to_json` as this function call only has a single parameter it should not be limited by the arguments limit. It is required to add a sub select to ensure that the property names are correct. As by default the column aliases are minimized to only alias when needed and only quote the alias when needed. This would result in property names being most of the time lower cased, but CAP is case sensitive which means that all columns require quoted aliases. To keep this change simple this is done in an additional sub select. 

## Example query

before

```sql
SELECT json_build_object('ID', Books.ID, 'title', Books.title) as _json_ from (
  SELECT ID, title FROM Books
) as Books
```

after

```sql
SELECT row_to_json(Books.*) as _json_ from (
  SELECT
    Books.ID as "ID",
    Books.title as "title"
  FROM (
    SELECT ID, title FROM Books
  ) as Books
) as Books
```

## Optimizations

It would be possible to optimize the query size by adjusting `SELECT_columns` and force quote all columns and inject the count columns when the query is an expand query.

## Related

reported issue: https://github.com/cap-js/cds-dbs/issues/139