### PR TITLE
fix: date functions with null value

### DIFF
--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -22,17 +22,16 @@ class SQLiteService extends SQLService {
         const isTime = /^\d{1,2}:\d{1,2}:\d{1,2}$/
         const hasTimezone = /([+-]\d{1,2}:?\d{0,2}|Z)$/
         const toDate = (d, allowTime = false) => {
-          if (d === null) return null
           const date = new Date(allowTime && isTime.test(d) ? `1970-01-01T${d}Z` : hasTimezone.test(d) ? d : d + 'Z')
           if (Number.isNaN(date.getTime())) throw new Error(`Value does not contain a valid ${allowTime ? 'time' : 'date'} "${d}"`)
           return date
         }
-        dbc.function('year', deterministic, d => toDate(d).getUTCFullYear())
-        dbc.function('month', deterministic, d => toDate(d).getUTCMonth() + 1)
-        dbc.function('day', deterministic, d => toDate(d).getUTCDate())
-        dbc.function('hour', deterministic, d => toDate(d, true).getUTCHours())
-        dbc.function('minute', deterministic, d => toDate(d, true).getUTCMinutes())
-        dbc.function('second', deterministic, d => toDate(d, true).getUTCSeconds())
+        dbc.function('year', deterministic, d => d === null ? null : toDate(d).getUTCFullYear())
+        dbc.function('month', deterministic, d => d === null ? null : toDate(d).getUTCMonth() + 1)
+        dbc.function('day', deterministic, d => d === null ? null : toDate(d).getUTCDate())
+        dbc.function('hour', deterministic, d => d === null ? null : toDate(d, true).getUTCHours())
+        dbc.function('minute', deterministic, d => d === null ? null : toDate(d, true).getUTCMinutes())
+        dbc.function('second', deterministic, d => d === null ? null : toDate(d, true).getUTCSeconds())
 
         dbc.function('json_merge', { varargs: true, deterministic: true }, (...args) =>
           args.join('').replace(/}{/g, ','),

--- a/test/scenarios/bookshop/funcs.test.js
+++ b/test/scenarios/bookshop/funcs.test.js
@@ -217,6 +217,14 @@ describe('Bookshop - Functions', () => {
       expect(res.status).to.be.eq(200)
       expect(res.data.value.length).to.be.eq(1)
     })
+
+    test('date function with null value', async () => {
+      const { result } = await SELECT.one(`day(null) as result`)
+      .from('sap.capire.bookshop.Books')
+
+      expect(result).to.be.null
+    })
+
     test.skip('fractionalseconds', async () => {
       // REVISIT: ERROR: Feature is not supported: Method "fractionalseconds" in $filter or $orderby query options
       const res = await GET(


### PR DESCRIPTION
 null values cause type error as e. g. _.getUTCFullYear()_ cannot be called on _null_.
If you have an alternative implementation, I'm open.