### PR TITLE
calculated elements: fixes and enhancements

### DIFF
--- a/db-service/lib/cql-functions.js
+++ b/db-service/lib/cql-functions.js
@@ -341,7 +341,7 @@ const HANAFunctions = {
    */
   years_between(x, y) {
     return `floor(${this.months_between(x, y)} / 12)`
-  },
+  }
 }
 
 for (let each in HANAFunctions) HANAFunctions[each.toUpperCase()] = HANAFunctions[each]

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -492,7 +492,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
     if (column.$refLinks) {
       const { $refLinks } = column
       value = $refLinks[$refLinks.length - 1].definition.value
-      if ($refLinks.length > 1) {
+      if (column.$refLinks.length > 1) {
         baseLink =
           [...$refLinks].reverse().find($refLink => $refLink.definition.isAssociation) ||
           // if there is no association in the path, the table alias is the base link

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1152,11 +1152,6 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
         if (ref[0] in { $self: true, $projection: true })
           cds.error(`Unexpected "${ref[0]}" following "exists", remove it or add a table alias instead`)
         const firstStepIsTableAlias = ref.length > 1 && ref[0] in inferred.sources
-        if($refLinks.at(-1).definition.value) {
-            const resolved = resolveCalculatedElement(tokenStream[i + 1], true)
-            const foo = getTransformedTokenStream(['exists', resolved.xpr])
-            console.log(resolved)
-        }
         for (let j = 0; j < ref.length; j += 1) {
           let current, next
           const step = ref[j]

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -492,7 +492,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
     if (column.$refLinks) {
       const { $refLinks } = column
       value = $refLinks[$refLinks.length - 1].definition.value
-      if (column.$refLinks.length > 1) {
+      if ($refLinks.length > 1) {
         baseLink =
           [...$refLinks].reverse().find($refLink => $refLink.definition.isAssociation) ||
           // if there is no association in the path, the table alias is the base link
@@ -511,7 +511,9 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
       res = { xpr: getTransformedTokenStream(value.xpr, baseLink) }
     } else if (val) {
       res = { val }
-    } else if (func) res = { args: getTransformedTokenStream(value.args, baseLink), func: value.func }
+    } else if (func) {
+      res = { args: getTransformedTokenStream(value.args, baseLink), func: value.func }
+    }
     if (!omitAlias) res.as = column.as || column.name || column.flatName
     return res
   }
@@ -913,6 +915,9 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
   function getColumnsForWildcard(exclude = [], replace = []) {
     const wildcardColumns = []
     Object.keys(inferred.$combinedElements).forEach(k => {
+      if (exclude.includes(k)) {
+        return
+      }
       const { index, tableAlias } = inferred.$combinedElements[k][0]
       const element = tableAlias.elements[k]
       // ignore FK for odata csn / ignore blobs from wildcard expansion

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -668,7 +668,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
     // everything after the wildcard, is a potential replacement
     // in the wildcard expansion
     const replace = []
-    // we need to absolutefy the refs
+    // we need to make the refs absolute
     col[prop].slice(wildcardIndex + 1).forEach(c => {
       const fakeColumn = { ...c }
       if (fakeColumn.ref) {
@@ -1275,8 +1275,15 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
               transformedTokenStream.push(...getTransformedTokenStream(dollarSelfReplacement))
               continue
             }
-            const tableAlias = getQuerySourceName(token, $baseLink)
-            if (!$baseLink && token.isJoinRelevant) {
+            // if we have e.g. a calculated element like `books.authorLastName,`
+            // we have effectively a ref ['books', 'author', 'lastName']
+            // in that case, we have a baseLink `books` which we need to resolve the following steps
+            // however, the correct table alias has been assigned to the `author` step
+            // hence we need to ignore the alias of the `$baseLink`
+            const refHasOwnAssoc =
+              token.isJoinRelevant && [...token.$refLinks].reverse().find(l => l.definition.isAssociation)
+            const tableAlias = getQuerySourceName(token, refHasOwnAssoc || $baseLink)
+            if ((!$baseLink || refHasOwnAssoc) && token.isJoinRelevant) {
               result.ref = [tableAlias, getFullName(token.$refLinks[token.$refLinks.length - 1].definition)]
             } else if (tableAlias) {
               result.ref = [tableAlias, token.flatName]
@@ -1952,7 +1959,6 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
     if ($baseLink) {
       return getBaseLinkAlias($baseLink)
     }
-
     if (node.isJoinRelevant) {
       return getJoinRelevantAlias(node)
     }

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1152,6 +1152,11 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
         if (ref[0] in { $self: true, $projection: true })
           cds.error(`Unexpected "${ref[0]}" following "exists", remove it or add a table alias instead`)
         const firstStepIsTableAlias = ref.length > 1 && ref[0] in inferred.sources
+        if($refLinks.at(-1).definition.value) {
+            const resolved = resolveCalculatedElement(tokenStream[i + 1], true)
+            const foo = getTransformedTokenStream(['exists', resolved.xpr])
+            console.log(resolved)
+        }
         for (let j = 0; j < ref.length; j += 1) {
           let current, next
           const step = ref[j]

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -914,24 +914,23 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
    */
   function getColumnsForWildcard(exclude = [], replace = []) {
     const wildcardColumns = []
-    Object.keys(inferred.$combinedElements).forEach(k => {
-      if (exclude.includes(k)) {
-        return
-      }
-      const { index, tableAlias } = inferred.$combinedElements[k][0]
-      const element = tableAlias.elements[k]
-      // ignore FK for odata csn / ignore blobs from wildcard expansion
-      if (isManagedAssocInFlatMode(element) || (element['@Core.MediaType'] && !element['@Core.IsURL'])) return
-      // for wildcard on subquery in from, just reference the elements
-      if (tableAlias.SELECT && !element.elements && !element.target) {
-        wildcardColumns.push(index ? { ref: [index, k] } : { ref: [k] })
-      } else if (isCalculatedOnRead(element)) {
-        wildcardColumns.push(resolveCalculatedElement(replace.find(r => r.as === k) || element))
-      } else {
-        const flatColumns = getFlatColumnsFor(element, { tableAlias: index }, [], { exclude, replace }, true)
-        wildcardColumns.push(...flatColumns)
-      }
-    })
+    Object.keys(inferred.$combinedElements)
+      .filter(k => !exclude.includes(k))
+      .forEach(k => {
+        const { index, tableAlias } = inferred.$combinedElements[k][0]
+        const element = tableAlias.elements[k]
+        // ignore FK for odata csn / ignore blobs from wildcard expansion
+        if (isManagedAssocInFlatMode(element) || (element['@Core.MediaType'] && !element['@Core.IsURL'])) return
+        // for wildcard on subquery in from, just reference the elements
+        if (tableAlias.SELECT && !element.elements && !element.target) {
+          wildcardColumns.push(index ? { ref: [index, k] } : { ref: [k] })
+        } else if (isCalculatedOnRead(element)) {
+          wildcardColumns.push(resolveCalculatedElement(replace.find(r => r.as === k) || element))
+        } else {
+          const flatColumns = getFlatColumnsFor(element, { tableAlias: index }, [], { exclude, replace }, true)
+          wildcardColumns.push(...flatColumns)
+        }
+      })
     return wildcardColumns
 
     /**

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -849,7 +849,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
           const leafOfCalculatedElementRef = arg.$refLinks[arg.$refLinks.length - 1].definition
           if (leafOfCalculatedElementRef.value) mergePathsIntoJoinTree(leafOfCalculatedElementRef.value, basePath)
 
-          mergePathIfNecessary(basePath, arg)         
+          mergePathIfNecessary(basePath, arg)
         } else if (arg.xpr) {
           arg.xpr.forEach(step => {
             if (step.ref) {
@@ -940,14 +940,14 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
         const { elements } = sources[aliases[0]]
         // only one query source and no overwritten columns
         Object.keys(elements)
-        .filter(k => !exclude(k))
-        .forEach((k) => {
-          const element = sources[aliases[0]].elements[k]
-          if (element.type !== 'cds.LargeBinary') queryElements[k] = element
-          if (element.value) {
-            linkCalculatedElement(element)
-          }
-        })
+          .filter(k => !exclude(k))
+          .forEach(k => {
+            const element = sources[aliases[0]].elements[k]
+            if (element.type !== 'cds.LargeBinary') queryElements[k] = element
+            if (element.value) {
+              linkCalculatedElement(element)
+            }
+          })
         return
       }
 

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -154,8 +154,9 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
    * @returns {void} This function does not return a value; it mutates the 'arg' object directly.
    */
   function attachRefLinksToArg(arg, $baseLink = null, expandOrExists = false) {
-    const { ref, xpr } = arg
+    const { ref, xpr, args } = arg
     if (xpr) xpr.forEach(t => attachRefLinksToArg(t, $baseLink, expandOrExists))
+    if (args) args.forEach(arg => attachRefLinksToArg(arg, $baseLink, expandOrExists))
     if (!ref) return
     init$refLinks(arg)
     ref.forEach((step, i) => {
@@ -752,6 +753,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
               columns: expand.filter(c => !c.inline),
             },
           }
+          if(col.excluding) expandSubquery.SELECT.excluding = col.excluding
           if (col.as) expandSubquery.SELECT.as = col.as
           const inferredExpandSubquery = infer(expandSubquery, model)
           const res = $leafLink.definition.is2one
@@ -938,7 +940,8 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
       if (Object.keys(queryElements).length === 0 && aliases.length === 1) {
         // only one query source and no overwritten columns
         Object.entries(sources[aliases[0]].elements).forEach(([name, element]) => {
-          if (!exclude(name) && element.type !== 'cds.LargeBinary') queryElements[name] = element
+          if(exclude(name)) return
+          if (element.type !== 'cds.LargeBinary') queryElements[name] = element
           if (element.value) {
             linkCalculatedElement(element)
           }

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -753,7 +753,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
               columns: expand.filter(c => !c.inline),
             },
           }
-          if(col.excluding) expandSubquery.SELECT.excluding = col.excluding
+          if (col.excluding) expandSubquery.SELECT.excluding = col.excluding
           if (col.as) expandSubquery.SELECT.as = col.as
           const inferredExpandSubquery = infer(expandSubquery, model)
           const res = $leafLink.definition.is2one
@@ -826,14 +826,13 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
             { definition: calcElement.parent, target: calcElement.parent },
             { inCalcElement: true },
           ),
-          
-          mergePathsIntoJoinTree(arg)
+            mergePathsIntoJoinTree(arg)
         }) // {func}.args are optional
-      
+
       /**
        * Calculates all paths from a given ref and merges them into the join tree.
        * Recursively walks into refs of calculated elements.
-       * 
+       *
        * @param {object} arg with a ref and sibling $refLinks
        * @param {object} basePath with a ref and sibling $refLinks, used for recursion
        */
@@ -850,14 +849,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
           const leafOfCalculatedElementRef = arg.$refLinks[arg.$refLinks.length - 1].definition
           if (leafOfCalculatedElementRef.value) mergePathsIntoJoinTree(leafOfCalculatedElementRef.value, basePath)
 
-          mergePathIfNecessary(basePath, arg)
-          if (basePath.ref.length === arg.ref.length) {
-            arg.$refLinks.forEach((link, i) => {
-              const mergedPathSegment = basePath.$refLinks[i]
-              if(link.definition === mergedPathSegment.definition && link.alias !== mergedPathSegment.alias)
-                link.alias = mergedPathSegment.alias
-            })
-          }
+          mergePathIfNecessary(basePath, arg)         
         } else if (arg.xpr) {
           arg.xpr.forEach(step => {
             if (step.ref) {
@@ -872,20 +864,6 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
                 }
               })
               mergePathIfNecessary(subPath, step)
-              // if a refLink got reassigned during the merge process
-              // we need to re-adjust the respective alias in the calculated element
-              // itself.
-              // this is the case if a specific path was already seen before and hence
-              // gets a already calculated, unique table alias assigned.
-              if(subPath.$refLinks[basePath.$refLinks.length-1]?.alias !== basePath.$refLinks.at(-1)?.alias) {
-                calcElement.value.$refLinks[basePath.$refLinks.length-1] = subPath.$refLinks[basePath.$refLinks.length-1]
-              } else if (step.ref.length === subPath.ref.length) {
-                step.$refLinks.forEach((link, i) => {
-                  const mergedPathSegment = subPath.$refLinks[i]
-                  if(link.definition === mergedPathSegment.definition && link.alias !== mergedPathSegment.alias)
-                    link.alias = mergedPathSegment.alias
-                })
-              }
             }
           })
         }
@@ -961,7 +939,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
       if (Object.keys(queryElements).length === 0 && aliases.length === 1) {
         // only one query source and no overwritten columns
         Object.entries(sources[aliases[0]].elements).forEach(([name, element]) => {
-          if(exclude(name)) return
+          if (exclude(name)) return
           if (element.type !== 'cds.LargeBinary') queryElements[name] = element
           if (element.value) {
             linkCalculatedElement(element)

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -937,10 +937,13 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
       const exclude = _.excluding ? x => _.excluding.includes(x) : () => false
 
       if (Object.keys(queryElements).length === 0 && aliases.length === 1) {
+        const { elements } = sources[aliases[0]]
         // only one query source and no overwritten columns
-        Object.entries(sources[aliases[0]].elements).forEach(([name, element]) => {
-          if (exclude(name)) return
-          if (element.type !== 'cds.LargeBinary') queryElements[name] = element
+        Object.keys(elements)
+        .filter(k => !exclude(k))
+        .forEach((k) => {
+          const element = sources[aliases[0]].elements[k]
+          if (element.type !== 'cds.LargeBinary') queryElements[k] = element
           if (element.value) {
             linkCalculatedElement(element)
           }

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -811,7 +811,10 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
       if (ref || xpr) {
         baseLink = baseLink || { definition: calcElement.parent, target: calcElement.parent }
         attachRefLinksToArg(calcElement.value, baseLink, true)
-        const basePath = { $refLinks: [], ref: [] }
+        const basePath =
+          column.$refLinks?.length > 1
+            ? { $refLinks: column.$refLinks.slice(0, -1), ref: column.ref.slice(0, -1) }
+            : { $refLinks: [], ref: [] }
         if (baseColumn) {
           basePath.$refLinks.push(...baseColumn.$refLinks)
           basePath.ref.push(...baseColumn.ref)
@@ -825,8 +828,9 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
             false,
             { definition: calcElement.parent, target: calcElement.parent },
             { inCalcElement: true },
-          ),
-            mergePathsIntoJoinTree(arg)
+          )
+          const basePath = column.$refLinks?.length > 1 ? { $refLinks: column.$refLinks.slice(0, -1), ref: column.ref.slice(0, -1) } : { $refLinks: [], ref: [] }
+          mergePathsIntoJoinTree(arg, basePath)
         }) // {func}.args are optional
 
       /**

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -181,7 +181,10 @@ class JoinTree {
       if (next) {
         // step already seen before
         node = next
-        col.$refLinks[i] = node.$refLink // re-set $refLink to point to already merged $refLink
+        // re-set $refLink to equal the one which got already merged
+        col.$refLinks[i].alias = node.$refLink.alias
+        col.$refLinks[i].definition = node.$refLink.definition
+        col.$refLinks[i].target = node.$refLink.target
       } else {
         if (col.expand && !col.ref[i + 1]) {
           node.$refLink.onlyForeignKeyAccess = false

--- a/db-service/test/bookshop/db/booksWithExpr.cds
+++ b/db-service/test/bookshop/db/booksWithExpr.cds
@@ -21,6 +21,9 @@ entity Books {
   volume : Decimal = area * height;
   storageVolume : Decimal = stock * volume;
 
+  // use calc element in infix filter
+  youngAuthorName: String = author[age < 50].name;
+
   // -- with paths
   authorLastName = author.lastName;
   authorName = author.name;
@@ -35,7 +38,12 @@ entity Authors {
   key ID : Integer;
   firstName : String;
   lastName : String;
- 
+  
+  dateOfBirth  : Date;
+  dateOfDeath  : Date;
+  
+  age: Integer = years_between(dateOfBirth, dateOfDeath);
+
   books : Association to many Books on books.author = $self;
   address : Association to Addresses;
 

--- a/db-service/test/cds-infer/calculated-elements.test.js
+++ b/db-service/test/cds-infer/calculated-elements.test.js
@@ -53,6 +53,7 @@ describe('Infer types of calculated elements in select list', () => {
       authorFullNameWithAddress: Books.elements.authorFullNameWithAddress,
       authorAdrText: Books.elements.authorAdrText,
       authorAge: Books.elements.authorAge,
+      youngAuthorName: Books.elements.youngAuthorName,
     })
   })
 })

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -497,13 +497,15 @@ describe('Unfolding calculated elements in select list', () => {
     expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)
   })
 
-  it.skip('calculated element used in infix filter of other calculated element', () => {
+  it('calculated element used in infix filter of other calculated element', () => {
     let query = cqn4sql(
       CQL`
     SELECT from booksCalc.Books {
       youngAuthorName,
       authorLastName,
-      authorName
+      authorName,
+      authorFullName,
+      authorAge
     } 
     `,
       model,
@@ -517,12 +519,14 @@ describe('Unfolding calculated elements in select list', () => {
         {
           author.firstName || ' ' || author.lastName as youngAuthorName,
           author2.lastName as authorLastName,
-          author2.firstName || ' ' || author2.lastName as authorName
+          author2.firstName || ' ' || author2.lastName as authorName,
+          author2.firstName || ' ' || author2.lastName as authorFullName,
+          years_between( author2.sortCode, author2.sortCode ) as authorAge
         }`
     expect(query).to.deep.equal(expected)
   })
 
-  it.skip('via wildcard in expand subquery include complex calc element', () => {
+  it('via wildcard in expand subquery include complex calc element', () => {
     let query = cqn4sql(
       CQL`
     SELECT from booksCalc.Authors {

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -526,6 +526,14 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
 
+  // TODO
+  it.skip('where exists cannot leverage calculated elements', () => {
+    // at the leaf of a where exists path, there must be an association
+    // calc elements can't end in an association, hence this does not work, yet.
+    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID } where exists youngAuthorName`, model)
+    expect(query).to.deep.throw()
+  })
+
   it('via wildcard in expand subquery include complex calc element', () => {
     let query = cqn4sql(
       CQL`

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -16,7 +16,6 @@ class SQLiteService extends SQLService {
         dbc.function('regexp', { deterministic: true }, (re, x) => (RegExp(re).test(x) ? 1 : 0))
         dbc.function('ISO', { deterministic: true }, d => d && new Date(d).toISOString())
         if (!dbc.memory) dbc.pragma('journal_mode = WAL')
-        dbc.pragma('foreign_keys = ON')
         return dbc
       },
       destroy: dbc => dbc.close(),

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -16,6 +16,7 @@ class SQLiteService extends SQLService {
         dbc.function('regexp', { deterministic: true }, (re, x) => (RegExp(re).test(x) ? 1 : 0))
         dbc.function('ISO', { deterministic: true }, d => d && new Date(d).toISOString())
         if (!dbc.memory) dbc.pragma('journal_mode = WAL')
+        dbc.pragma('foreign_keys = ON')
         return dbc
       },
       destroy: dbc => dbc.close(),


### PR DESCRIPTION
This change contains several fixes for the calculated elements on read:
- If multiple calculated elements share the same join node, make sure that refs are properly rewritten to the correct TA
- make sure that infix filter arguments in calculated elements are properly massaged into join arguments
  - make sure that such an infix filter can also be a calculated element by itself
- provide a base context for function arguments making sure that aliases are properly added to the refs

other changes:

- add test - which is currently skipped - that shows that calculated elements are currently not properly rejected after `where exists` arguments