### PR TITLE
feat: use a simple select for flat queries

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -144,7 +144,9 @@ class HANAService extends SQLService {
       })
       .join(' UNION ALL ')
 
-    const ret = `DO BEGIN ${values} SELECT * FROM (${unions}) ORDER BY "_path_" ASC; END;`
+    const ret = temporary.length === 1
+      ? `SELECT _path_ as "_path_",_blobs_ as "_blobs_",_expands_ as "_expands_",_json_ as "_json_"${blobColumns} FROM (SELECT ${temporary[0].select})`
+      : `DO BEGIN ${values} SELECT * FROM (${unions}) ORDER BY "_path_" ASC; END;`
     DEBUG?.(ret)
     return ret
   }
@@ -422,7 +424,7 @@ class HANAService extends SQLService {
         // Making each row a maximum size of 2gb instead of the whole result set to be 2gb
         // Excluding binary columns as they are not supported by FOR JSON and themselves can be 2gb
         const rawJsonColumn = sql.length
-          ? `(SELECT ${sql} FROM DUMMY FOR JSON ('format'='no', 'omitnull'='no', 'arraywrap'='no') RETURNS NCLOB) AS _json_`
+          ? `(SELECT ${sql} FROM DUMMY FOR JSON ('format'='no', 'omitnull'='no', 'arraywrap'='no') RETURNS NVARCHAR(2147483647)) AS _json_`
           : `TO_NCLOB('{}') AS _json_`
 
         let jsonColumn = rawJsonColumn


### PR DESCRIPTION
# Details

Without this change every query is wrapped inside a `DO BEGIN` which allows for multiple queries to be executed, but this comes with a bit of an overhead. So now flat queries (without expands) are now done as a `SELECT` directly.

Additionally the `_json_` column is returned as an `NVARCHAR` as the HANA network protocol for `NCLOB` requires additional `FETCH` calls which cause a dramatic overal request response time.