### PR TITLE
test: remove accidental (?) .only

### DIFF
--- a/sqlite/test/deep/deepInputProcessing.test.js
+++ b/sqlite/test/deep/deepInputProcessing.test.js
@@ -61,7 +61,7 @@ describe('UUID Generation', () => {
     expect(resUpdate.data.toOneChild.ID).toEqual(resUpdate.data.toOneChild.toManySubChild[1].backlink_ID)
   })
 
-  test.only('generate UUID on update programmatically', async () => {
+  test('generate UUID on update programmatically', async () => {
     const uuid = cds.utils.uuid()
     await cds.db
       .insert({


### PR DESCRIPTION
in #32 a test has been added, I assume it should not be the `.only` one run as part of this test suite. @johannes-vogel 