### PR TITLE
[IMPORTANT:] Using is distinct from only

### DIFF
--- a/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
@@ -74,7 +74,7 @@ exports[`cqn2sql complex combinations AS, sub query 1`] = `"SELECT Foo.a,Foo.b a
 
 exports[`cqn2sql complex combinations Exists in object mode in complex where 1`] = `
 {
-  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id != ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name != ?) )",
+  "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.ID = ? and ( exists (SELECT Author.id FROM Author as Author WHERE Author.id is distinct from ?) or exists (SELECT Foo2.ID FROM Foo2 as Foo2 WHERE Foo2.name is distinct from ?) )",
   "values": [
     "123",
     "",

--- a/db-service/test/cqn2sql/expression.test.js
+++ b/db-service/test/cqn2sql/expression.test.js
@@ -93,7 +93,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x != Foo.a/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is distinct from Foo.a/i)
     // Note: test before was that, which is wrong:
     // sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x != Foo.a',
   })
@@ -107,7 +107,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null != Foo.x/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE null is distinct from Foo.x/i)
   })
 
   test('ref != 5', () => {
@@ -118,7 +118,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x != 5/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x is distinct from 5/i)
   })
 
   test('ref <> 5', () => {
@@ -140,7 +140,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x = 7 or Foo.x != 5/i)
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x = 7 or Foo.x is distinct from 5/i)
   })
 
   // We don't have to support that
@@ -153,7 +153,7 @@ describe('expressions', () => {
     }
     const { sql, values } = cqn2sql(cqn)
     expect({ sql, values }).toEqual({
-      sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 != Foo.x',
+      sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE 5 is distinct from Foo.x',
       values: [],
     })
   })
@@ -173,7 +173,7 @@ describe('expressions', () => {
       },
     }
     const { sql } = cqn2sql(cqn)
-    expect(sql).toEqual('SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x != 5) or (Foo.x is NULL)')
+    expect(sql).toEqual('SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x is distinct from 5) or (Foo.x is NULL)')
   })
 
   test('ref is like pattern', () => {

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -303,8 +303,7 @@ GROUP BY k
       else return super.operator(x, i, xpr)
     }
 
-    get is_() { return 'is not distinct from' }
-    get is_not_() { return 'is distinct from' }
+    get is_distinct_from_() { return 'is distinct from' }
 
     defaultValue(defaultValue = this.context.timestamp.toISOString()) {
       return this.string(`${defaultValue}`)

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -303,8 +303,6 @@ GROUP BY k
       else return super.operator(x, i, xpr)
     }
 
-    get is_distinct_from_() { return 'is distinct from' }
-
     defaultValue(defaultValue = this.context.timestamp.toISOString()) {
       return this.string(`${defaultValue}`)
     }

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -208,6 +208,7 @@ class SQLiteService extends SQLService {
     }
 
     get is_distinct_from_() { return 'is not' }
+    get is_not_distinct_from_() { return 'is' }
 
     static ReservedWords = { ...super.ReservedWords, ...require('./ReservedWords.json') }
   }

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -207,8 +207,7 @@ class SQLiteService extends SQLService {
       Timestamp: () => 'TIMESTAMP_TEXT',
     }
 
-    get is_() { return 'is' }
-    get is_not_() { return 'is not' }
+    get is_distinct_from_() { return 'is not' }
 
     static ReservedWords = { ...super.ReservedWords, ...require('./ReservedWords.json') }
   }


### PR DESCRIPTION
@BobdenOs : this is reverting the symmetric support for IS and IS NOT. 

When I saw that very many ON conditions got translated to the like of `WHERE author_ID IS Authors.ID`, I recalled why I didn't have this symmetry in the initial implementation. → the comment in changed files.

Fixes #156 
Replaces #157