### PR TITLE
feat: Reduce distinct from usage - part 1

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -701,9 +701,10 @@ class CQN2SQLRenderer {
    * @returns {string} The correct operator string
    */
   operator(x, i, xpr) {
-    if (x === '=') return this.operator_has_null(i, xpr) ? 'is' : '='
-    if (x === '!=') return this.operator_has_null(i, xpr) ? 'is not' : '!='
-    else return x
+    // Convert into ANSI SQL NULL operators
+    if (x === '=' && xpr[i + 1]?.val === null) return 'is'
+    if (x === '!=' && xpr[i + 1]?.val === null) return 'is not'
+    return x
   }
 
   /**
@@ -726,9 +727,9 @@ class CQN2SQLRenderer {
     // Also catches when the val is null
     if (!left || !right) return true
 
-    left = left.key || left.notNull || left != null
-    right = right.key || right.notNull || left != null
-    return left && right
+    left = !(left.key || left.notNull)
+    right = !(right.key || right.notNull)
+    return left || right
   }
 
   /**

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -701,8 +701,8 @@ class CQN2SQLRenderer {
     return x
     function _not_null(operand) {
       if (!operand) return
-      operand = operand.element || operand.val
-      return operand?.key || operand?.notNull
+      const element = operand.element
+      return element?.key || element?.notNull || operand.val != null
     }
   }
 

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -695,9 +695,34 @@ class CQN2SQLRenderer {
    * @returns {string} The correct operator string
    */
   operator(x, i, xpr) {
-    if (x === '=' && xpr[i + 1]?.val === null) return 'is'
-    if (x === '!=') return 'is not'
+    if (x === '=') return this.operator_has_null(i, xpr) ? 'is' : '='
+    if (x === '!=') return this.operator_has_null(i, xpr) ? 'is not' : '!='
     else return x
+  }
+
+  /**
+   * Tests if the operator could contain a null value
+   * @param {Number} i Current index of the operator inside the xpr
+   * @param {import('./infer/cqn').predicate[]} xpr The parent xpr in which the operator is used
+   * @returns {boolean}
+   */
+  operator_has_null(i, xpr) {
+    let left = xpr[i - 1]
+    let right = xpr[i + 1]
+
+    // When there is no expression abort
+    if (!left || !right) return true
+
+    left = left.element || left.val
+    right = right.element || right.val
+
+    // When the type is not known abort
+    // Also catches when the val is null
+    if (!left || !right) return true
+
+    left = left.key || left.notNull || left != null
+    right = right.key || right.notNull || left != null
+    return left && right
   }
 
   /**

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -696,36 +696,18 @@ class CQN2SQLRenderer {
    * @returns {string} The correct operator string
    */
   operator(x, i, xpr) {
-    // Convert into ANSI SQL NULL operators
-    if (x === '=' && xpr[i + 1]?.val === null) return 'is'
-    if (x === '!=' && xpr[i + 1]?.val === null) return 'is not'
+    if (x === '=')  return xpr[i + 1]?.val === null ? 'is'     : _not_null(xpr[i-1]) && _not_null(xpr[i+1]) ? '='  : this.is_
+    if (x === '!=') return xpr[i + 1]?.val === null ? 'is not' : _not_null(xpr[i-1]) && _not_null(xpr[i+1]) ? '<>' : this.is_not_
     return x
+    function _not_null(operand) {
+      if (!operand) return
+      operand = operand.element || operand.val
+      return operand?.key || operand?.notNull
+    }
   }
 
-  /**
-   * Tests if the operator could contain a null value
-   * @param {Number} i Current index of the operator inside the xpr
-   * @param {import('./infer/cqn').predicate[]} xpr The parent xpr in which the operator is used
-   * @returns {boolean}
-   */
-  operator_has_null(i, xpr) {
-    let left = xpr[i - 1]
-    let right = xpr[i + 1]
-
-    // When there is no expression abort
-    if (!left || !right) return true
-
-    left = left.element || left.val
-    right = right.element || right.val
-
-    // When the type is not known abort
-    // Also catches when the val is null
-    if (!left || !right) return true
-
-    left = !(left.key || left.notNull)
-    right = !(right.key || right.notNull)
-    return left || right
-  }
+  get is_() { return 'is' }
+  get is_not_() { return 'is not' }
 
   /**
    * Renders an argument place holder into the SQL for prepared statements

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -702,10 +702,15 @@ class CQN2SQLRenderer {
     function _not_null(operand) {
       if (!operand) return false
       if (operand.val != null) return true // non-null values are not null
-      let element = operand.element
-      if (!element) return false
-      if (element.key) return true // primary keys usually should not be null
-      if (element.notNull) return true // not null elements cannot be null
+
+      // REVISIT: The below cannot be merged yet due to a glitch in cqn4sql
+      // which erroneously assigns the definition of Genre.ID as element to
+      // the column Genre.parent_ID, and the like
+      //
+      // let element = operand.element
+      // if (!element) return false
+      // if (element.key) return true // primary keys usually should not be null
+      // if (element.notNull) return true // not null elements cannot be null
     }
   }
 

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -700,9 +700,12 @@ class CQN2SQLRenderer {
     if (x === '!=') return xpr[i + 1]?.val === null ? 'is not' : _not_null(xpr[i-1]) && _not_null(xpr[i+1]) ? '<>' : this.is_not_
     return x
     function _not_null(operand) {
-      if (!operand) return
-      const element = operand.element
-      return element?.key || element?.notNull || operand.val != null
+      if (!operand) return false
+      if (operand.val != null) return true // non-null values are not null
+      let element = operand.element
+      if (!element) return false
+      if (element.key) return true // primary keys usually should not be null
+      if (element.notNull) return true // not null elements cannot be null
     }
   }
 

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -706,8 +706,9 @@ class CQN2SQLRenderer {
     }
   }
 
-  get is_() { return 'is' }
-  get is_not_() { return 'is not' }
+  // ANSI does not have IS and IS NOT as operators
+  get is_() { return '=' }
+  get is_not_() { return '!=' }
 
   /**
    * Renders an argument place holder into the SQL for prepared statements

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1251,6 +1251,8 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           let result = is_regexp(token?.val) ? token : copy(token) // REVISIT: too expensive! //
           if (token.ref) {
             const { definition } = token.$refLinks[token.$refLinks.length - 1]
+            // Add definition to result
+            setElementOnColumns(result, definition)
             if (isCalculatedOnRead(definition)) {
               const calculatedElement = resolveCalculatedElement(token, true, $baseLink)
               transformedTokenStream.push(calculatedElement)

--- a/db-service/test/cqn2sql/__snapshots__/delete.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/delete.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`delete test complex cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null or Books.author_version is not null ) and not exists (SELECT 1 as _exists FROM Author as Author left JOIN Books as parent ON parent.ID is Author.parent_ID WHERE Author.parent_ID is parent.code and parent.descr is Author.version)"`;
+exports[`delete test complex cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null or Books.author_version is not null ) and not exists (SELECT 1 as _exists FROM Author as Author left JOIN Books as parent ON parent.ID = Author.parent_ID WHERE Author.parent_ID = parent.code and parent.descr = Author.version)"`;
 
-exports[`delete test simple cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null ) and not exists (SELECT 1 as _exists FROM Author as Author WHERE Author.id is Author.parent_ID)"`;
+exports[`delete test simple cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null ) and not exists (SELECT 1 as _exists FROM Author as Author WHERE Author.id = Author.parent_ID)"`;
 
 exports[`delete test simple cascade delete for entity with 'not in' 1`] = `"DELETE FROM Foo as Foo WHERE Foo.x not in (SELECT Foo2.a FROM Foo2 as Foo2)"`;
 

--- a/db-service/test/cqn2sql/__snapshots__/delete.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/delete.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`delete test complex cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null or Books.author_version is not null ) and not exists (SELECT 1 as _exists FROM Author as Author left JOIN Books as parent ON parent.ID = Author.parent_ID WHERE Author.parent_ID = parent.code and parent.descr = Author.version)"`;
+exports[`delete test complex cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null or Books.author_version is not null ) and not exists (SELECT 1 as _exists FROM Author as Author left JOIN Books as parent ON parent.ID is Author.parent_ID WHERE Author.parent_ID is parent.code and parent.descr is Author.version)"`;
 
-exports[`delete test simple cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null ) and not exists (SELECT 1 as _exists FROM Author as Author WHERE Author.id = Author.parent_ID)"`;
+exports[`delete test simple cascade delete for entity with 'not exists' 1`] = `"DELETE FROM Books as Books WHERE ( Books.author_id is not null ) and not exists (SELECT 1 as _exists FROM Author as Author WHERE Author.id is Author.parent_ID)"`;
 
 exports[`delete test simple cascade delete for entity with 'not in' 1`] = `"DELETE FROM Foo as Foo WHERE Foo.x not in (SELECT Foo2.a FROM Foo2 as Foo2)"`;
 

--- a/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
@@ -74,7 +74,7 @@ exports[`cqn2sql complex combinations AS, sub query 1`] = `"SELECT Foo.a,Foo.b a
 
 exports[`cqn2sql complex combinations Exists in object mode in complex where 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id != ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name != ?) )",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id <> ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name != ?) )",
   "values": [
     "123",
     "",

--- a/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
@@ -12,7 +12,7 @@ exports[`cqn2sql ONE one results in limit 1 1`] = `"SELECT Foo.a,Foo.b,Foo.c FRO
 
 exports[`cqn2sql ORDER BY ORDER BY alias 1`] = `"SELECT Foo.a,Foo.b,count(Foo.x) as count1 FROM Foo as Foo ORDER BY count1 ASC"`;
 
-exports[`cqn2sql WHERE EXISTS with nested EXISTS 1`] = `"SELECT T2.ID,T2.a,T2.b,T2.c,T2.x FROM Foo as T2 WHERE exists (SELECT 1 FROM Books as T1 WHERE T1.ID is 1 and exists (SELECT 1 FROM Foo2 as T0 WHERE T0.ID is 11 and T1.ID is T0.a) and T2.ID is T1.ID)"`;
+exports[`cqn2sql WHERE EXISTS with nested EXISTS 1`] = `"SELECT T2.ID,T2.a,T2.b,T2.c,T2.x FROM Foo as T2 WHERE exists (SELECT 1 FROM Books as T1 WHERE T1.ID = 1 and exists (SELECT 1 FROM Foo2 as T0 WHERE T0.ID = 11 and T1.ID = T0.a) and T2.ID = T1.ID)"`;
 
 exports[`cqn2sql WHERE entries where one column holds entries smaller than 9 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x < 9"`;
 
@@ -20,14 +20,14 @@ exports[`cqn2sql WHERE entries where one column holds entries which are in list 
 
 exports[`cqn2sql WHERE entries where with int reference and param true 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is :7",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x = :7",
   "values": [],
 }
 `;
 
 exports[`cqn2sql WHERE entries where with place holder 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID is ?",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ?",
   "values": [],
 }
 `;
@@ -36,11 +36,11 @@ exports[`cqn2sql WHERE select with a nested select in a complex where 1`] = `"SE
 
 exports[`cqn2sql WHERE select with a nested select in where 1`] = `"SELECT Foo.a,Foo.b,Foo.c FROM Foo as Foo WHERE Foo.x IN (SELECT Foo.a FROM Foo as Foo WHERE Foo.x < 9)"`;
 
-exports[`cqn2sql WHERE where with partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x is 9)"`;
+exports[`cqn2sql WHERE where with partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x = 9)"`;
 
-exports[`cqn2sql WHERE where with two partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x + 9) is 9"`;
+exports[`cqn2sql WHERE where with two partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x + 9) = 9"`;
 
-exports[`cqn2sql WHERE with contains with multiple arguments 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.a is 0 and ifnull(instr((Foo.a,Foo.b,Foo.c,Foo.x),?),0)"`;
+exports[`cqn2sql WHERE with contains with multiple arguments 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.a = 0 and ifnull(instr((Foo.a,Foo.b,Foo.c,Foo.x),?),0)"`;
 
 exports[`cqn2sql WHERE with contains with one column in where clause 1`] = `
 {
@@ -53,7 +53,7 @@ exports[`cqn2sql WHERE with contains with one column in where clause 1`] = `
 
 exports[`cqn2sql WHERE with list of values 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.a,Foo.b,1) is (Foo.c,?,Foo.x)",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.a,Foo.b,1) = (Foo.c,?,Foo.x)",
   "values": [
     "d",
   ],
@@ -74,7 +74,7 @@ exports[`cqn2sql complex combinations AS, sub query 1`] = `"SELECT Foo.a,Foo.b a
 
 exports[`cqn2sql complex combinations Exists in object mode in complex where 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID is ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id is not ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name is not ?) )",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id != ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name != ?) )",
   "values": [
     "123",
     "",
@@ -83,22 +83,22 @@ exports[`cqn2sql complex combinations Exists in object mode in complex where 1`]
 }
 `;
 
-exports[`cqn2sql complex combinations WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET 1`] = `"SELECT Foo.x + 1 as foo1,Foo.b,Foo.c FROM Foo as Foo WHERE Foo.ID is 111 GROUP BY Foo.x HAVING Foo.x < 9 ORDER BY c ASC LIMIT 11 OFFSET 22"`;
+exports[`cqn2sql complex combinations WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET 1`] = `"SELECT Foo.x + 1 as foo1,Foo.b,Foo.c FROM Foo as Foo WHERE Foo.ID = 111 GROUP BY Foo.x HAVING Foo.x < 9 ORDER BY c ASC LIMIT 11 OFFSET 22"`;
 
 exports[`cqn2sql functions new notation in filter with 1 arg new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.c) is ?",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.c) = ?",
   "values": [
     "name",
   ],
 }
 `;
 
-exports[`cqn2sql functions new notation in filter with 2 arg new notation 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c is Foo.a||Foo.b"`;
+exports[`cqn2sql functions new notation in filter with 2 arg new notation 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c = Foo.a||Foo.b"`;
 
 exports[`cqn2sql functions new notation in filter with 3 arg new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c is ?||Foo.a||?",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c = ?||Foo.a||?",
   "values": [
     "Existing",
     "!",
@@ -110,7 +110,7 @@ exports[`cqn2sql functions new notation in filter with asterisk as arg new notat
 
 exports[`cqn2sql functions new notation in filter with nested functions new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.a) is lower(upper(trim(?))) and length(trim(?)) is Foo.b",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.a) = lower(upper(trim(?))) and length(trim(?)) = Foo.b",
   "values": [
     "   existing name  ",
     "  name",
@@ -118,13 +118,13 @@ exports[`cqn2sql functions new notation in filter with nested functions new nota
 }
 `;
 
-exports[`cqn2sql functions new notation in filter with subselect as function param 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID is any((SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.a is 1))"`;
+exports[`cqn2sql functions new notation in filter with subselect as function param 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = any((SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.a = 1))"`;
 
 exports[`cqn2sql functions new notation in orderby with 1 arg new notation 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo ORDER BY lower(Foo.c) DESC"`;
 
 exports[`cqn2sql quoted column aliases select with simple subselect and column aliases 1`] = `"SELECT Foo.a,Foo.b as B,1 as C,Foo.x + 2 as D,(SELECT Foo2.a,Foo2.b as B,false as False,Foo2.x + 2 as Xpr FROM Foo as Foo2) as E FROM Foo as Foo"`;
 
-exports[`cqn2sql quoted column aliases select with subselect in exists and column aliases 1`] = `"SELECT T2.id,T2.version,T2.parent_ID FROM Author as T2 WHERE exists (SELECT 1 as One,T1.code as Xpr1 FROM Books as T1 WHERE T1.ID is 1 and exists (SELECT 3 as Three,T0.x + 1 as Xpr2 FROM Foo as T0 WHERE T0.ID is 11 and T1.ID is T0.b))"`;
+exports[`cqn2sql quoted column aliases select with subselect in exists and column aliases 1`] = `"SELECT T2.id,T2.version,T2.parent_ID FROM Author as T2 WHERE exists (SELECT 1 as One,T1.code as Xpr1 FROM Books as T1 WHERE T1.ID = 1 and exists (SELECT 3 as Three,T0.x + 1 as Xpr2 FROM Foo as T0 WHERE T0.ID = 11 and T1.ID = T0.b))"`;
 
 exports[`cqn2sql quoted column aliases select with subselect with in and column aliases 1`] = `
 {

--- a/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
@@ -74,7 +74,7 @@ exports[`cqn2sql complex combinations AS, sub query 1`] = `"SELECT Foo.a,Foo.b a
 
 exports[`cqn2sql complex combinations Exists in object mode in complex where 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id <> ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name != ?) )",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id != ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name != ?) )",
   "values": [
     "123",
     "",

--- a/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
@@ -12,7 +12,7 @@ exports[`cqn2sql ONE one results in limit 1 1`] = `"SELECT Foo.a,Foo.b,Foo.c FRO
 
 exports[`cqn2sql ORDER BY ORDER BY alias 1`] = `"SELECT Foo.a,Foo.b,count(Foo.x) as count1 FROM Foo as Foo ORDER BY count1 ASC"`;
 
-exports[`cqn2sql WHERE EXISTS with nested EXISTS 1`] = `"SELECT T2.ID,T2.a,T2.b,T2.c,T2.x FROM Foo as T2 WHERE exists (SELECT 1 FROM Books as T1 WHERE T1.ID = 1 and exists (SELECT 1 FROM Foo2 as T0 WHERE T0.ID = 11 and T1.ID = T0.a) and T2.ID = T1.ID)"`;
+exports[`cqn2sql WHERE EXISTS with nested EXISTS 1`] = `"SELECT T2.ID,T2.a,T2.b,T2.c,T2.x FROM Foo as T2 WHERE exists (SELECT 1 FROM Books as T1 WHERE T1.ID is 1 and exists (SELECT 1 FROM Foo2 as T0 WHERE T0.ID is 11 and T1.ID is T0.a) and T2.ID is T1.ID)"`;
 
 exports[`cqn2sql WHERE entries where one column holds entries smaller than 9 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x < 9"`;
 
@@ -20,14 +20,14 @@ exports[`cqn2sql WHERE entries where one column holds entries which are in list 
 
 exports[`cqn2sql WHERE entries where with int reference and param true 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x = :7",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is :7",
   "values": [],
 }
 `;
 
 exports[`cqn2sql WHERE entries where with place holder 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ?",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID is ?",
   "values": [],
 }
 `;
@@ -36,11 +36,11 @@ exports[`cqn2sql WHERE select with a nested select in a complex where 1`] = `"SE
 
 exports[`cqn2sql WHERE select with a nested select in where 1`] = `"SELECT Foo.a,Foo.b,Foo.c FROM Foo as Foo WHERE Foo.x IN (SELECT Foo.a FROM Foo as Foo WHERE Foo.x < 9)"`;
 
-exports[`cqn2sql WHERE where with partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x = 9)"`;
+exports[`cqn2sql WHERE where with partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x is 9)"`;
 
-exports[`cqn2sql WHERE where with two partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x + 9) = 9"`;
+exports[`cqn2sql WHERE where with two partial cqn 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x + 9) is 9"`;
 
-exports[`cqn2sql WHERE with contains with multiple arguments 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.a = 0 and ifnull(instr((Foo.a,Foo.b,Foo.c,Foo.x),?),0)"`;
+exports[`cqn2sql WHERE with contains with multiple arguments 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.a is 0 and ifnull(instr((Foo.a,Foo.b,Foo.c,Foo.x),?),0)"`;
 
 exports[`cqn2sql WHERE with contains with one column in where clause 1`] = `
 {
@@ -53,7 +53,7 @@ exports[`cqn2sql WHERE with contains with one column in where clause 1`] = `
 
 exports[`cqn2sql WHERE with list of values 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.a,Foo.b,1) = (Foo.c,?,Foo.x)",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.a,Foo.b,1) is (Foo.c,?,Foo.x)",
   "values": [
     "d",
   ],
@@ -74,7 +74,7 @@ exports[`cqn2sql complex combinations AS, sub query 1`] = `"SELECT Foo.a,Foo.b a
 
 exports[`cqn2sql complex combinations Exists in object mode in complex where 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id is not ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name is not ?) )",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID is ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id is not ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name is not ?) )",
   "values": [
     "123",
     "",
@@ -83,22 +83,22 @@ exports[`cqn2sql complex combinations Exists in object mode in complex where 1`]
 }
 `;
 
-exports[`cqn2sql complex combinations WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET 1`] = `"SELECT Foo.x + 1 as foo1,Foo.b,Foo.c FROM Foo as Foo WHERE Foo.ID = 111 GROUP BY Foo.x HAVING Foo.x < 9 ORDER BY c ASC LIMIT 11 OFFSET 22"`;
+exports[`cqn2sql complex combinations WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET 1`] = `"SELECT Foo.x + 1 as foo1,Foo.b,Foo.c FROM Foo as Foo WHERE Foo.ID is 111 GROUP BY Foo.x HAVING Foo.x < 9 ORDER BY c ASC LIMIT 11 OFFSET 22"`;
 
 exports[`cqn2sql functions new notation in filter with 1 arg new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.c) = ?",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.c) is ?",
   "values": [
     "name",
   ],
 }
 `;
 
-exports[`cqn2sql functions new notation in filter with 2 arg new notation 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c = Foo.a||Foo.b"`;
+exports[`cqn2sql functions new notation in filter with 2 arg new notation 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c is Foo.a||Foo.b"`;
 
 exports[`cqn2sql functions new notation in filter with 3 arg new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c = ?||Foo.a||?",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.c is ?||Foo.a||?",
   "values": [
     "Existing",
     "!",
@@ -110,7 +110,7 @@ exports[`cqn2sql functions new notation in filter with asterisk as arg new notat
 
 exports[`cqn2sql functions new notation in filter with nested functions new notation 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.a) = lower(upper(trim(?))) and length(trim(?)) = Foo.b",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.a) is lower(upper(trim(?))) and length(trim(?)) is Foo.b",
   "values": [
     "   existing name  ",
     "  name",
@@ -118,13 +118,13 @@ exports[`cqn2sql functions new notation in filter with nested functions new nota
 }
 `;
 
-exports[`cqn2sql functions new notation in filter with subselect as function param 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = any((SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.a = 1))"`;
+exports[`cqn2sql functions new notation in filter with subselect as function param 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID is any((SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.a is 1))"`;
 
 exports[`cqn2sql functions new notation in orderby with 1 arg new notation 1`] = `"SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo ORDER BY lower(Foo.c) DESC"`;
 
 exports[`cqn2sql quoted column aliases select with simple subselect and column aliases 1`] = `"SELECT Foo.a,Foo.b as B,1 as C,Foo.x + 2 as D,(SELECT Foo2.a,Foo2.b as B,false as False,Foo2.x + 2 as Xpr FROM Foo as Foo2) as E FROM Foo as Foo"`;
 
-exports[`cqn2sql quoted column aliases select with subselect in exists and column aliases 1`] = `"SELECT T2.id,T2.version,T2.parent_ID FROM Author as T2 WHERE exists (SELECT 1 as One,T1.code as Xpr1 FROM Books as T1 WHERE T1.ID = 1 and exists (SELECT 3 as Three,T0.x + 1 as Xpr2 FROM Foo as T0 WHERE T0.ID = 11 and T1.ID = T0.b))"`;
+exports[`cqn2sql quoted column aliases select with subselect in exists and column aliases 1`] = `"SELECT T2.id,T2.version,T2.parent_ID FROM Author as T2 WHERE exists (SELECT 1 as One,T1.code as Xpr1 FROM Books as T1 WHERE T1.ID is 1 and exists (SELECT 3 as Three,T0.x + 1 as Xpr2 FROM Foo as T0 WHERE T0.ID is 11 and T1.ID is T0.b))"`;
 
 exports[`cqn2sql quoted column aliases select with subselect with in and column aliases 1`] = `
 {

--- a/db-service/test/cqn2sql/expression.test.js
+++ b/db-service/test/cqn2sql/expression.test.js
@@ -173,9 +173,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toEqual(
-      'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x != 5) or (Foo.x is NULL)',
-    )
+    expect(sql).toEqual('SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x != 5) or (Foo.x is NULL)')
   })
 
   test('ref is like pattern', () => {

--- a/db-service/test/cqn2sql/expression.test.js
+++ b/db-service/test/cqn2sql/expression.test.js
@@ -82,7 +82,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 != 6/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 <> 6/i)
   })
 
   test('ref != ref', () => {

--- a/db-service/test/cqn2sql/expression.test.js
+++ b/db-service/test/cqn2sql/expression.test.js
@@ -48,7 +48,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null = Foo.x/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null is Foo.x/i)
   })
 
   // We should never have supported that!
@@ -140,7 +140,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x = 7 or Foo.x is not 5/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is 7 or Foo.x is not 5/i)
   })
 
   // We don't have to support that

--- a/db-service/test/cqn2sql/expression.test.js
+++ b/db-service/test/cqn2sql/expression.test.js
@@ -48,7 +48,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null is Foo.x/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null = Foo.x/i)
   })
 
   // We should never have supported that!
@@ -82,7 +82,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 is not 6/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 != 6/i)
   })
 
   test('ref != ref', () => {
@@ -93,7 +93,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is not Foo.a/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x != Foo.a/i)
     // Note: test before was that, which is wrong:
     // sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x != Foo.a',
   })
@@ -107,7 +107,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null IS NOT Foo.x/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null != Foo.x/i)
   })
 
   test('ref != 5', () => {
@@ -118,7 +118,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is not 5/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x != 5/i)
   })
 
   test('ref <> 5', () => {
@@ -140,7 +140,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is 7 or Foo.x is not 5/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x = 7 or Foo.x != 5/i)
   })
 
   // We don't have to support that
@@ -153,7 +153,7 @@ describe('expressions', () => {
     }
     const { sql, values } = cqn2sql(cqn)
     expect({ sql, values }).toEqual({
-      sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 is not Foo.x',
+      sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 != Foo.x',
       values: [],
     })
   })
@@ -174,7 +174,7 @@ describe('expressions', () => {
     }
     const { sql } = cqn2sql(cqn)
     expect(sql).toEqual(
-      'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x is not 5) or (Foo.x is NULL)',
+      'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x != 5) or (Foo.x is NULL)',
     )
   })
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,16 @@
 const pipeline = !!process.env.CI
 
-exports.transform = {} // Fixes debugging
+// Add github-actions reporter in pipelines
+if (pipeline) exports.reporters = [ 'default', 'github-actions' ]
 
 // Ignore inherited tests that encounter tuple errors
-if (!pipeline)
-  exports.testPathIgnorePatterns = [
-    '<rootDir>/postgres/test/timezone.test.js',
-    '<rootDir>/postgres/test/service.test.js',
-    '<rootDir>/postgres/test/service-types.test.js',
-    '<rootDir>/postgres/test/service-admin.test.js',
-    '<rootDir>/postgres/test/odata-string-functions.test.js',
-  ]
-if (pipeline) exports.reporters = ['github-actions', 'summary']
+if (!pipeline) exports.testPathIgnorePatterns = [
+  '<rootDir>/postgres/test/timezone.test.js',
+  '<rootDir>/postgres/test/service.test.js',
+  '<rootDir>/postgres/test/service-types.test.js',
+  '<rootDir>/postgres/test/service-admin.test.js',
+  '<rootDir>/postgres/test/odata-string-functions.test.js',
+]
+
+// Fix debugging
+exports.transform = {}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "express": "^4"
   },
   "scripts": {
-    "test": "npm run setup && CDS_JEST_MEM_FIX=1 npx jest --silent --colors",
-    "setup": "cd postgres && npm run setup",
+    "test": "npm start -w postgres && CDS_JEST_MEM_FIX=1 npx jest --silent --colors",
     "lint": "npx eslint ."
   },
   "license": "SEE LICENSE"

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -290,11 +290,11 @@ GROUP BY k
       return ret === '?' ? `$${this.values.length}` : ret
     }
 
-    operator(x) {
+    operator(x, i, xpr, q) {
       if (x === 'regexp') return '~'
-      if (x === '=') return 'is not distinct from'
-      if (x === '!=') return 'is distinct from'
-      else return x
+      if (x === '=') return this.operator_has_null(i, xpr) ? 'is not distinct from' : '='
+      if (x === '!=') return this.operator_has_null(i, xpr) ? 'is distinct from' : '!='
+      return x
     }
 
     defaultValue(defaultValue = this.context.timestamp.toISOString()) {

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -290,7 +290,7 @@ GROUP BY k
       return ret === '?' ? `$${this.values.length}` : ret
     }
 
-    operator(x, i, xpr, q) {
+    operator(x, i, xpr) {
       if (x === 'regexp') return '~'
       if (x === '=') return this.operator_has_null(i, xpr) ? 'is not distinct from' : '='
       if (x === '!=') return this.operator_has_null(i, xpr) ? 'is distinct from' : '!='

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -291,7 +291,10 @@ GROUP BY k
     }
 
     operator(x, i, xpr) {
+      let y = super.operator(x, i, xpr)
+      if (y !== x) return y
       if (x === 'regexp') return '~'
+      // Convert into Postgres NULL compliant operators
       if (x === '=') return this.operator_has_null(i, xpr) ? 'is not distinct from' : '='
       if (x === '!=') return this.operator_has_null(i, xpr) ? 'is distinct from' : '!='
       return x

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -302,11 +302,10 @@ GROUP BY k
       let y = super.operator(x, i, xpr)
       if (y !== x) return y
       if (x === 'regexp') return '~'
-      // Convert into Postgres NULL compliant operators
-      if (x === '=') return this.operator_has_null(i, xpr) ? 'is not distinct from' : '='
-      if (x === '!=') return this.operator_has_null(i, xpr) ? 'is distinct from' : '!='
-      return x
     }
+
+    get is_() { return 'is not distinct from' }
+    get is_not_() { return 'is distinct from' }
 
     defaultValue(defaultValue = this.context.timestamp.toISOString()) {
       return this.string(`${defaultValue}`)

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -299,9 +299,8 @@ GROUP BY k
     }
 
     operator(x, i, xpr) {
-      let y = super.operator(x, i, xpr)
-      if (y !== x) return y
       if (x === 'regexp') return '~'
+      else return super.operator(x, i, xpr)
     }
 
     get is_() { return 'is not distinct from' }

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -27,7 +27,7 @@
     "npm": ">=8"
   },
   "scripts": {
-    "setup": "docker-compose -f pg-stack.yml up -d"
+    "start": "docker-compose -f pg-stack.yml up -d"
   },
   "dependencies": {
     "@cap-js/db-service": "^1.1.0",

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -142,9 +142,12 @@ class SQLiteService extends SQLService {
     }
 
     operator(x, i, xpr) {
-      if (x === '=' && xpr[i + 1]?.val === null) return 'is'
-      if (x === '!=') return 'is not'
-      else return x
+      let y = super.operator(x, i, xpr)
+      if (y !== x) return y
+      // Convert into SQLite NULL compliant operators
+      if (x === '=') return this.operator_has_null(i, xpr) ? 'IS' : '='
+      if (x === '!=') return this.operator_has_null(i, xpr) ? 'IS NOT' : '!='
+      return x
     }
 
     // Used for INSERT statements

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -124,6 +124,7 @@ class SQLiteService extends SQLService {
   }
 
   static CQN2SQL = class CQN2SQLite extends SQLService.CQN2SQL {
+
     column_alias4(x, q) {
       let alias = super.column_alias4(x, q)
       if (alias) return alias
@@ -137,15 +138,6 @@ class SQLiteService extends SQLService {
         }
         return obm[x.ref.at(-1)]
       }
-    }
-
-    operator(x, i, xpr) {
-      let y = super.operator(x, i, xpr)
-      if (y !== x) return y
-      // Convert into SQLite NULL compliant operators
-      if (x === '=') return this.operator_has_null(i, xpr) ? 'IS' : '='
-      if (x === '!=') return this.operator_has_null(i, xpr) ? 'IS NOT' : '!='
-      return x
     }
 
     // Used for INSERT statements

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -207,6 +207,9 @@ class SQLiteService extends SQLService {
       Timestamp: () => 'TIMESTAMP_TEXT',
     }
 
+    get is_() { return 'is' }
+    get is_not_() { return 'is not' }
+
     static ReservedWords = { ...super.ReservedWords, ...require('./ReservedWords.json') }
   }
 


### PR DESCRIPTION
## Description

When using the `=` and `!=` cqn operator it should consider `NULL` as equal to `NULL`. Which means that for `SQL` it is required to use other operators then `=` and `!=`. For SQLite it is `IS` and `IS NOT`. For Postgres it is `is not distinct from` and `is distinct from`. Which in certain cases does not apply optimizations that `=` and `!=` have on the database.

With this change it is checked that both sides of the operation cannot contain `NULL` as result. Which allows for the usage of `=` and `!=`. This will mostly only be true when doing simple expressions like `... WHERE ID = 201`. For anything more complex like `... WHERE ID = (200 + 1)` it won't be capable of guaranteeing that both side will never be `NULL`.

> Why do both sides have to not be `NULL`

When an `=` or `!=` operator encounter a `NULL` on either side it will return `NULL`. This can cascade to any further operators.

```SQL
SELECT * FROM Books WHERE NOT(Books.ID = NULL) -- Books.ID = NULL -> NULL -> NOT(NULL) -> NULL -> false
SELECT * FROM Books WHERE NOT(Books.ID IS NULL) -- Books.ID IS NULL -> false -> NOT(false) -> true
```

## Issues

Reported by: https://github.com/cap-js/cds-dbs/issues/156