### PR TITLE
fix: do not rely on db constraints for deep delete

### DIFF
--- a/db-service/lib/SQLService.js
+++ b/db-service/lib/SQLService.js
@@ -153,7 +153,8 @@ class SQLService extends DatabaseService {
   }
 
   get onDELETE() {
-    return super.onDELETE = cds.env.features.assert_integrity === 'db' ? this.onSIMPLE : deep_delete
+    // REVISIT: It's not yet 100 % clear under which circumstances we can rely on db constraints
+    return super.onDELETE = /* cds.env.features.assert_integrity === 'db' ? this.onSIMPLE : */ deep_delete
     async function deep_delete(/** @type {Request} */ req) {
       let { compositions } = req.target
       if (compositions) {


### PR DESCRIPTION
For draft tables, no db constraints for cascading delete is added.
Also no db constraints are added for compositions of one.

We should first clarify under which circumstances we can rely on it.