### PR TITLE
fix: Ensure safe rollback and release

### DIFF
--- a/db-service/lib/SQLService.js
+++ b/db-service/lib/SQLService.js
@@ -20,6 +20,7 @@ const cqn4sql = require('./cqn4sql')
 class SQLService extends DatabaseService {
 
   init() {
+    const ret = super.init()
     this.on(['SELECT'], this.transformStreamFromCQN)
     this.on(['UPDATE'], this.transformStreamIntoCQN)
     this.on(['INSERT', 'UPSERT', 'UPDATE', 'DELETE'], require('./fill-in-keys')) // REVISIT should be replaced by correct input processing eventually
@@ -32,7 +33,7 @@ class SQLService extends DatabaseService {
     this.on(['BEGIN', 'COMMIT', 'ROLLBACK'], this.onEVENT)
     this.on(['STREAM'], this.onSTREAM)
     this.on(['*'], this.onPlainSQL)
-    return super.init()
+    return ret
   }
 
   /** @type {Handler} */


### PR DESCRIPTION
## Description

When a database connection encounters an error in a query it will trigger the default rollback mechanism. As all queries including rollback are asynchronous it is possible that queries are in progress or in the process of being send. Which can mean that the rollback happens before a parallel query. Which allows the query to escape the transaction. Additionally it is possible to send a query to the database service while it is in the process of rolling back. All new queries to a rollback database transaction should be rejected.

To prevent the database connection to be released back into the pool with queries that are in progress this PR implements a tracker of all returned promises. Which is awaited before the rollback is triggered. After which the database connection is safely released back to the connection pool.

```js
this.on(['*'], () => {
  const prom = next()
  this.activeQueries.push(prom)
  return prom
})
```