### PR TITLE
cqn4sql: pass context for association expansion

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -548,7 +548,10 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
         dollarSelfColumn.ref = [...referencedColumn.ref, ...dollarSelfColumn.ref.slice(2)]
         Object.defineProperties(dollarSelfColumn, {
           flatName: {
-            value: referencedColumn.$refLinks[0].definition.kind === 'entity' ?  dollarSelfColumn.ref.slice(1).join('_') : dollarSelfColumn.ref.join('_'),
+            value:
+              referencedColumn.$refLinks[0].definition.kind === 'entity'
+                ? dollarSelfColumn.ref.slice(1).join('_')
+                : dollarSelfColumn.ref.join('_'),
           },
           isJoinRelevant: {
             value: referencedColumn.isJoinRelevant,
@@ -1242,7 +1245,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           ) {
             if (notSupportedOps.some(([firstOp]) => firstOp === next))
               cds.error(`The operator "${next}" is not supported for structure comparison`)
-            const newTokens = expandComparison(token, ops, rhs)
+            const newTokens = expandComparison(token, ops, rhs, $baseLink)
             const needXpr = Boolean(tokenStream[i - 1] || tokenStream[indexRhs + 1])
             transformedTokenStream.push(...(needXpr ? [asXpr(newTokens)] : newTokens))
             i = indexRhs // jump to next relevant index
@@ -1301,9 +1304,14 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
    * @param {object} token with $refLinks
    * @param {string} operator one of allOps
    * @param {object} value either `null` or a column (with `ref` and `$refLinks`)
+   * @param {object} $baseLink optional base `$refLink`, e.g. for infix filters of scoped queries.
+   *                           In the following example, we must pass `bookshop:Reproduce` as $baseLink for `author`:
+   *
+   *                           `DELETE.from('bookshop.Reproduce[author = null]:accessGroup')`
+   *                                                            ^^^^^^
    * @returns {array}
    */
-  function expandComparison(token, operator, value) {
+  function expandComparison(token, operator, value, $baseLink = null) {
     const { definition } = token.$refLinks[token.$refLinks.length - 1]
     let flatRhs
     const result = []
@@ -1366,7 +1374,10 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
       if (!def.$refLinks) return def
       const leaf = def.$refLinks[def.$refLinks.length - 1]
       const first = def.$refLinks[0]
-      const tableAlias = getQuerySourceName(def, def.ref.length > 1 && first.definition.isAssociation ? first : null)
+      const tableAlias = getQuerySourceName(
+        def,
+        def.ref.length > 1 && first.definition.isAssociation ? first : $baseLink,
+      )
       if (leaf.definition.parent.kind !== 'entity')
         // we need the base name
         return getFlatColumnsFor(leaf.definition, {

--- a/db-service/test/bookshop/db/schema.cds
+++ b/db-service/test/bookshop/db/schema.cds
@@ -164,6 +164,7 @@ entity WithStructuredKey {
 entity AssocWithStructuredKey {
   key ID: Integer;
   toStructuredKey: Association to WithStructuredKey;
+  accessGroup : Composition of AccessGroups;
 }
 entity Intermediate {
   key ID: Integer;

--- a/db-service/test/bookshop/db/schema.cds
+++ b/db-service/test/bookshop/db/schema.cds
@@ -390,3 +390,10 @@ entity PartialStructuredKey {
   };
   toSelf: Association to PartialStructuredKey { struct.one as partial}
 }
+
+  entity Reproduce {
+    key ID : Integer;
+    title : String(5000);
+    author : Association to Authors;
+    accessGroup : Composition of AccessGroups;
+  }

--- a/db-service/test/cqn4sql/DELETE.test.js
+++ b/db-service/test/cqn4sql/DELETE.test.js
@@ -69,4 +69,72 @@ describe('DELETE', () => {
       }`)
     expect(query.DELETE).to.deep.equal(expected.DELETE)
   })
+
+  it('DELETE with assoc filter and where exists expansion', () => {
+    const { DELETE } = cds.ql
+    let d = DELETE.from('bookshop.Reproduce[author = null and ID = 99]:accessGroup')
+    const query = cqn4sql(d)
+
+    const expected = JSON.parse(`{
+        "DELETE": {
+          "from": {
+            "ref": [
+              "bookshop.AccessGroups"
+            ],
+            "as": "accessGroup"
+          },
+          "where": [
+            "exists",
+            {
+              "SELECT": {
+                "from": {
+                  "ref": [
+                    "bookshop.Reproduce"
+                  ],
+                  "as": "Reproduce"
+                },
+                "columns": [
+                  {
+                    "val": 1
+                  }
+                ],
+                "where": [
+                  {
+                    "ref": [
+                      "Reproduce",
+                      "author_ID"
+                    ]
+                  },
+                  "=",
+                  { val: null },
+                  "and",
+                  {
+                    "ref": [
+                      "Reproduce",
+                      "ID"
+                    ]
+                  },
+                  "=",
+                  { val: 99 },"and",
+                  {
+                    "ref": [
+                      "accessGroup",
+                      "ID"
+                    ]
+                  },
+                  "=",
+                  {
+                    "ref": [
+                      "Reproduce",
+                      "accessGroup_ID"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }`)
+    expect(query.DELETE).to.deep.equal(expected.DELETE)
+  })
 })

--- a/db-service/test/cqn4sql/DELETE.test.js
+++ b/db-service/test/cqn4sql/DELETE.test.js
@@ -75,66 +75,75 @@ describe('DELETE', () => {
     let d = DELETE.from('bookshop.Reproduce[author = null and ID = 99]:accessGroup')
     const query = cqn4sql(d)
 
-    const expected = JSON.parse(`{
-        "DELETE": {
-          "from": {
-            "ref": [
-              "bookshop.AccessGroups"
-            ],
-            "as": "accessGroup"
-          },
-          "where": [
-            "exists",
-            {
-              "SELECT": {
-                "from": {
-                  "ref": [
-                    "bookshop.Reproduce"
-                  ],
-                  "as": "Reproduce"
-                },
-                "columns": [
-                  {
-                    "val": 1
-                  }
+    const expected = {
+      "DELETE": {
+        "from": {
+          "ref": [
+            "bookshop.AccessGroups"
+          ],
+          "as": "accessGroup"
+        },
+        "where": [
+          "exists",
+          {
+            "SELECT": {
+              "from": {
+                "ref": [
+                  "bookshop.Reproduce"
                 ],
-                "where": [
-                  {
-                    "ref": [
-                      "Reproduce",
-                      "author_ID"
-                    ]
-                  },
-                  "=",
-                  { val: null },
-                  "and",
-                  {
-                    "ref": [
-                      "Reproduce",
-                      "ID"
-                    ]
-                  },
-                  "=",
-                  { val: 99 },"and",
-                  {
-                    "ref": [
-                      "accessGroup",
-                      "ID"
-                    ]
-                  },
-                  "=",
-                  {
-                    "ref": [
-                      "Reproduce",
-                      "accessGroup_ID"
-                    ]
-                  }
-                ]
-              }
+                "as": "Reproduce"
+              },
+              "columns": [
+                {
+                  "val": 1
+                }
+              ],
+              "where": [
+                {
+                  "ref": [
+                    "Reproduce",
+                    "accessGroup_ID"
+                  ]
+                },
+                "=",
+                {
+                  "ref": [
+                    "accessGroup",
+                    "ID"
+                  ]
+                },
+                "and",
+                {
+                  "xpr": [
+                    {
+                      "ref": [
+                        "Reproduce",
+                        "author_ID"
+                      ]
+                    },
+                    "=",
+                    {
+                      "val": null
+                    }
+                  ]
+                },
+                "and",
+                {
+                  "ref": [
+                    "Reproduce",
+                    "ID"
+                  ]
+                },
+                "=",
+                {
+                  "val": 99
+                }
+              ]
             }
-          ]
-        }
-      }`)
+          }
+        ]
+      }
+    }
     expect(query.DELETE).to.deep.equal(expected.DELETE)
   })
 })

--- a/db-service/test/cqn4sql/tupleExpansion.test.js
+++ b/db-service/test/cqn4sql/tupleExpansion.test.js
@@ -260,6 +260,24 @@ describe('Structural comparison', () => {
       expect(query).to.deep.equal(CQL(expectedQueryString))
     })
   })
+
+  it('expands comparison also in exists subquery', () => {
+      const queryString = `SELECT from bookshop.AssocWithStructuredKey[toStructuredKey = null]:accessGroup { ID }`
+      let query = cqn4sql(CQL(queryString), model)
+      const expectedQueryString = `
+        SELECT from bookshop.AccessGroups as accessGroup
+        { accessGroup.ID }
+        where exists (
+          SELECT 1 from bookshop.AssocWithStructuredKey as AssocWithStructuredKey
+          where AssocWithStructuredKey.accessGroup_ID = accessGroup.ID and
+              AssocWithStructuredKey.toStructuredKey_struct_mid_leaf        = null and
+              AssocWithStructuredKey.toStructuredKey_struct_mid_anotherLeaf = null and
+              AssocWithStructuredKey.toStructuredKey_second                 = null
+        )
+      `
+      expect(query).to.deep.equal(CQL(expectedQueryString))
+  })
+
   it('compare assocs with multiple keys', () => {
     eqOps.forEach(op => {
       const [first] = op


### PR DESCRIPTION
When having a scoped query, as in the test example, we must pass the context for an infix filter (that is the entity where the filter is resolvable in) if the filter is not part of the last `ref` and hence not part of the `elements` of the query.

---

@patricebender FYI.
When testing #212 with the current runtime implementation, we observed that a request like this causes a crash in cqn4sql.
If you have some time, you could have a look. Assumption is that the association in the filter is flattened to its foreign key.