### PR TITLE
feat(`DELETE`): enable path expressions 

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -99,9 +99,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
         if (inferred.UPDATE) {
           const subquery = {
             SELECT: {
-              from: {
-                ref: transformedFrom.ref,
-              },
+              from: transformedFrom,
               columns: [{ val: 1 }],
               where: [...inferred.UPDATE.where],
             },

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -96,17 +96,21 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
       }
 
       if (queryNeedsJoins) {
-        if (inferred.UPDATE) {
+        if (inferred.UPDATE || inferred.DELETE) {
+          const prop = inferred.UPDATE ? 'UPDATE' : 'DELETE'
           const subquery = {
             SELECT: {
               from: transformedFrom,
               columns: [{ val: 1 }],
-              where: [...inferred.UPDATE.where],
+              where: [...transformedProp.where],
             },
           }
           const transformedSubquery = cqn4sql(subquery)
-          transformedQuery.UPDATE.where = ['exists', transformedSubquery]
-          transformedQuery.UPDATE.entity = transformedFrom
+          transformedQuery[prop].where = ['exists', transformedSubquery]
+          if(prop === 'UPDATE')
+            transformedQuery.UPDATE.entity = transformedFrom
+          else
+            transformedQuery.DELETE.from = transformedFrom
         } else {
           transformedQuery[kind].from = translateAssocsToJoins(transformedQuery[kind].from)
         }

--- a/db-service/test/cqn4sql/DELETE.test.js
+++ b/db-service/test/cqn4sql/DELETE.test.js
@@ -77,7 +77,7 @@ describe('DELETE', () => {
 
     // this is the final exists subquery
     const subquery = CQL`
-     SELECT 1 from bookshop.Authors as author
+     SELECT author.ID from bookshop.Authors as author
       left join bookshop.Books as books on books.author_ID = author.ID
      where exists (
       SELECT 1 from bookshop.Books as Books2 where Books2.author_ID = author.ID
@@ -89,11 +89,21 @@ describe('DELETE', () => {
             "ref": [
               "bookshop.Authors"
             ],
-            "as": "author"
+            "as": "author2"
           }
         }
       }`)
-    expected.DELETE.where = ['exists', subquery]
+    expected.DELETE.where = [
+      {
+        list: [
+          {
+            ref: ['author2', 'ID'],
+          },
+        ],
+      },
+      'in',
+      subquery,
+    ]
     expect(query.DELETE).to.deep.equal(expected.DELETE)
   })
 

--- a/db-service/test/cqn4sql/DELETE.test.js
+++ b/db-service/test/cqn4sql/DELETE.test.js
@@ -69,6 +69,33 @@ describe('DELETE', () => {
       }`)
     expect(query.DELETE).to.deep.equal(expected.DELETE)
   })
+  it('DELETE with where exists expansion and path expression', () => {
+    cds.model = cds.compile.for.nodejs(cds.model)
+    const { DELETE } = cds.ql
+    let d = DELETE.from('bookshop.Books:author').where(`books.title = 'Harry Potter'`)
+    const query = cqn4sql(d)
+
+    // this is the final exists subquery
+    const subquery = CQL`
+     SELECT 1 from bookshop.Authors as author
+      left join bookshop.Books as books on books.author_ID = author.ID
+     where exists (
+      SELECT 1 from bookshop.Books as Books2 where Books2.author_ID = author.ID
+     ) and books.title = 'Harry Potter'
+    `
+    const expected = JSON.parse(`{
+      "DELETE": {
+          "from": {
+            "ref": [
+              "bookshop.Authors"
+            ],
+            "as": "author"
+          }
+        }
+      }`)
+    expected.DELETE.where = ['exists', subquery]
+    expect(query.DELETE).to.deep.equal(expected.DELETE)
+  })
 
   it('DELETE with assoc filter and where exists expansion', () => {
     const { DELETE } = cds.ql
@@ -76,73 +103,57 @@ describe('DELETE', () => {
     const query = cqn4sql(d)
 
     const expected = {
-      "DELETE": {
-        "from": {
-          "ref": [
-            "bookshop.AccessGroups"
-          ],
-          "as": "accessGroup"
+      DELETE: {
+        from: {
+          ref: ['bookshop.AccessGroups'],
+          as: 'accessGroup',
         },
-        "where": [
-          "exists",
+        where: [
+          'exists',
           {
-            "SELECT": {
-              "from": {
-                "ref": [
-                  "bookshop.Reproduce"
-                ],
-                "as": "Reproduce"
+            SELECT: {
+              from: {
+                ref: ['bookshop.Reproduce'],
+                as: 'Reproduce',
               },
-              "columns": [
+              columns: [
                 {
-                  "val": 1
-                }
+                  val: 1,
+                },
               ],
-              "where": [
+              where: [
                 {
-                  "ref": [
-                    "Reproduce",
-                    "accessGroup_ID"
-                  ]
+                  ref: ['Reproduce', 'accessGroup_ID'],
                 },
-                "=",
+                '=',
                 {
-                  "ref": [
-                    "accessGroup",
-                    "ID"
-                  ]
+                  ref: ['accessGroup', 'ID'],
                 },
-                "and",
+                'and',
                 {
-                  "xpr": [
+                  xpr: [
                     {
-                      "ref": [
-                        "Reproduce",
-                        "author_ID"
-                      ]
+                      ref: ['Reproduce', 'author_ID'],
                     },
-                    "=",
+                    '=',
                     {
-                      "val": null
-                    }
-                  ]
+                      val: null,
+                    },
+                  ],
                 },
-                "and",
+                'and',
                 {
-                  "ref": [
-                    "Reproduce",
-                    "ID"
-                  ]
+                  ref: ['Reproduce', 'ID'],
                 },
-                "=",
+                '=',
                 {
-                  "val": 99
-                }
-              ]
-            }
-          }
-        ]
-      }
+                  val: 99,
+                },
+              ],
+            },
+          },
+        ],
+      },
     }
     expect(query.DELETE).to.deep.equal(expected.DELETE)
   })

--- a/db-service/test/cqn4sql/UPDATE.test.js
+++ b/db-service/test/cqn4sql/UPDATE.test.js
@@ -70,7 +70,7 @@ describe('UPDATE', () => {
     })
   })
 
-  it('Update with path expressions in where is handled', () => {
+  it.only('Update with path expressions in where is handled', () => {
     const { UPDATE } = cds.ql
     let u = UPDATE.entity({ ref: ['bookshop.Books'] }).where(
       `author.name LIKE '%Bron%' or ( author.name LIKE '%King' and title = 'The Dark Tower') and stock >= 15`,
@@ -84,11 +84,11 @@ describe('UPDATE', () => {
     let expected = UPDATE.entity({ ref: ['bookshop.Books'] }).where(`
     exists (SELECT 1 from bookshop.Books as Books
               left join bookshop.Authors as author on author.ID = Books.author_ID
-              where author.name LIKE '%Bron%' or ( author.name LIKE '%King' and Books.title = 'The Dark Tower') and Books.stock >= 15
+              where author.name LIKE '%Bron%' or ( author.name LIKE '%King' and Books.title = 'The Dark Tower') and Books.stock >= 15 and ( Books2.ID = Books.ID )
             )
   `)
     expected.UPDATE.entity = {
-      as: 'Books',
+      as: 'Books2',
       ref: [
         'bookshop.Books'
       ]


### PR DESCRIPTION
this change enables the usage of path expressions in `where` clauses of `DELETE` queries.

If there is a path expressions found in a `where` of an `DELETE`, the `where` clause is cut out of the `DELETE` and is put into a `where` clause  in a dummy subselect, which is then transformed by `cqn4sql`. The result of the transformation is then put into the `DELETE` again, as `exists <subquery>`.
--> `DELETE.where = ['exists', cqn4sql(subquery)]`

---

based on #325

fix https://github.com/cap-js/cds-dbs/issues/159