### PR TITLE
calculated elements: enable smart wildcard replacements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-### Product owner own everything
-* @danjoa @johannes-vogel @stewsk
+# Product owner own everything
+
+** @danjoa @johannes-vogel @stewsk
 
 db-service/lib/cqn4sql.js @patricebender
 db-service/test/cqn4sql/ @patricebender

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -672,7 +672,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
         }
       }
       if (leafArt.value && !leafArt.value.stored) {
-        resolveCalculatedElement(column, $baseLink, baseColumn)
+        linkCalculatedElement(column, $baseLink, baseColumn)
       }
 
       /**
@@ -801,7 +801,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
         throw new Error(err)
       }
     }
-    function resolveCalculatedElement(column, baseLink, baseColumn) {
+    function linkCalculatedElement(column, baseLink, baseColumn) {
       const calcElement = column.$refLinks?.[column.$refLinks.length - 1].definition || column
       if (alreadySeenCalcElements.has(calcElement)) return
       else alreadySeenCalcElements.add(calcElement)
@@ -927,8 +927,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
         Object.entries(sources[aliases[0]].elements).forEach(([name, element]) => {
           if (!exclude(name) && element.type !== 'cds.LargeBinary') queryElements[name] = element
           if (element.value) {
-            // we might have join relevant calculated elements
-            resolveCalculatedElement(element)
+            linkCalculatedElement(element)
           }
         })
         return
@@ -943,6 +942,9 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
         if (exclude(name) || name in queryElements) return true
         const element = tableAliases[0].tableAlias.elements[name]
         if (element.type !== 'cds.LargeBinary') queryElements[name] = element
+        if (element.value) {
+          linkCalculatedElement(element)
+        }
       })
 
       if (Object.keys(ambiguousElements).length > 0) throwAmbiguousWildcardError()

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -462,8 +462,8 @@ describe('Unfolding calculated elements in select list', () => {
         }`
     expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)
   })
-  // TODO
-  it.skip('replacement for calculated element is considered for wildcard expansion', () => {
+
+  it('replacement for calculated element is considered for wildcard expansion', () => {
     let query = cqn4sql(
       CQL`SELECT from booksCalc.Books { *, volume as ctitle } excluding { length, width, height, stock, price}`,
       model,

--- a/db-service/test/cqn4sql/pseudo-variable-replacement.test.js
+++ b/db-service/test/cqn4sql/pseudo-variable-replacement.test.js
@@ -123,16 +123,4 @@ describe('Pseudo Variables', () => {
       '"$whatever" not found in the elements of "bookshop.Books"',
     )
   })
-
-  // it.skip('$user', () => {})
-  // it.skip('$user.id', () => {})
-  // it.skip('$user.locale', () => {})
-  // it.skip('$user.<attr>', () => {})
-  // it.skip('$tenant', () => {}) //?
-  // it.skip('$now', () => {})
-  // it.skip('$at', () => {})
-  // it.skip('$from, $to', () => {})
-
-  // $search maybe via external mechanism
-  // --> would be smart to do before path resolving
 })

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -672,6 +672,7 @@ describe('EXISTS predicate in infix filter', () => {
        where exists leads[ participant.scholar_userID = $user.id ]
     `
     // maybe in the future this could be something like this
+    // eslint-disable-next-line no-unused-vars
     const futureExpectation = CQL`
       SELECT from Collaborations as Collaborations {
         Collaborations.id


### PR DESCRIPTION
this is an easy fix, we must link the calculated element first in `infer` then, we can insert the calculated element as wildcard replacements as we do with all other columns. In the end, we must only deduplicate the already-inserted wildcard replacment.

---

also applied some minor changes to the `CODEOWNERS` file. Now our POs should be requested for review for every file.