### PR TITLE
fix: Add countdistinct to hana functions

### DIFF
--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -9,6 +9,7 @@ const StandardFunctions = {
       ? `substring( ${x}, case when ${y} < 0 then length(${x}) + ${y} + 1 else ${y} + 1 end, ${z} )`
       : `substring( ${x}, case when ${y} < 0 then length(${x}) + ${y} + 1 else ${y} + 1 end )`,
   count: x => `count(${x || '*'})`,
+  countdistinct: x => `count(distinct ${x || '*'})`,
   average: x => `avg(${x})`,
   contains: (...args) => `(CASE WHEN coalesce(locate(${args}),0)>0 THEN TRUE ELSE FALSE END)`,
   search: function (ref, arg) {


### PR DESCRIPTION
The SFlight tests started to fail with `countdistinct` not being an HANA aggregate function.