### PR TITLE
Update CODEOWNERS > narrow down scopes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@ db-service/lib/infer/**.js @patricebender
 db-service/test/cds-infer/ @patricebender
 
 db-service/lib/InsertResults.js @BobdenOs
+db-service/lib/converters.d.ts @BobdenOs
 db-service/lib/SQLService.js @BobdenOs
 db-service/lib/converters.js @BobdenOs
 db-service/lib/cql-functions.js @BobdenOs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,21 @@
 * @BobdenOs @David-Kunz @patricebender @danjoa @gregorwolf @johannes-vogel @vobu @stewsk @sebastianesch @sjvans
+
+db-service/lib/cqn4sql.js @patricebender @stewsk
+db-service/test/cqn4sql/ @patricebender @stewsk
+
+db-service/lib/infer/**.js @patricebender @stewsk
+db-service/test/cds-infer/ @patricebender @stewsk
+
+db-service/lib/InsertResults.js @BobdenOs @johannes-vogel @danjoa
+db-service/lib/SQLService.js @BobdenOs @johannes-vogel @danjoa
+db-service/lib/converters.js @BobdenOs @johannes-vogel @danjoa
+db-service/lib/cql-functions.js @BobdenOs @johannes-vogel @danjoa
+db-service/lib/cqn2sql.js @BobdenOs @johannes-vogel @danjoa
+db-service/lib/deep-queries.js @BobdenOs @johannes-vogel @danjoa
+db-service/lib/fill-in-keys.js @BobdenOs @johannes-vogel @danjoa
+
+db-service/test/cqn2sql/**.js @BobdenOs @johannes-vogel @danjoa
+db-service/test/deep/**.js @BobdenOs @johannes-vogel @danjoa
+db-service/test/etc/**.js @BobdenOs @johannes-vogel @danjoa
+db-service/test/tsc/**.js @BobdenOs @johannes-vogel @danjoa
+db-service/test/index.js @BobdenOs @johannes-vogel @danjoa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,25 @@
-* @BobdenOs @David-Kunz @patricebender @danjoa @gregorwolf @johannes-vogel @vobu @stewsk @sebastianesch @sjvans
+### Product owner own everything
+* @danjoa @johannes-vogel @stewsk
 
-db-service/lib/cqn4sql.js @patricebender @stewsk
-db-service/test/cqn4sql/ @patricebender @stewsk
+db-service/lib/cqn4sql.js @patricebender
+db-service/test/cqn4sql/ @patricebender
 
-db-service/lib/infer/**.js @patricebender @stewsk
-db-service/test/cds-infer/ @patricebender @stewsk
+db-service/lib/infer/**.js @patricebender
+db-service/test/cds-infer/ @patricebender
 
-db-service/lib/InsertResults.js @BobdenOs @johannes-vogel @danjoa
-db-service/lib/SQLService.js @BobdenOs @johannes-vogel @danjoa
-db-service/lib/converters.js @BobdenOs @johannes-vogel @danjoa
-db-service/lib/cql-functions.js @BobdenOs @johannes-vogel @danjoa
-db-service/lib/cqn2sql.js @BobdenOs @johannes-vogel @danjoa
-db-service/lib/deep-queries.js @BobdenOs @johannes-vogel @danjoa
-db-service/lib/fill-in-keys.js @BobdenOs @johannes-vogel @danjoa
+db-service/lib/InsertResults.js @BobdenOs
+db-service/lib/SQLService.js @BobdenOs
+db-service/lib/converters.js @BobdenOs
+db-service/lib/cql-functions.js @BobdenOs
+db-service/lib/cqn2sql.js @BobdenOs
+db-service/lib/deep-queries.js @BobdenOs
+db-service/lib/fill-in-keys.js @BobdenOs
 
-db-service/test/cqn2sql/**.js @BobdenOs @johannes-vogel @danjoa
-db-service/test/deep/**.js @BobdenOs @johannes-vogel @danjoa
-db-service/test/etc/**.js @BobdenOs @johannes-vogel @danjoa
-db-service/test/tsc/**.js @BobdenOs @johannes-vogel @danjoa
-db-service/test/index.js @BobdenOs @johannes-vogel @danjoa
+db-service/test/cqn2sql/**.js @BobdenOs
+db-service/test/deep/**.js @BobdenOs
+db-service/test/etc/**.js @BobdenOs
+db-service/test/tsc/**.js @BobdenOs
+db-service/test/index.js @BobdenOs
+
+sqlite/ @BobdenOs @patricebender
+postgres/ @BobdenOs @patricebender @gregorwolf @sebastianesch @vobu


### PR DESCRIPTION
With this change, I want to achieve that people feel more obligated to review a particular change.
This can be achieved by restricting the code ownership to specific areas. E.g. @vobu @gregorwolf @sebastianesch might be interested in `postgres` while not being interested in changes in e.g. `cqn4sql`.

Our product owners @stewsk @johannes-vogel and @danjoa are still owning everything and hence are able to approve changes in all areas.

If you have suggestions how to improve my initiative, please let me know.

---

@David-Kunz  @sjvans

would you like to be a code owner in a particular area?