### PR TITLE
test: Split test script into each package again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           IMAGE_ID: ${{ steps.find-hxe.outputs.IMAGE_ID }}
 
       # testing
-      - run: npm test -ws
+      - run: npm test -ws -- --maxWorkers=1
         env:
           FORCE_COLOR: true
           TAG: ${{ steps.find-hxe.outputs.TAG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,18 +58,20 @@ jobs:
       - name: Build HXE image
         if: ${{ steps.find-hxe.outputs.BUILD_HXE == 'true' }}
         run: |
-          TAG=${{ steps.find-hxe.outputs.TAG }};
-          IMAGE_ID=${{ steps.find-hxe.outputs.IMAGE_ID }};
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin;
           DOCKER_BUILDKIT=1 docker build -t $IMAGE_ID:$TAG ./hana/tools/docker/hxe;
           docker push $IMAGE_ID:$TAG;
+        env:
+          TAG: ${{ steps.find-hxe.outputs.TAG }}
+          IMAGE_ID: ${{ steps.find-hxe.outputs.IMAGE_ID }}
       # Star the latest HXE image in the background
       - name: Start HXE image
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin;
-          TAG=${{ steps.find-hxe.outputs.TAG }};
-          IMAGE_ID=${{ steps.find-hxe.outputs.IMAGE_ID }};
           { npm start -w hana; } &
+        env:
+          TAG: ${{ steps.find-hxe.outputs.TAG }}
+          IMAGE_ID: ${{ steps.find-hxe.outputs.IMAGE_ID }}
 
       # testing
       - run: npm test -ws

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,18 +63,15 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin;
           DOCKER_BUILDKIT=1 docker build -t $IMAGE_ID:$TAG ./hana/tools/docker/hxe;
           docker push $IMAGE_ID:$TAG;
-      # Pull the latest HXE image when not building it
-      - name: Pull HXE image
-        id: pull-hxe
+      # Star the latest HXE image in the background
+      - name: Start HXE image
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin;
           TAG=${{ steps.find-hxe.outputs.TAG }};
           IMAGE_ID=${{ steps.find-hxe.outputs.IMAGE_ID }};
-          { docker pull $IMAGE_ID:$TAG; docker tag $IMAGE_ID:$TAG hanaexpress:current; } &
-          echo "HXE_PULL=$!" >> $GITHUB_OUTPUT
-          wait
+          { npm start -w hana } &
 
       # testing
-      - run: npm test -- --runInBand
+      - run: npm test -ws
         env:
-          HXE_PULL: ${{ steps.pull-hxe.outputs.HXE_PULL }}
+          FORCE_COLOR: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin;
           TAG=${{ steps.find-hxe.outputs.TAG }};
           IMAGE_ID=${{ steps.find-hxe.outputs.IMAGE_ID }};
-          { npm start -w hana } &
+          { npm start -w hana; } &
 
       # testing
       - run: npm test -ws

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,3 +75,5 @@ jobs:
       - run: npm test -ws
         env:
           FORCE_COLOR: true
+          TAG: ${{ steps.find-hxe.outputs.TAG }}
+          IMAGE_ID: ${{ steps.find-hxe.outputs.IMAGE_ID }}

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -25,6 +25,9 @@
     "node": ">=16",
     "npm": ">=8"
   },
+  "scripts": {
+    "test": "jest --silent"
+  },
   "peerDependencies": {
     "@sap/cds": ">=7.1.1"
   },

--- a/hana/jest.config.js
+++ b/hana/jest.config.js
@@ -1,0 +1,1 @@
+exports.testTimeout = 30 * 1000

--- a/hana/jest.config.js
+++ b/hana/jest.config.js
@@ -1,1 +1,1 @@
-exports.testTimeout = 30 * 1000
+exports.testTimeout = 120 * 1000

--- a/hana/package.json
+++ b/hana/package.json
@@ -20,9 +20,10 @@
     "npm": ">=8"
   },
   "scripts": {
-    "setup": "npm run setup:hce || npm run setup:hxe",
-    "setup:hce": "cd ./tools/docker/hce/ && ./start.sh",
-    "setup:hxe": "cd ./tools/docker/hxe/ && ./start.sh"
+    "test": "npm start && jest --silent",
+    "start": "npm run start:hce || npm run start:hxe",
+    "start:hce": "cd ./tools/docker/hce/ && ./start.sh",
+    "start:hxe": "cd ./tools/docker/hxe/ && ./start.sh"
   },
   "dependencies": {
     "hdb": "^0.19.5"

--- a/hana/tools/docker/hxe/ci.yml
+++ b/hana/tools/docker/hxe/ci.yml
@@ -3,7 +3,7 @@ version: '3.1'
 
 services:
   hana:
-    image: hanaexpress:current
+    image: ${IMAGE_ID}:${TAG}
     restart: always
     hostname: buildkitsandbox
     ulimits:

--- a/hana/tools/docker/hxe/ready.sh
+++ b/hana/tools/docker/hxe/ready.sh
@@ -1,4 +1,7 @@
-docker cp ./start-hdi.sql hxe_hana_1:/usr/sap/HXE/start-hdi.sql
+until docker cp ./start-hdi.sql hxe_hana_1:/usr/sap/HXE/start-hdi.sql
+do
+  sleep 1
+done
 
 docker exec hxe_hana_1 bash -c "until /check_hana_health -n -e ready-status > /dev/null; do sleep 1; done;"
 echo "HANA has started"

--- a/hana/tools/docker/hxe/start.sh
+++ b/hana/tools/docker/hxe/start.sh
@@ -1,9 +1,4 @@
-if [ $HXE_PULL ]; then
-    wait $HXE_PULL;
-fi
-
-exists=$(docker images hanaexpress:current -q);
-if [ $exists ]; then
+if [ $IMAGE_ID ] && [ $TAG ]; then
     echo "Using prepared HXE image"
     docker-compose -f ci.yml up -d;
 else

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,2 @@
-const pipeline = !!process.env.CI
-
-// Add github-actions reporter in pipelines
-if (pipeline) exports.reporters = [ 'default', 'github-actions' ]
-
-// Ignore inherited tests that encounter tuple errors
-if (!pipeline) exports.testPathIgnorePatterns = [
-  '<rootDir>/postgres/test/timezone.test.js',
-  '<rootDir>/postgres/test/service.test.js',
-  '<rootDir>/postgres/test/service-types.test.js',
-  '<rootDir>/postgres/test/service-admin.test.js',
-  '<rootDir>/postgres/test/odata-string-functions.test.js',
-]
-
 // Fix debugging
 exports.transform = {}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "SAP SE (https://www.sap.com)",
   "workspaces": [
     "db-service",
-    "postgres",
     "sqlite",
+    "postgres",
     "hana"
   ],
   "devDependencies": {
@@ -22,7 +22,7 @@
     "express": "^4"
   },
   "scripts": {
-    "test": "npm start -w postgres && npm run setup -w hana && CDS_JEST_MEM_FIX=1 npx jest --silent --colors",
+    "test": "CDS_JEST_MEM_FIX=1 npm t -w db-service -w sqlite",
     "lint": "npx eslint ."
   },
   "license": "SEE LICENSE"

--- a/postgres/jest.config.js
+++ b/postgres/jest.config.js
@@ -1,3 +1,5 @@
+exports.testTimeout = 30 * 1000
+
 // Ignore inherited tests that encounter tuple errors
 if (!process.env.CI) exports.testPathIgnorePatterns = [
   '<rootDir>/test/timezone.test.js',

--- a/postgres/jest.config.js
+++ b/postgres/jest.config.js
@@ -1,0 +1,8 @@
+// Ignore inherited tests that encounter tuple errors
+if (!process.env.CI) exports.testPathIgnorePatterns = [
+  '<rootDir>/test/timezone.test.js',
+  '<rootDir>/test/service.test.js',
+  '<rootDir>/test/service-types.test.js',
+  '<rootDir>/test/service-admin.test.js',
+  '<rootDir>/test/odata-string-functions.test.js',
+]

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -27,6 +27,7 @@
     "npm": ">=8"
   },
   "scripts": {
+    "test": "npm start && jest --silent",
     "start": "docker-compose -f pg-stack.yml up -d"
   },
   "dependencies": {

--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -26,6 +26,9 @@
     "node": ">=16",
     "npm": ">=8"
   },
+  "scripts": {
+    "test": "jest --silent"
+  },
   "dependencies": {
     "@cap-js/db-service": "^1.1.0",
     "better-sqlite3": "^8"

--- a/sqlite/test/bookshop.test.js
+++ b/sqlite/test/bookshop.test.js
@@ -1,0 +1,3 @@
+describe('sqlite', () => {
+  require('../../test/scenarios/bookshop')
+})

--- a/sqlite/test/compliance.test.js
+++ b/sqlite/test/compliance.test.js
@@ -1,3 +1,3 @@
 describe('sqlite', () => {
-  require('../../test')
+  require('../../test/compliance')
 })

--- a/sqlite/test/sflight.test.js
+++ b/sqlite/test/sflight.test.js
@@ -1,0 +1,3 @@
+describe('sqlite', () => {
+  require('../../test/scenarios/sflight')
+})

--- a/test/cds.js
+++ b/test/cds.js
@@ -54,7 +54,7 @@ module.exports.test = Object.setPrototypeOf(function () {
     if (ret.data._autoIsolation) {
       await ret.data.isolate()
     }
-  }, 30 * 1000)
+  })
 
   const cds = ret.cds
 
@@ -101,7 +101,7 @@ module.exports.test = Object.setPrototypeOf(function () {
       ret.data._deployed = cds.deploy(cds.options.from[0])
       await ret.data._deployed
     }
-  }, 30 * 1000)
+  })
 
   global.afterAll(async () => {
     // Clean database connection pool
@@ -113,7 +113,7 @@ module.exports.test = Object.setPrototypeOf(function () {
     delete cds.db
     delete cds.model
     global.cds.resolve.cache = {}
-  }, 30 * 1000)
+  })
 
   return ret
 }, cdsTest.constructor.prototype)


### PR DESCRIPTION
Change the approach of doing multi workspace testing

```sh
npm t -ws # runs all test in the workspaces in order of the package.json workspaces array
npm t -w postgres -w hana # will run the test command for postgres and hana
```

Which allows each package to do their `start` script before running their tests. Also it allows for all the packages to have their own local `jest.config.js` files. Which allows `sqlite` to have a smaller `testTimeout` then `postgres` and `hana`.