### PR TITLE
fix(localized): `ref`s in subqueries in `from` are translated

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -946,6 +946,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
       outerQueries.push(inferred)
       Object.defineProperty(q, 'outerQueries', { value: outerQueries })
     }
+    if (isLocalized(inferred.target)) q.SELECT.localized = true
     return cqn4sql(q, model)
   }
 

--- a/db-service/test/cqn4sql/localized.test.js
+++ b/db-service/test/cqn4sql/localized.test.js
@@ -92,7 +92,6 @@ describe('localized', () => {
                       BPLocalized.title,
                     }`)
   })
-  // TODO dont shadow query alias
   it('performs simple replacement of ref within subquery', () => {
     const q = CQL`SELECT from bookshop.Books {ID, title, (SELECT title from bookshop.Books) as foo}`
     q.SELECT.localized = true
@@ -104,6 +103,19 @@ describe('localized', () => {
                       Books.title,
                       (SELECT Books2.title from localized.bookshop.Books as Books2) as foo
                     }`)
+  })
+  it('performs simple replacement of ref within subquery in from', () => {
+    const q = CQL`SELECT from (SELECT Books.title from bookshop.Books) as foo { foo.title }`
+    q.SELECT.localized = true
+    let query = cqn4sql(q, model)
+    expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`
+        SELECT from (
+            SELECT Books.title from localized.bookshop.Books as Books
+          ) as foo
+        {
+          foo.title,
+        }`
+    )
   })
   it('performs no replacement of ref within subquery if main query has ”@cds.localized: false”', () => {
     const q = CQL`SELECT from bookshop.BP {ID, title, (SELECT title from bookshop.Books) as foo}`


### PR DESCRIPTION
if the main queries target is `localized` and this is not overwritten by `cds.localized: false`, `ref`erences in subqueries will also be translated. This was already the case for subqueries in columns or expands. The responsible code has been moved to a central entry point for all subqueries, hence this now also covers subqueries in `from`.