### PR TITLE
chore: revert "Should we upgrade to better-sqlite@9? (#312)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5659,9 +5659,9 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.0.0.tgz",
-      "integrity": "sha512-lDxQ9qg/XuUHZG6xzrQaMHkNWl37t35/LPB/VJGV8DdScSuGFNfFSqgscXEd8UIuyk/d9wU8iaMxQa4If5Wqog==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.6.0.tgz",
+      "integrity": "sha512-jwAudeiTMTSyby+/SfbHDebShbmC2MCH8mU2+DXi0WJfv13ypEJm47cd3kljmy/H130CazEvkf2Li//ewcMJ1g==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -10055,7 +10055,7 @@
       "license": "SEE LICENSE",
       "dependencies": {
         "@cap-js/db-service": "^1.3.1",
-        "better-sqlite3": "^9"
+        "better-sqlite3": "^8"
       },
       "engines": {
         "node": ">=16",

--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@cap-js/db-service": "^1.3.1",
-    "better-sqlite3": "^9"
+    "better-sqlite3": "^8"
   },
   "peerDependencies": {
     "@sap/cds": ">=7"


### PR DESCRIPTION
This reverts commit 7d5ac0234c74fa88fdc1dab8b930e6846cedd151. Will re-enable with proper conventional commit message.