### PR TITLE
ci: use cap bots to create release please PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.CDS_DBS_TOKEN}}
           command: manifest
           monorepo-tags: true
       # The logic below handles the npm publication:


### PR DESCRIPTION
if the `GITHUB_TOKEN` is used, PRs created by the github actions bot do not trigger workflow runs