### PR TITLE
chore: use pg 15 image

### DIFF
--- a/postgres/pg-stack.yml
+++ b/postgres/pg-stack.yml
@@ -3,7 +3,7 @@ version: '3.1'
 
 services:
   db:
-    image: postgres:alpine
+    image: postgres:15-alpine
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
[pg 16 is now latest ](https://github.com/docker-library/postgres/commit/7df6bc166fbf0d7f28c85700235012317a22f88e)and seems to break with our test setup.
revert to 15 for running pipelines.
BLI created to analyze issue with pg 16.