### PR TITLE
fix: `cds build` now generates the correct output folder structure for Node.js and Java apps.

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,12 +4,6 @@
 - The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.4.1](https://github.com/cap-js/cds-dbs/compare/postgres-v1.4.0...postgres-v1.4.1) tbd
-
-### Fixed
-
-- `cds build` now generates the correct output folder structure for Node.js and Java apps.
-
 ## [1.4.0](https://github.com/cap-js/cds-dbs/compare/postgres-v1.3.1...postgres-v1.4.0) (2023-11-20)
 
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.4.1](https://github.com/cap-js/cds-dbs/compare/postgres-v1.4.0...postgres-v1.4.1) tbd
+
+### Fixed
+
+- `cds build` now generates the correct output folder structure for Node.js and Java apps.
+
 ## [1.4.0](https://github.com/cap-js/cds-dbs/compare/postgres-v1.3.1...postgres-v1.4.0) (2023-11-20)
 
 

--- a/postgres/lib/build.js
+++ b/postgres/lib/build.js
@@ -2,9 +2,16 @@ const cds = require('@sap/cds')
 const { fs, path } = cds.utils
 
 module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
-
   static hasTask() {
     return cds.requires.db?.kind === 'postgres'
+  }
+
+  init() {
+    if (this.task.dest === this.task.src) {
+      this.task.dest = path.join(this.task.dest, 'gen/pg')
+    } else {
+      this.task.dest = path.resolve(this.task.dest, '../pg')
+    }
   }
 
   async build() {
@@ -15,8 +22,8 @@ module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
     promises.push(this.write({
         dependencies: { '@sap/cds': '^7', '@cap-js/postgres': '^1' },
         scripts: { start: 'cds-deploy' },
-      }).to('pg/package.json'))
-    promises.push(this.write(cds.compile.to.json(model)).to(path.join('pg/db', 'csn.json')))
+      }).to('package.json'))
+    promises.push(this.write(cds.compile.to.json(model)).to(path.join('db', 'csn.json')))
 
     let data
     if (fs.existsSync(path.join(this.task.src, 'data'))) {
@@ -25,7 +32,7 @@ module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
       data = 'csv'
     }
     if (data) {
-      promises.push(this.copy(data).to(path.join('pg/db', 'data')))
+      promises.push(this.copy(data).to(path.join('db', 'data')))
     }
     return Promise.all(promises)
   }

--- a/postgres/lib/build.js
+++ b/postgres/lib/build.js
@@ -16,10 +16,16 @@ module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
     if (!model) return
 
     const promises = []
-    promises.push(this.write({
-        dependencies: { '@sap/cds': '^7', '@cap-js/postgres': '^1' },
-        scripts: { start: 'cds-deploy' },
-      }).to('package.json'))
+    if (fs.existsSync(path.join(this.task.src, 'package.json'))) {
+      promises.push(this.copy(path.join(this.task.src, 'package.json')).to('package.json'))
+    } else {
+      promises.push(
+        this.write({
+          dependencies: { '@sap/cds': '^7', '@cap-js/postgres': '^1' },
+          scripts: { start: 'cds-deploy' },
+        }).to('package.json'),
+      )
+    }
     promises.push(this.write(cds.compile.to.json(model)).to(path.join('db', 'csn.json')))
 
     let data

--- a/postgres/lib/build.js
+++ b/postgres/lib/build.js
@@ -8,7 +8,7 @@ module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
 
   init() {
     // different from the default build output structure
-    this.task.dest = path.join(cds.root, 'gen/pg')
+    this.task.dest = path.join(cds.root, cds.env.build.target !== '.' ? cds.env.build.target : 'gen', 'pg')
   }
 
   async build() {

--- a/postgres/lib/build.js
+++ b/postgres/lib/build.js
@@ -7,13 +7,8 @@ module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
   }
 
   init() {
-    super.init()
     // different from the default build output structure
-    if (cds.env.build.target === '.') {
-      this.task.dest = path.join(this.task.dest, 'pg')
-    } else {
-      this.task.dest = path.join(this.task.dest, '..', 'pg')
-    }
+    this.task.dest = path.join(cds.root, 'gen/pg')
   }
 
   async build() {

--- a/postgres/lib/build.js
+++ b/postgres/lib/build.js
@@ -7,10 +7,11 @@ module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
   }
 
   init() {
-    if (this.task.dest === this.task.src) {
-      this.task.dest = path.join(this.task.dest, 'gen/pg')
+    super.init()
+    if (cds.env.build.target === '.') {
+      this.task.dest = path.join(this.task.dest, 'pg')
     } else {
-      this.task.dest = path.resolve(this.task.dest, '../pg')
+      this.task.dest = path.join(this.task.dest, '..', 'pg')
     }
   }
 

--- a/postgres/lib/build.js
+++ b/postgres/lib/build.js
@@ -8,6 +8,7 @@ module.exports = class PostgresBuildPlugin extends cds.build.BuildPlugin {
 
   init() {
     super.init()
+    // different from the default build output structure
     if (cds.env.build.target === '.') {
       this.task.dest = path.join(this.task.dest, 'pg')
     } else {


### PR DESCRIPTION
- identical output folder structure for node.js and java as documented in Capire
- use existing package.json from db folder instead of generated one
