### PR TITLE
fix(cqn2sql): supporting calculated elements

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -394,7 +394,7 @@ class CQN2SQLRenderer {
       return // REVISIT: mtx sends an insert statement without entries and no reference entity
     }
     const columns = elements
-      ? ObjectKeys(elements).filter(c => c in elements && !elements[c].virtual && !elements[c].isAssociation)
+      ? ObjectKeys(elements).filter(c => c in elements && !elements[c].virtual && !elements[c].value && !elements[c].isAssociation)
       : ObjectKeys(INSERT.entries[0])
 
     /** @type {string[]} */

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -516,6 +516,7 @@ class HANAService extends SQLService {
       return foreignKeys
     }
 
+    // REVISIT: Find a way to avoid overriding the whole function redundantly
     INSERT_entries(q) {
       this.values = undefined
       const { INSERT } = q
@@ -527,7 +528,7 @@ class HANAService extends SQLService {
         return // REVISIT: mtx sends an insert statement without entries and no reference entity
       }
       const columns = elements
-        ? ObjectKeys(elements).filter(c => c in elements && !elements[c].virtual && !elements[c].isAssociation)
+        ? ObjectKeys(elements).filter(c => c in elements && !elements[c].virtual && !elements[c].value && !elements[c].isAssociation)
         : ObjectKeys(INSERT.entries[0])
       this.columns = columns.filter(elements ? c => !elements[c]?.['@cds.extension'] : () => true)
 


### PR DESCRIPTION
This fix is important to support calculated elements. Without it we generate inserts that try to fill in data to them, even if there's no data in the input data payload. 

Would be good if we could public a hotfix asap. I wanted to use it in a demo on Monday. 