### PR TITLE
cqn4sql: for `$self` replacements, do not use table alias for flat name

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -548,7 +548,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
         dollarSelfColumn.ref = [...referencedColumn.ref, ...dollarSelfColumn.ref.slice(2)]
         Object.defineProperties(dollarSelfColumn, {
           flatName: {
-            value: dollarSelfColumn.ref.join('_'),
+            value: referencedColumn.$refLinks[0].definition.kind === 'entity' ?  dollarSelfColumn.ref.slice(1).join('_') : dollarSelfColumn.ref.join('_'),
           },
           isJoinRelevant: {
             value: referencedColumn.isJoinRelevant,

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -17,31 +17,6 @@ describe('table alias access', () => {
       let query = cqn4sql(CQL`SELECT from bookshop.Books { ID }`, model)
       expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }`)
     })
-    it('escaped identifier does not hurt', () => {
-      let query = cqn4sql(
-        CQL`
-      SELECT FROM bookshop.Books as ![FROM]
-      {
-        ![FROM].title as group,
-      }
-      where $self.group = 'foo'
-      group by $self.group
-      having $self.group = 'foo'
-      order by $self.group
-      `,
-        model,
-      )
-      expect(query).to.deep.equal(CQL`
-      SELECT from bookshop.Books as ![FROM]
-      {
-        ![FROM].title as group,
-      }
-      where ![FROM].title = 'foo' 
-      group by ![FROM].title
-      having ![FROM].title = 'foo' 
-      order by ![FROM].title
-      `)
-    })
 
     it('omits alias for anonymous query which selects from other query', () => {
       let query = cqn4sql(CQL`SELECT from (SELECT from bookshop.Books { ID } )`, model)
@@ -241,6 +216,31 @@ describe('table alias access', () => {
   })
 
   describe('replace $self references', () => {
+    it('escaped identifier does not hurt', () => {
+      let query = cqn4sql(
+        CQL`
+      SELECT FROM bookshop.Books as ![FROM]
+      {
+        ![FROM].title as group,
+      }
+      where $self.group = 'foo'
+      group by $self.group
+      having $self.group = 'foo'
+      order by $self.group
+      `,
+        model,
+      )
+      expect(query).to.deep.equal(CQL`
+      SELECT from bookshop.Books as ![FROM]
+      {
+        ![FROM].title as group,
+      }
+      where ![FROM].title = 'foo' 
+      group by ![FROM].title
+      having ![FROM].title = 'foo' 
+      order by ![FROM].title
+      `)
+    })
     it('refer to other query element', () => {
       const q = CQL`SELECT from bookshop.Books {
       Books.title,

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -17,19 +17,29 @@ describe('table alias access', () => {
       let query = cqn4sql(CQL`SELECT from bookshop.Books { ID }`, model)
       expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }`)
     })
-    it.skip('escaped identifier does not hurt', () => {
+    it('escaped identifier does not hurt', () => {
       let query = cqn4sql(
         CQL`
       SELECT FROM bookshop.Books as ![FROM]
       {
         ![FROM].title as group,
-      } where $self.group = 'foo'`,
+      }
+      where $self.group = 'foo'
+      group by $self.group
+      having $self.group = 'foo'
+      order by $self.group
+      `,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as ![FROM]
+      expect(query).to.deep.equal(CQL`
+      SELECT from bookshop.Books as ![FROM]
       {
         ![FROM].title as group,
-      } where ![FROM].title = 'foo' 
+      }
+      where ![FROM].title = 'foo' 
+      group by ![FROM].title
+      having ![FROM].title = 'foo' 
+      order by ![FROM].title
       `)
     })
 


### PR DESCRIPTION
easy fix, just check if `ref[0]` is an entity, if so, it must not be part of the flat name.

---

@stewsk please have a look