### PR TITLE
fix: Ensure globally unique aliases with large expand queries

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -266,6 +266,8 @@ class HANAService extends SQLService {
       this.temporary = this.temporary || []
       this.temporaryValues = this.temporaryValues || []
 
+      const { limit, one, orderBy, expand, columns, localized, count, from, parent } = q.SELECT
+
       const walkAlias = q => {
         if (q.args) return q.as || walkAlias(q.args[0])
         if (q.SELECT?.from) return walkAlias(q.SELECT?.from)
@@ -273,9 +275,8 @@ class HANAService extends SQLService {
       }
       const alias = walkAlias(q)
       q.as = alias
+      q.alias = `${parent ? parent.alias + '.' : ''}${alias}`
       const src = q
-
-      const { limit, one, orderBy, expand, columns, localized, count, from, parent } = q.SELECT
 
       // When one of these is defined wrap the query in a sub query
       if (expand || (parent && (limit || one || orderBy))) {
@@ -381,8 +382,9 @@ class HANAService extends SQLService {
 
       if (expand === 'root') {
         this.cqn = q
-        this.withclause.unshift(`${this.quote(alias)} as (${this.sql})`)
-        this.temporary.unshift({ blobs: this._blobs, select: `SELECT ${this._outputColumns} FROM ${this.quote(alias)}` })
+        const fromSQL = this.from({ ref: [q.alias] })
+        this.withclause.unshift(`${fromSQL} as (${this.sql})`)
+        this.temporary.unshift({ blobs: this._blobs, select: `SELECT ${this._outputColumns} FROM ${fromSQL}` })
         if (this.values) {
           this.temporaryValues.unshift(this.values)
           this.values = this.temporaryValues.flat()
@@ -417,7 +419,7 @@ class HANAService extends SQLService {
 
                 x.SELECT.from = {
                   join: 'inner',
-                  args: [{ ref: [parent.as], as: parent.as }, x.SELECT.from],
+                  args: [{ ref: [parent.alias], as: parent.as }, x.SELECT.from],
                   on: x.SELECT.where,
                   as: x.SELECT.from.as,
                 }

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -273,9 +273,8 @@ class HANAService extends SQLService {
         if (q.SELECT?.from) return walkAlias(q.SELECT?.from)
         return q.as
       }
-      const alias = walkAlias(q)
-      q.as = alias
-      q.alias = `${parent ? parent.alias + '.' : ''}${alias}`
+      q.as = walkAlias(q)
+      const alias = q.alias = `${parent ? parent.alias + '.' : ''}${q.as}`
       const src = q
 
       // When one of these is defined wrap the query in a sub query
@@ -382,7 +381,7 @@ class HANAService extends SQLService {
 
       if (expand === 'root') {
         this.cqn = q
-        const fromSQL = this.from({ ref: [q.alias] })
+        const fromSQL = this.from({ ref: [alias] })
         this.withclause.unshift(`${fromSQL} as (${this.sql})`)
         this.temporary.unshift({ blobs: this._blobs, select: `SELECT ${this._outputColumns} FROM ${fromSQL}` })
         if (this.values) {


### PR DESCRIPTION
The current implementation relied upon the unique aliases provided by `cqn4sql`. This works in most scenarios, but stops working for the `HANAService` specifically as the aliases are only locally unique. While the `WITH` clauses requires globally unique aliases. Therefor this change uses the parent alias to ensure globally unique aliases.

```cql
SELECT Books {
  author {
    texts { * } -- Alias will be texts
    books {
      texts { * } -- Alias will be texts2
    }
  },
  genre {
    texts { * } -- Alias will be texts
  }
}
```

with this change the aliases for the `HANAService` are transformed into

```cql
SELECT Books {
  author {
    texts { * } -- Alias will be Books.author.texts
    books {
      texts { * } -- Alias will be Books.author.books.texts2
    }
  },
  genre {
    texts { * } -- Alias will be Books.genre.texts
  }
}
```
