### PR TITLE
fix: pass json as parameter instead of sql string

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -809,7 +809,7 @@ class CQN2SQLRenderer {
    * @returns {string} SQL
    */
   json(o) {
-    return this.string(JSON.stringify(o))
+    return JSON.stringify(o)
   }
 
   /**


### PR DESCRIPTION
When updating a `many` column type. The `json` value is converted into a `SQL` string, but is send as a parameter.