### PR TITLE
cqn4sql: reject calc elements \w exists predicate

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -482,7 +482,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
 
     function handleEmptyColumns(columns) {
       if (columns.some(c => c.$refLinks?.[c.$refLinks.length - 1].definition.type === 'cds.Composition')) return
-      throw new cds.error('Queries must have at least one non-virtual column')
+      cds.error('Queries must have at least one non-virtual column')
     }
   }
 
@@ -1221,7 +1221,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
             flatKeys.push(...getFlatColumnsFor(v, { tableAlias: $baseLink.alias }))
           })
         if (flatKeys.length > 1)
-          throw new Error('Filters can only be applied to managed associations which result in a single foreign key')
+          cds.error('Filters can only be applied to managed associations which result in a single foreign key')
         flatKeys.forEach(c => keyValComparisons.push([...[c, '=', token]]))
         keyValComparisons.forEach((kv, j) =>
           transformedTokenStream.push(...kv) && keyValComparisons[j + 1] ? transformedTokenStream.push('and') : null,
@@ -1410,10 +1410,10 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
       rejectStructInExpression()
 
     function rejectAssocInExpression() {
-      throw new Error(/An association can't be used as a value in an expression/)
+      cds.error("An association can't be used as a value in an expression")
     }
     function rejectStructInExpression() {
-      throw new Error(/A structured element can't be used as a value in an expression/)
+      cds.error("A structured element can't be used as a value in an expression")
     }
   }
 
@@ -1856,6 +1856,13 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
   function getWhereExistsSubquery(current, next, customWhere = null, inWhere = false) {
     const { definition } = current
     const { definition: nextDefinition } = next
+    if (definition.value || nextDefinition.value) {
+      cds.error(
+        `Unexpected calculated element “${
+          definition.value ? definition.name : nextDefinition.name
+        }” in path preceded by “exists” predicate`,
+      )
+    }
     const on = []
     const fkSource = inWhere ? nextDefinition : definition
     // TODO: use onCondFor()
@@ -1954,7 +1961,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
    */
   function getQuerySourceName(node, $baseLink = null) {
     if (!node || !node.$refLinks || !node.ref) {
-      throw new Error('Invalid node')
+      cds.error('Invalid node')
     }
     if ($baseLink) {
       return getBaseLinkAlias($baseLink)

--- a/db-service/test/cds-infer/negative.test.js
+++ b/db-service/test/cds-infer/negative.test.js
@@ -95,6 +95,7 @@ describe('negative', () => {
 
     it('$self reference is not found in the query elements with subquery -> cds.infer hints alternatives', () => {
       let query = CQL`SELECT from (select from bookshop.Books) as Foo { $self.author }`
+      // _inferred(query)
       // wording? select list not optimal, did you mean to refer to bookshop.Books?
       expect(() => _inferred(query)).to.throw(
         /"author" not found in the columns list of query, did you mean "Foo.author"?/, // revisit: error message
@@ -113,9 +114,9 @@ describe('negative', () => {
 
     it('scoped query does not end in queryable artifact', () => {
       let query = CQL`SELECT from bookshop.Books:name { * }` // name does not exist
-      expect(() => _inferred(query)).to.throw(/No association "name" in entity "bookshop.Books"/)
+      expect(() => _inferred(query)).to.throw(/No association “name” in entity “bookshop.Books”/)
       let fromEndsWithScalar = CQL`SELECT from bookshop.Books:title { * }`
-      expect(() => _inferred(fromEndsWithScalar)).to.throw(/No association "title" in entity "bookshop.Books"/)
+      expect(() => _inferred(fromEndsWithScalar)).to.throw(/No association “title” in entity “bookshop.Books”/)
     })
 
     // queries with multiple sources are not supported for cqn4sql transformation  (at least for now)

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -606,12 +606,20 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
 
-  // TODO
-  it.skip('where exists cannot leverage calculated elements', () => {
+  it('where exists cannot leverage calculated elements', () => {
     // at the leaf of a where exists path, there must be an association
     // calc elements can't end in an association, hence this does not work, yet.
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID } where exists youngAuthorName`, model)
-    expect(query).to.deep.throw()
+    expect(() => cqn4sql(CQL`SELECT from booksCalc.Books { ID } where exists youngAuthorName`, model)).to.throw(
+      'Unexpected calculated element “youngAuthorName” in path preceded by “exists” predicate',
+    )
+  })
+
+  it('scoped query cannot leverage calculated elements', () => {
+    // at the leaf of a where exists path, there must be an association
+    // calc elements can't end in an association, hence this does not work, yet.
+    expect(() => cqn4sql(CQL`SELECT from booksCalc.Books:youngAuthorName { ID }`, model)).to.throw(
+      'No association “youngAuthorName” in entity “booksCalc.Books”',
+    )
   })
 
   it('via wildcard in expand subquery include complex calc element', () => {


### PR DESCRIPTION
also streamline error handling to always use `cds.error`.