### PR TITLE
cqn4sql: fix transformation of nested expand

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1627,6 +1627,34 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           continue
         }
         const rhs = result[i + 2]
+        if (rhs?.ref || lhs.ref) {
+          // if we have refs on each side of the comparison, we might need to perform tuple expansion
+          // or flatten the structures
+          const refLinkFaker = thing => {
+            const { ref } = thing
+            const assocHost = getParentEntity(assocRefLink.definition)
+            Object.defineProperty(thing, '$refLinks', {
+              value: [],
+              writable: true,
+            })
+            ref.reduce((prev, res, i) => {
+              if (res === '$self')
+                // next is resolvable in entity
+                return prev
+              const definition = prev?.elements?.[res] || prev?._target?.elements[res] || pseudos.elements[res]
+              const target = getParentEntity(definition)
+              thing.$refLinks[i] = { definition, target, alias: definition.name }
+              return prev?.elements?.[res] || prev?._target?.elements[res] || pseudos.elements[res]
+            }, assocHost)
+          }
+
+          // comparison in on condition needs to be expanded...
+          // re-use existing algorithm for that
+          // we need to fake some $refLinks for that to work though...
+          lhs?.ref && !lhs.$refLinks && refLinkFaker(lhs)
+          rhs?.ref && !rhs.$refLinks && refLinkFaker(rhs)
+        }
+
         let backlink
         if (rhs?.ref && lhs?.ref) {
           if (lhs?.ref?.length === 1 && lhs.ref[0] === '$self')
@@ -1640,32 +1668,6 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
               lhs.ref[0] in { $self: true, $projection: true } ? getParentEntity(assocRefLink.definition) : target,
             )
           else {
-            // if we have refs on each side of the comparison, we might need to perform tuple expansion
-            // or flatten the structures
-            // REVISIT: this whole section needs a refactoring, it is too complex and some edge cases may still be not considered...
-            const refLinkFaker = thing => {
-              const { ref } = thing
-              const assocHost = getParentEntity(assocRefLink.definition)
-              Object.defineProperty(thing, '$refLinks', {
-                value: [],
-                writable: true,
-              })
-              ref.reduce((prev, res, i) => {
-                if (res === '$self')
-                  // next is resolvable in entity
-                  return prev
-                const definition = prev?.elements?.[res] || prev?._target?.elements[res] || pseudos.elements[res]
-                const target = getParentEntity(definition)
-                thing.$refLinks[i] = { definition, target, alias: definition.name }
-                return prev?.elements?.[res] || prev?._target?.elements[res] || pseudos.elements[res]
-              }, assocHost)
-            }
-
-            // comparison in on condition needs to be expanded...
-            // re-use existing algorithm for that
-            // we need to fake some $refLinks for that to work though...
-            lhs?.ref && refLinkFaker(lhs)
-            rhs?.ref && refLinkFaker(rhs)
             const lhsLeafArt = lhs.ref && lhs.$refLinks[lhs.$refLinks.length - 1].definition
             const rhsLeafArt = rhs.ref && rhs.$refLinks[rhs.$refLinks.length - 1].definition
             if (lhsLeafArt?.target || rhsLeafArt?.target) {

--- a/db-service/test/cqn4sql/expand.test.js
+++ b/db-service/test/cqn4sql/expand.test.js
@@ -1021,7 +1021,6 @@ describe('Unfold expands on associations to special subselects', () => {
         }
       }
     `
-    // q.SELECT.localized = true
     let transformed = cqn4sql(q, cds.compile.for.nodejs(model))
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.eql(CQL`
       SELECT from Collaborations as Collaborations {

--- a/db-service/test/cqn4sql/expand.test.js
+++ b/db-service/test/cqn4sql/expand.test.js
@@ -8,7 +8,6 @@ describe('Unfold expands on structure', () => {
   beforeAll(async () => {
     cds.model = await cds.load(__dirname + '/../bookshop/db/schema').then(cds.linked)
   })
-
   it('supports nested projections for structs', () => {
     let query = CQL`SELECT from bookshop.Books { ID, dedication { addressee } }`
     let transformed = cqn4sql(query)
@@ -1061,6 +1060,29 @@ describe('expand on structure part II', () => {
         Employee.office_address_street
     }`
     expect(cqn4sql(expandQuery, model)).to.eql(expected)
+  })
+
+  it.only('nested expand with multiple conditions', async () => {
+    // innermost expand on association with backlink plus additional condition
+    // must be properly linked
+    const model = await cds.load(__dirname + '/model/collaborations').then(cds.linked)
+    const q = CQL`
+      SELECT from Collaborations {
+        id,
+        leads {
+          id
+        },
+        subCollaborations {
+          id,
+          leads {
+            id
+          }
+        }
+      }
+    `
+    // q.SELECT.localized = true
+    let transformed = cqn4sql(q, cds.compile.for.nodejs(model))
+    console.log(transformed)
   })
 
   it('multi expand with star', () => {

--- a/db-service/test/cqn4sql/model/collaborations.cds
+++ b/db-service/test/cqn4sql/model/collaborations.cds
@@ -1,0 +1,35 @@
+// inspired by a customer bug report
+// where a nested expand on an association with
+// multiple conditions next to the `$self` backlink led to issues
+aspect cuid {
+  key id: Integer;
+}
+
+entity Collaborations : cuid {
+  subCollaborations: Composition of many SubCollaborations on subCollaborations.collaboration = $self;
+  leads           : Association to many CollaborationLeads on leads.collaboration = $self and leads.isLead = true;
+}
+entity SubCollaborations : cuid {
+    collaboration: Association to Collaborations;
+    leads           : Association to many SubCollaborationAssignments on leads.subCollaboration = $self and leads.isLead = true;
+}
+
+entity CollaborationLeads: cuid {
+  collaboration: Association to Collaborations;
+  isLead: Boolean;
+}
+
+entity SubCollaborationAssignments : cuid {
+    subCollaboration : Association to one SubCollaborations;
+    isLead           : Boolean default false;
+
+}
+entity CollaborationParticipants : cuid {
+}
+entity CollaborationApplications : cuid {
+    subCollaborations: Composition of many SubCollaborationApplications on subCollaborations.application = $self;
+}
+
+entity SubCollaborationApplications : cuid {
+    application      : Association to one CollaborationApplications;
+}


### PR DESCRIPTION
This resolves a dump found by a customer:

```log
TypeError: Cannot read properties of undefined (reading 'ref')
      at calculateOnCondition (lib/cqn4sql.js:1630:17)
      at onCondFor (lib/cqn4sql.js:1607:13)
      at getWhereExistsSubquery (lib/cqn4sql.js:1852:27)
      at _transformFrom (lib/cqn4sql.js:1479:38)
      at getTransformedFrom (lib/cqn4sql.js:1436:14)
      at cqn4sql (lib/cqn4sql.js:72:53)
      at transformSubquery (lib/cqn4sql.js:891:12)
      at expandColumn (lib/cqn4sql.js:776:22)
      at handleExpand (lib/cqn4sql.js:396:40)
      at /Users/patricebender/SAPDevelop/dev/cds-dbs/db-service/lib/cqn4sql.js:322:32
      at getTransformedColumns (lib/cqn4sql.js:350:21)
      at transformSelectQuery (lib/cqn4sql.js:121:41)
      at cqn4sql (lib/cqn4sql.js:76:28)
```