### PR TITLE
reproduce issue with timestamp as key

### DIFF
--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -141,7 +141,8 @@ class SQLiteService extends SQLService {
     }
 
     val(v) {
-      if (/\d{4}-\d{2}-\d{2}T[0-2]\d:[0-5]{2}:\d{2}[Z+-]/.test(v.val)) v.val = new Date(v.val)
+      // intercept DateTime values and convert to Date objects to compare ISO Strings
+      if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[Z+-]/.test(v.val)) v.val = new Date(v.val)
       return super.val(v)
     }
 

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -140,6 +140,11 @@ class SQLiteService extends SQLService {
       }
     }
 
+    val(v) {
+      if (/\d{4}-\d{2}-\d{2}T[0-2]\d:[0-5]{2}:\d{2}[Z+-]/.test(v.val)) v.val = new Date(v.val)
+      return super.val(v)
+    }
+
     // Used for INSERT statements
     static InputConverters = {
       ...super.InputConverters,

--- a/sqlite/test/general/datetime.test.js
+++ b/sqlite/test/general/datetime.test.js
@@ -7,9 +7,11 @@ describe('datetime handling', () => {
     let res
     const payload = { dt: '2020-12-31T01:02:03Z', int: 4711}
     res = await cds.db.run(INSERT.into('DateTimeEntity').entries(payload))
-    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(payload .dt).toISOString() })) // this finds the value
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(payload .dt).toISOString() }))
     expect(res).toMatchObject(payload)
-    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: payload.dt})) // this returns undefined
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(payload .dt).toISOString() }))
+    expect(res).toMatchObject(payload)
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: payload.dt}))
     expect(res).toMatchObject(payload)
   })
 })

--- a/sqlite/test/general/datetime.test.js
+++ b/sqlite/test/general/datetime.test.js
@@ -1,0 +1,14 @@
+const cds = require('../../../test/cds.js')
+
+cds.test(__dirname, 'testModel.cds')
+
+describe('datetime handling', () => {
+  test('datetime elements as key', async () => {
+    let res
+    const payload = { dt: '2020-12-31T01:02:03Z', int: 4711}
+    res = await cds.db.run(INSERT.into('DateTimeEntity').entries(payload))
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: payload.dt})) // this returns undefined
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: '2020-12-31T01:02:03.000Z'})) // this finds the value but shouldn't
+    expect(res).toMatchObject(payload)
+  })
+})

--- a/sqlite/test/general/datetime.test.js
+++ b/sqlite/test/general/datetime.test.js
@@ -7,7 +7,7 @@ describe('datetime handling', () => {
     let res
     const payload = { dt: '2020-12-31T01:02:03Z', int: 4711}
     res = await cds.db.run(INSERT.into('DateTimeEntity').entries(payload))
-    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(dt).toISOString() })) // this finds the value
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(payload .dt).toISOString() })) // this finds the value
     expect(res).toMatchObject(payload)
     res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: payload.dt})) // this returns undefined
     expect(res).toMatchObject(payload)

--- a/sqlite/test/general/datetime.test.js
+++ b/sqlite/test/general/datetime.test.js
@@ -7,7 +7,7 @@ describe('datetime handling', () => {
     let res
     const payload = { dt: '2020-12-31T01:02:03Z', int: 4711}
     res = await cds.db.run(INSERT.into('DateTimeEntity').entries(payload))
-    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(dt).toISOString() })) // this finds the value but shouldn't
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(dt).toISOString() })) // this finds the value
     expect(res).toMatchObject(payload)
     res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: payload.dt})) // this returns undefined
     expect(res).toMatchObject(payload)

--- a/sqlite/test/general/datetime.test.js
+++ b/sqlite/test/general/datetime.test.js
@@ -7,8 +7,9 @@ describe('datetime handling', () => {
     let res
     const payload = { dt: '2020-12-31T01:02:03Z', int: 4711}
     res = await cds.db.run(INSERT.into('DateTimeEntity').entries(payload))
+    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: new Date(dt).toISOString() })) // this finds the value but shouldn't
+    expect(res).toMatchObject(payload)
     res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: payload.dt})) // this returns undefined
-    res = await cds.db.run(SELECT.one.from('DateTimeEntity').where({dt: '2020-12-31T01:02:03.000Z'})) // this finds the value but shouldn't
     expect(res).toMatchObject(payload)
   })
 })

--- a/sqlite/test/general/testModel.cds
+++ b/sqlite/test/general/testModel.cds
@@ -74,6 +74,11 @@ entity DBDeepEntity {
                      on children.parentRename = ID;
 }
 
+entity DateTimeEntity {
+  key dt: DateTime;
+  int: Integer;
+}
+
 entity FProjDeep  as projection on DBDeepEntity {
   ID         as IDRename,
   parent     as parentRename,


### PR DESCRIPTION
Oliver has switched the odata-v2 proxy to use the new db layer in his tests.
This reveals a problem with datetime elements as key.

On first glance, the ISO function formats datetime values as timestamps which cannot be found anymore as we don't apply the same function on where clauses. Alternatively, we must not use the function for datetime elements.

caused by #131