### PR TITLE
cqn4sql: reject non associations following `exists` predicate

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1184,8 +1184,17 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           next.alias = as
           if (next.definition.value) {
             throw new Error(
-              `Calculated elements cannot be used in “exists” predicates in: “exists ${
-                tokenStream[i+1].ref.map(idOnly).join('.')
+              `Calculated elements cannot be used in “exists” predicates in: “exists ${tokenStream[i + 1].ref
+                .map(idOnly)
+                .join('.')}”`,
+            )
+          }
+          if (!next.definition.target) {
+            throw new Error(
+              `Expecting path “${tokenStream[i + 1].ref
+                .map(idOnly)
+                .join('.')}” following “EXISTS” predicate to end with association/composition, found “${
+                next.definition.type
               }”`,
             )
           }

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -547,7 +547,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
             throw new Error(
               `Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ ${column.ref.map(
                 idOnly,
-              )} ]`,
+              ).join(', ')} ]`,
             )
           }
 

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -512,7 +512,7 @@ function infer(originalQuery, model = cds.context?.model || cds.model) {
                       .join('.')}" must not be an unmanaged association`,
                   )
                 // no non-fk traversal in infix filter
-                if (nextStep && !(nextStep in element.foreignKeys))
+                if (nextStep && element.foreignKeys && !(nextStep in element.foreignKeys))
                   throw new Error(`Only foreign keys of "${element.name}" can be accessed in infix filter`)
               }
               const resolvableIn = definition.target ? definition._target : target

--- a/db-service/test/cds-infer/negative.test.js
+++ b/db-service/test/cds-infer/negative.test.js
@@ -226,7 +226,7 @@ describe('negative', () => {
   describe('path traversals via $self are rejected', () => {
     it('simple field access', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author,name ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
           CQL`SELECT from bookshop.Books{
@@ -239,7 +239,7 @@ describe('negative', () => {
     })
     it('in order by', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author,name ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
           CQL`SELECT from bookshop.Books{
@@ -251,7 +251,7 @@ describe('negative', () => {
     })
     it('in group by', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author,name ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
           CQL`SELECT from bookshop.Books{
@@ -263,7 +263,7 @@ describe('negative', () => {
     })
     it('in where', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author,name ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
           CQL`SELECT from bookshop.Books{
@@ -275,7 +275,7 @@ describe('negative', () => {
     })
     it('in xpr', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author,name ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
           CQL`SELECT from bookshop.Books{
@@ -288,7 +288,7 @@ describe('negative', () => {
     })
     it('deep field access', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,dedication,addressee,ID ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, dedication, addressee, ID ]'
       expect(() =>
         _inferred(
           CQL`SELECT from bookshop.Books{
@@ -300,7 +300,7 @@ describe('negative', () => {
       ).to.throw(errorMessage)
     })
     it('with infix filter', () => {
-      const errorMessage = `Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author,ID ]`
+      const errorMessage = `Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, ID ]`
       expect(() =>
         cqn4sql(
           CQL`SELECT from bookshop.Books{
@@ -313,7 +313,7 @@ describe('negative', () => {
     })
     it('with inline syntax', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author ]'
       expect(() =>
         cqn4sql(
           CQL`SELECT from bookshop.Books{
@@ -326,7 +326,7 @@ describe('negative', () => {
     })
     it('with expand syntax', () => {
       const errorMessage =
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author ]'
+        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author ]'
       expect(() =>
         cqn4sql(
           CQL`SELECT from bookshop.Books{

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -1389,7 +1389,7 @@ describe('comparisons of associations in on condition of elements needs to be ex
   })
 })
 
-describe.only('Sanity checks for `exists` predicate', () => {
+describe('Sanity checks for `exists` predicate', () => {
   let model
   beforeAll(async () => {
     model = cds.model = await cds.load(__dirname + '/../bookshop/srv/cat-service').then(cds.linked)

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -1396,7 +1396,7 @@ describe('Sanity checks for `exists` predicate', () => {
   })
   it('rejects $self following exists predicate', () => {
     expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author } where exists $self.author`, model)).to.throw(
-      'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author ]',
+      'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author ]',
     )
   })
 

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -28,7 +28,8 @@ describe('EXISTS predicate in where', () => {
          GROUP BY Books.ID
          HAVING EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID
-         )`)
+         )`,
+      )
     })
     it('exists predicate after having with infix filter', () => {
       let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } group by ID having exists author[ID=42]`, model)
@@ -39,10 +40,14 @@ describe('EXISTS predicate in where', () => {
          GROUP BY Books.ID
          HAVING EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and author.ID = 42
-         )`)
+         )`,
+      )
     })
     it('MUST ... two EXISTS both on same path in where', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists genre.children[code = 'ABC'] or exists genre.children[code = 'DEF']`, model)
+      let query = cqn4sql(
+        CQL`SELECT from bookshop.Books { ID } where exists genre.children[code = 'ABC'] or exists genre.children[code = 'DEF']`,
+        model,
+      )
       expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
       WHERE EXISTS (
         SELECT 1 from bookshop.Genres as genre where genre.ID = Books.genre_ID
@@ -67,11 +72,6 @@ describe('EXISTS predicate in where', () => {
       WHERE EXISTS (
         SELECT 1 from bookshop.Authors as author2 where author2.ID = Books.author_ID
         ) and ((author.name + 's') = 'Schillers')`)
-    })
-    it('rejects $self following exists predicate', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author } where exists $self.author`, model)).to.throw(
-        'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author ]',
-      )
     })
 
     it('handles simple where exists with implicit table alias', () => {
@@ -706,8 +706,9 @@ describe('EXISTS predicate in infix filter', () => {
             and participant.scholar_userID = $user.id
       )
     `
-    expect(() => { cqn4sql(q, cds.compile.for.nodejs(model)) })
-      .to.throw(/Only foreign keys of "participant" can be accessed in infix filter/)
+    expect(() => {
+      cqn4sql(q, cds.compile.for.nodejs(model))
+    }).to.throw(/Only foreign keys of "participant" can be accessed in infix filter/)
   })
 })
 
@@ -1385,5 +1386,43 @@ describe('comparisons of associations in on condition of elements needs to be ex
       )
     `
     expect(query).to.eql(expected)
+  })
+})
+
+describe.only('Sanity checks for `exists` predicate', () => {
+  let model
+  beforeAll(async () => {
+    model = cds.model = await cds.load(__dirname + '/../bookshop/srv/cat-service').then(cds.linked)
+  })
+  it('rejects $self following exists predicate', () => {
+    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author } where exists $self.author`, model)).to.throw(
+      'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self,author ]',
+    )
+  })
+
+  it('rejects non assoc following exists predicate', () => {
+    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author[exists name].name as author }`, model)).to.throw(
+      'Expecting path “name” following “EXISTS” predicate to end with association/composition, found “cds.String”',
+    )
+  })
+
+  it('rejects non assoc following exists predicate in scoped query', () => {
+    expect(() => cqn4sql(CQL`SELECT from bookshop.Books:author[exists name] { ID }`, model)).to.throw(
+      'Expecting path “name” following “EXISTS” predicate to end with association/composition, found “cds.String”',
+    )
+  })
+
+  it('rejects non assoc following exists predicate in where', () => {
+    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists author[exists name]`, model)).to.throw(
+      'Expecting path “name” following “EXISTS” predicate to end with association/composition, found “cds.String”',
+    )
+  })
+
+  it('rejects non assoc at leaf of path following exists predicate', () => {
+    expect(() =>
+      cqn4sql(CQL`SELECT from bookshop.Books { ID, author[exists books.title].name as author }`, model),
+    ).to.throw(
+      'Expecting path “books.title” following “EXISTS” predicate to end with association/composition, found “cds.String”',
+    )
   })
 })

--- a/postgres/lib/func.js
+++ b/postgres/lib/func.js
@@ -19,6 +19,15 @@ const StandardFunctions = {
   hour: x => `date_part('hour',(${x})::TIMESTAMP)`,
   minute: x => `date_part('minute',(${x})::TIMESTAMP)`,
   second: x => `date_part('second',(${x})::TIMESTAMP)`,
+
+  search: function (ref, arg) {
+    if (!('val' in arg)) {
+      console.log(JSON.stringify(arg))
+    }
+    const refs = ref.list || [ref],
+      { toString } = ref
+    return '(' + refs.map(ref2 => this.contains(this.tolower(toString(ref2)), this.tolower(arg))).join(' or ') + ')'
+  },
 }
 
 const HANAFunctions = {

--- a/postgres/lib/func.js
+++ b/postgres/lib/func.js
@@ -19,15 +19,6 @@ const StandardFunctions = {
   hour: x => `date_part('hour',(${x})::TIMESTAMP)`,
   minute: x => `date_part('minute',(${x})::TIMESTAMP)`,
   second: x => `date_part('second',(${x})::TIMESTAMP)`,
-
-  search: function (ref, arg) {
-    if (!('val' in arg)) {
-      console.log(JSON.stringify(arg))
-    }
-    const refs = ref.list || [ref],
-      { toString } = ref
-    return '(' + refs.map(ref2 => this.contains(this.tolower(toString(ref2)), this.tolower(arg))).join(' or ') + ')'
-  },
 }
 
 const HANAFunctions = {


### PR DESCRIPTION
before this change, there was a dump for this.