### PR TITLE
fix: enumeration issue with session context in @cap-js/hana

### DIFF
--- a/db-service/lib/common/session-context.js
+++ b/db-service/lib/common/session-context.js
@@ -28,5 +28,19 @@ class TemporalSessionContext extends SessionContext {
   }
 }
 
+// Set all getters as enumerable
+const iterate = { enumerable: true }
+const getters = (obj) => {
+  const prot = obj.prototype
+  const patch = {}
+  for (const [key, value] of Object.entries(Object.getOwnPropertyDescriptors(prot))) {
+    if (!value.get) continue
+    patch[key] = iterate
+  }
+  Object.defineProperties(prot, patch)
+}
+getters(SessionContext)
+getters(TemporalSessionContext)
+
 // REVISIT: only set temporal context if required!
 module.exports = TemporalSessionContext

--- a/hana/lib/drivers/hana-client.js
+++ b/hana/lib/drivers/hana-client.js
@@ -45,7 +45,9 @@ class HANAClientDriver extends driver {
   }
 
   set(variables) {
-    Object.keys(variables).forEach(k => this._native.setClientInfo(k, variables[k]))
+    for(const key in variables) {
+      this._native.setClientInfo(key, variables[key])
+    }
   }
 
   async prepare(sql) {

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -40,7 +40,8 @@ class HDBDriver extends driver {
 
   set(variables) {
     const clientInfo = this._native._connection.getClientInfo()
-    Object.keys(variables).forEach(k => clientInfo.setProperty(k, variables[k]))
+    clientInfo._updatedProperties = variables
+    clientInfo._properties = variables
   }
 
   async validate() {

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -40,8 +40,9 @@ class HDBDriver extends driver {
 
   set(variables) {
     const clientInfo = this._native._connection.getClientInfo()
-    clientInfo._updatedProperties = variables
-    clientInfo._properties = variables
+    for(const key in variables) {
+      clientInfo.setProperty(key, variables[key])
+    }
   }
 
   async validate() {


### PR DESCRIPTION
Made it so that the getters are defined as enumerable. Allowing the hana driver to use simple `in` loops.