### PR TITLE
ci: bootstrap release please configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,30 @@
+on:
+    push:
+      branches:
+        - main
+name: release-please
+jobs:
+    release-please:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: google-github-actions/release-please-action@v3
+          id: release
+          with:
+            release-type: node
+            package-name: test-release-please
+        # The logic below handles the npm publication:
+        - uses: actions/checkout@v2
+          # these if statements ensure that a publication only occurs when
+          # a new release is created:
+          if: ${{ steps.release.outputs.release_created }}
+        - uses: actions/setup-node@v1
+          with:
+            node-version: 18
+            registry-url: 'https://registry.npmjs.org'
+          if: ${{ steps.release.outputs.release_created }}
+        - run: npm ci
+          if: ${{ steps.release.outputs.release_created }}
+        - run: npm publish
+          env:
+            NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,32 +1,32 @@
 on:
-    push:
-      branches:
-        - main
+  push:
+    branches:
+      - main
 name: release-please
 jobs:
-    release-please:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: google-github-actions/release-please-action@v3
-          id: release
-          with:
-            token: ${{secrets.GITHUB_TOKEN}}
-            command: manifest
-            monorepo-tags: true
-            changelog-types: '[{"type":"feat","section":"Added","hidden":false},{"type":"fix","section":"Fixed","hidden":false}]'
-        # The logic below handles the npm publication:
-        - uses: actions/checkout@v2
-          # these if statements ensure that a publication only occurs when
-          # a new release is created:
-          if: ${{ steps.release.outputs.release_created }}
-        - uses: actions/setup-node@v1
-          with:
-            node-version: 18
-            registry-url: 'https://registry.npmjs.org'
-          if: ${{ steps.release.outputs.release_created }}
-        - run: npm ci
-          if: ${{ steps.release.outputs.release_created }}
-        - run: npm publish
-          env:
-            NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-          if: ${{ steps.release.outputs.release_created }}
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          command: manifest
+          monorepo-tags: true
+          changelog-types: '[{"type":"feat","section":"Added","hidden":false},{"type":"fix","section":"Fixed","hidden":false}]'
+      # The logic below handles the npm publication:
+      - uses: actions/checkout@v2
+        # these if statements ensure that a publication only occurs when
+        # a new release is created:
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm ci
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,8 +10,10 @@ jobs:
         - uses: google-github-actions/release-please-action@v3
           id: release
           with:
-            release-type: node
-            package-name: test-release-please
+            token: ${{secrets.GITHUB_TOKEN}}
+            command: manifest
+            monorepo-tags: true
+            changelog-types: '[{"type":"feat","section":"Added","hidden":false},{"type":"fix","section":"Fixed","hidden":false}]'
         # The logic below handles the npm publication:
         - uses: actions/checkout@v2
           # these if statements ensure that a publication only occurs when

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
 name: release-please
 jobs:
   release-please:
+    permissions:
+        contents: write
+        pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "db-service ": "1.3.1",
+  "sqlite ": "1.3.1",
+  "postgres": "1.3.1"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,25 @@ The following rule governs code contributions:
 * We use GitHub issues to track bugs and enhancement requests.
 
 * Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.
+
+## Committing
+
+Our commit messages use a simplified form of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). This is how our automated release system knows what a given commit means.
+
+```md
+<type>: <description>
+
+[body]
+```
+
+### Commit type prefixes
+
+The `type` can be any of `feat`, `fix` or `chore`.
+
+The prefix is used to calculate the semver release level, and the section of the release notes to place the commit message in.
+
+| **type**  | when to use                         | release level | release note section |
+| --------- | ----------------------------------- | ------------- | -------------------- |
+| feat      | a feature has been added            | `minor`       | **Features**         |
+| fix       | a bug has been patched              | `patch`       | **Bug fixes**        |
+| chore     | any changes that aren't user-facing | none          | none                 |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bootstrap-sha": "52869aaa897d1ad0a4447be456890ee7b6f3a290",
   "packages": {
     "db-service ": {},
     "sqlite ": {},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,7 @@
+{
+  "packages": {
+    "db-service ": {},
+    "sqlite ": {},
+    "postgres": {}
+  }
+}


### PR DESCRIPTION
follow steps in https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md which is targeting monorepo setups.

To use release please we need to install the `release-please` npm package: `npm i release-please -g`.

work for #109

---

inspired by https://github.com/Financial-Times/origami → those guys are releasing dozens of components from their monorepo with `release-please`