### PR TITLE
fix: better-sqlite3@8.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "license": "SEE LICENSE",
       "workspaces": [
         "db-service",
-        "postgres",
         "sqlite",
+        "postgres",
         "hana"
       ],
       "devDependencies": {
         "@capire/sflight": "sap-samples/cap-sflight",
         "@sap/hana-client": "^2.16.26",
-        "axios": ">=1.3",
+        "axios": "^1",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "chai-subset": "^1.6.0",
@@ -47,14 +47,16 @@
       "name": "@cap-js/hana",
       "version": "1.0.0",
       "license": "SEE LICENSE",
+      "dependencies": {
+        "hdb": "^0.19.5"
+      },
       "engines": {
         "node": ">=16",
         "npm": ">=8"
       },
       "peerDependencies": {
         "@sap/cds": ">=7",
-        "@sap/hana-client": "^2.16.26",
-        "hdb": "^0.19.5"
+        "@sap/hana-client": ">=2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2031,13 +2033,13 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.5.0.tgz",
-      "integrity": "sha512-vbPcv/Hx5WYdyNg/NbcfyaBZyv9s/NVbxb7yCeC5Bq1pVocNxeL2tZmSu3Rlm4IEOTjYdGyzWQgyx0OSdORBzw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.6.0.tgz",
+      "integrity": "sha512-jwAudeiTMTSyby+/SfbHDebShbmC2MCH8mU2+DXi0WJfv13ypEJm47cd3kljmy/H130CazEvkf2Li//ewcMJ1g==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.0"
+        "prebuild-install": "^7.1.1"
       }
     },
     "node_modules/big.js": {

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -128,6 +128,19 @@ describe('SELECT', () => {
       assert.equal(res[2].xpr, false)
     })
 
+    test('select 200 columns', async () => {
+      const cqn = {
+        SELECT: {
+          from: { ref: ['basic.projection.string'] },
+          columns: new Array(200).fill().map((_, i) => ({ as: `${i}`, val: i })),
+        },
+      }
+
+      const res = await cds.run(cqn)
+      assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
+      assert.equal(Object.keys(res[0]).length, cqn.SELECT.columns.length)
+    })
+
     test.skip('invalid cast (wrong)', async () => {
       await assert.rejects(
         cds.run(CQL`


### PR DESCRIPTION
`better-sqlite3@8.6.0` includes an upgrade of `sqlite3` which contains a performance optimization for `json` functions ([changelog](https://www.sqlite.org/releaselog/3_43_0.html#:~:text=Performance%20enhancements%20to%20JSON%20processing%20results%20in%20a%202x%20performance%20improvement%20for%20some%20kinds%20of%20processing%20on%20large%20JSON%20strings.))

The performance optimization seems to take the trade of that it uses more memory. Which made the `lean-draft` tests run into `SQLITE_NOMEM` (out of memory) errors. After some investigating this seems to be related to the solution used to support 50+ columns in select statements. This PR switches to use `json_patch` which is equal to `Object.assign({...},{...})`. Which seems to make the behavior as expected again. Might even be a small general performance increase.