### PR TITLE
test: add scenario for upsert `array of`

### DIFF
--- a/test/bookshop/db/schema.cds
+++ b/test/bookshop/db/schema.cds
@@ -11,6 +11,7 @@ entity Books : managed {
   price  : Decimal;
   currency : Currency;
   image : LargeBinary @Core.MediaType : 'image/png';
+  footnotes: array of String;
 }
 
 entity Authors : managed {

--- a/test/scenarios/bookshop/update.test.js
+++ b/test/scenarios/bookshop/update.test.js
@@ -27,20 +27,20 @@ describe('Bookshop - Update', () => {
   test('Update array of', async () => {
     // create book
     const insert = INSERT.into('sap.capire.bookshop.Books')
-      .columns(['ID', 'footnotes'])
-      .values([150, ['one']])
+      .columns(['ID'])
+      .values([150])
     await cds.run(insert)
 
     const update = await PUT(
       '/admin/Books(150)', // UPSERT new footnotes
       {
         descr: 'UPDATED',
-        footnotes: ['one', 'two']
+        footnotes: ['one']
       },
       admin,
     )
     expect(update.status).to.be.eq(200)
-    expect(update.data.footnotes).to.be.eql(['one', 'two'])
+    expect(update.data.footnotes).to.be.eql(['one'])
   })
 
   test('programmatic update without body incl. managed', async () => {

--- a/test/scenarios/bookshop/update.test.js
+++ b/test/scenarios/bookshop/update.test.js
@@ -24,6 +24,24 @@ describe('Bookshop - Update', () => {
     expect(res.data.author_ID).to.be.eq(201)
     expect(res.data.descr).to.be.eq('UPDATED')
   })
+  test('Update array of', async () => {
+    // create book
+    const insert = INSERT.into('sap.capire.bookshop.Books')
+      .columns(['ID', 'footers'])
+      .values([150, ['one']])
+    await cds.run(insert)
+
+    const update = await PUT(
+      '/admin/Books(150)', // UPSERT new footnotes
+      {
+        descr: 'UPDATED',
+        footnotes: ['one', 'two']
+      },
+      admin,
+    )
+    expect(update.status).to.be.eq(200)
+    expect(update.data.footnotes).to.be.eql(['one', 'two'])
+  })
 
   test('programmatic update without body incl. managed', async () => {
     const { modifiedAt } = await cds.db.run(cds.ql.SELECT.from('sap.capire.bookshop.Books', { ID: 251 }))

--- a/test/scenarios/bookshop/update.test.js
+++ b/test/scenarios/bookshop/update.test.js
@@ -27,7 +27,7 @@ describe('Bookshop - Update', () => {
   test('Update array of', async () => {
     // create book
     const insert = INSERT.into('sap.capire.bookshop.Books')
-      .columns(['ID', 'footers'])
+      .columns(['ID', 'footnotes'])
       .values([150, ['one']])
     await cds.run(insert)
 


### PR DESCRIPTION
there was an issue with `postgres v1.1.0` - reported in https://github.com/cap-js/cds-dbs/issues/201 - which has been resolved in the meantime. Adding a test for bookkeeping.