### PR TITLE
ci: Update actions/checkout and actions/setup-node to v4

### DIFF
--- a/.github/workflows/hana.yml
+++ b/.github/workflows/hana.yml
@@ -22,8 +22,8 @@ jobs:
         node: [18]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
         node: [18]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'


### PR DESCRIPTION
See

 - https://github.com/actions/checkout/releases/tag/v4.0.0
 - https://github.com/actions/setup-node/releases/tag/v4.0.0

Major version change due to internal upgrade from Node 16 to 20.