### PR TITLE
fix: deep insert with backlinks as key in children

### DIFF
--- a/db-service/lib/fill-in-keys.js
+++ b/db-service/lib/fill-in-keys.js
@@ -23,6 +23,11 @@ const generateUUIDandPropagateKeys = (target, data, event) => {
     }
 
     if (elements[element].is2one || elements[element].is2many) {
+      // propagate own foreign keys to propagate further to sub data
+      propagateForeignKeys(element, data, elements[element]._foreignKeys, elements[element].isComposition, {
+        deleteAssocs: true,
+      })
+
       let subData = data[element]
       if (subData) {
         if (!Array.isArray(subData)) {
@@ -33,10 +38,6 @@ const generateUUIDandPropagateKeys = (target, data, event) => {
           generateUUIDandPropagateKeys(elements[element]._target, sub, 'CREATE')
         }
       }
-
-      propagateForeignKeys(element, data, elements[element]._foreignKeys, elements[element].isComposition, {
-        deleteAssocs: true,
-      })
     }
   }
 }

--- a/db-service/test/deep/deep.cds
+++ b/db-service/test/deep/deep.cds
@@ -49,6 +49,28 @@ entity ProjChild as projection on BaseChild {
   text as rText
 }
 
+service keyAssocs {
+    entity Header {
+    key uniqueName : String(50);
+    key realm      : String(50);
+        l1s  : Composition of many L1 on l1s.header = $self;
+}
+
+
+entity L1 {
+    key ID: UUID;
+    key header              : Association to Header;
+        number              : Integer;
+        l2s    : Composition of many L2 on l2s.l1 = $self;
+}
+
+entity L2 {
+    key ID: UUID;
+    key l1    : Association to L1;
+        percentage  : Double;
+}
+}
+
 service bla {
     entity RootUUID {
         key ID         : UUID;

--- a/db-service/test/deep/deep.test.js
+++ b/db-service/test/deep/deep.test.js
@@ -868,8 +868,8 @@ describe('test deep query generation', () => {
         {
           ID: expect.any(String),
           l1_ID: l1s[0].ID,
-          l1_header_realm: 'dummy',
-          l1_header_uniqueName: 'PR1',
+          l1_header_realm: entry.realm,
+          l1_header_uniqueName: entry.uniqueName,
         },
         {
           ID: expect.any(String),


### PR DESCRIPTION
I've added a test to reproduce the problem. Still needs to be fixed.