### PR TITLE
cqn4sql: attach adjacent fk adjacent to assoc as element of column

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1072,7 +1072,10 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           else flatColumn = { ref: [fkBaseName] }
           if (tableAlias) flatColumn.ref.unshift(tableAlias)
 
-          setElementOnColumns(flatColumn, fkElement)
+          // in a flat model, we must assign the foreign key rather than the key in the target
+          const flatForeignKey = model.definitions[element.parent.name]?.elements[fkBaseName]
+
+          setElementOnColumns(flatColumn, flatForeignKey || fkElement)
           Object.defineProperty(flatColumn, '_csnPath', { value: csnPath, writable: true })
           flatColumns.push(flatColumn)
         }

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -662,7 +662,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
         const colWithBase = baseColumn
           ? { ref: [...baseColumn.ref, ...column.ref], $refLinks: [...baseColumn.$refLinks, ...column.$refLinks] }
           : column
-        if (isColumnJoinRelevant(colWithBase, $baseLink)) {
+        if (isColumnJoinRelevant(colWithBase)) {
           if (originalQuery.UPDATE)
             throw cds.error(
               'Path expressions for UPDATE statements are not supported. Use “where exists” with infix filters instead.',

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -880,7 +880,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
      * @param {object} column the column with the `ref` to check for join relevance
      * @returns {boolean} true if the column ref needs to be merged into a join tree
      */
-    function isColumnJoinRelevant(column, baseLink) {
+    function isColumnJoinRelevant(column) {
       let fkAccess = false
       let assoc = null
       for (let i = 0; i < column.ref.length; i++) {

--- a/db-service/test/cqn4sql/column.element.test.js
+++ b/db-service/test/cqn4sql/column.element.test.js
@@ -107,7 +107,7 @@ describe('assign element onto columns with flat model', () => {
     `
     const { Authors } = model.entities
     expect(JSON.parse(JSON.stringify(query))).to.deep.eql(expected)
-    // foreign key is part of flat model
+
     expect(query.SELECT.columns[1].SELECT.columns[0]).to.have.property('element').that.eqls(Authors.elements.ID)
   })
 

--- a/db-service/test/cqn4sql/column.element.test.js
+++ b/db-service/test/cqn4sql/column.element.test.js
@@ -63,3 +63,75 @@ describe('assign element onto columns', () => {
     expect(query.SELECT.columns[3]).to.have.property('element').that.is.an.instanceof(cds.type) // has cds.String information through cast
   })
 })
+
+describe('assign element onto columns with flat model', () => {
+  let model
+  beforeAll(async () => {
+    model = cds.model = await cds.load('db/schema').then(cds.linked)
+    model = cds.compile.for.nodejs(model)
+  })
+
+  it('foreign key is adjacent to its association in flat model', () => {
+    let query = cqn4sql(CQL`
+      SELECT from bookshop.Books {
+        ID,
+        author
+      }
+    `, model)
+    const expected = CQL`SELECT from bookshop.Books as Books {
+        Books.ID,
+        Books.author_ID
+    }
+    `
+    const { Books } = model.entities
+    expect(query).to.deep.eql(expected)
+    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(Books.elements['ID'])
+    // foreign key part is part of flat model
+    expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(Books.elements.author_ID)
+  })
+
+  it('foreign key is adjacent to its association in flat model with multiple foreign keys', () => {
+    let query = cqn4sql(CQL`
+      SELECT from bookshop.AssocWithStructuredKey {
+        ID,
+        toStructuredKey
+      }
+    `, model)
+    const expected = CQL`SELECT from bookshop.AssocWithStructuredKey as AssocWithStructuredKey {
+        AssocWithStructuredKey.ID,
+        AssocWithStructuredKey.toStructuredKey_struct_mid_leaf,
+        AssocWithStructuredKey.toStructuredKey_struct_mid_anotherLeaf,
+
+        AssocWithStructuredKey.toStructuredKey_second
+    }
+    `
+    const { AssocWithStructuredKey } = model.entities
+    expect(query).to.deep.eql(expected)
+    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements['ID'])
+    // foreign key part is part of flat model
+    expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements.toStructuredKey_struct_mid_leaf)
+    expect(query.SELECT.columns[2]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements.toStructuredKey_struct_mid_anotherLeaf)
+    expect(query.SELECT.columns[3]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements.toStructuredKey_second)
+  })
+
+  it('foreign key is adjacent to its association in flat model and is renamed', () => {
+    let query = cqn4sql(CQL`
+      SELECT from bookshop.TestPublisher {
+        ID,
+        publisherRenamedKey
+      }
+    `, model)
+    // structured key is renamed in model:
+    // --> `key publisherRenamedKey : Association to Publisher { structuredKey.ID as notID };`
+    const expected = CQL`SELECT from bookshop.TestPublisher as TestPublisher {
+        TestPublisher.ID,
+        TestPublisher.publisherRenamedKey_notID
+    }
+    `
+    const { TestPublisher } = model.entities
+    expect(query).to.deep.eql(expected)
+    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(TestPublisher.elements['ID'])
+    // foreign key part is part of flat model
+    expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(TestPublisher.elements.publisherRenamedKey_notID)
+  })
+})

--- a/db-service/test/cqn4sql/column.element.test.js
+++ b/db-service/test/cqn4sql/column.element.test.js
@@ -85,8 +85,8 @@ describe('assign element onto columns with flat model', () => {
     `
     const { Books } = model.entities
     expect(query).to.deep.eql(expected)
-    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(Books.elements['ID'])
-    // foreign key part is part of flat model
+    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(Books.elements.ID)
+    // foreign key is part of flat model
     expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(Books.elements.author_ID)
   })
 
@@ -107,10 +107,11 @@ describe('assign element onto columns with flat model', () => {
     `
     const { AssocWithStructuredKey } = model.entities
     expect(query).to.deep.eql(expected)
-    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements['ID'])
-    // foreign key part is part of flat model
+    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements.ID)
+    // foreign key is part of flat model
     expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements.toStructuredKey_struct_mid_leaf)
     expect(query.SELECT.columns[2]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements.toStructuredKey_struct_mid_anotherLeaf)
+
     expect(query.SELECT.columns[3]).to.have.property('element').that.eqls(AssocWithStructuredKey.elements.toStructuredKey_second)
   })
 
@@ -130,8 +131,8 @@ describe('assign element onto columns with flat model', () => {
     `
     const { TestPublisher } = model.entities
     expect(query).to.deep.eql(expected)
-    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(TestPublisher.elements['ID'])
-    // foreign key part is part of flat model
+    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(TestPublisher.elements.ID)
+    // foreign key is part of flat model
     expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(TestPublisher.elements.publisherRenamedKey_notID)
   })
 })


### PR DESCRIPTION
for a flat model, we must attach the foreign key which is adjacent to it's association as the columns `element` property. If such a flat fk is found next to the association in the containing entity, it is used as the `element` rather than the key in the target of the association.

fixes #165