### PR TITLE
fix: non-fk access in filter conditions are properly rejected

### DIFF
--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -209,13 +209,21 @@ describe('EXISTS predicate in where', () => {
         )`)
     })
 
-    it.skip('MUST fail if following managed assoc in filter', () => {
+    it('MUST fail if following managed assoc in filter in where exists', () => {
       expect(() =>
         cqn4sql(
           CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[dedication.addressee.name = 'Hasso']`,
           model,
         ),
-      ).to.throw()
+      ).to.throw('Only foreign keys of "addressee" can be accessed in infix filter')
+    })
+    it('MUST fail if following managed assoc in filter', () => {
+      expect(() =>
+        cqn4sql(
+          CQL`SELECT from bookshop.Authors { ID, books[dedication.addressee.name = 'Hasso'].dedication.addressee.name as Hasso }`,
+          model,
+        ),
+      ).to.throw('Only foreign keys of "addressee" can be accessed in infix filter')
     })
 
     it('MUST handle simple where exists with multiple association and also with $self backlink', () => {
@@ -230,7 +238,7 @@ describe('EXISTS predicate in where', () => {
         )`)
     })
 
-    it('MUST handle simple where exists with additional filter, shourcut notation', () => {
+    it('MUST handle simple where exists with additional filter, shortcut notation', () => {
       let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists author[17]`, model)
       expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and author.ID = 17


### PR DESCRIPTION
for assocs embeeded in structures, this check was not executed. This situation can only happen with structured csn. However, better to have it fixed. :)