### PR TITLE
test(deep-update): add regression test for huge payloads

### DIFF
--- a/test/compliance/UPDATE.test.js
+++ b/test/compliance/UPDATE.test.js
@@ -1,4 +1,9 @@
+const cds = require('../cds.js')
+
 describe('UPDATE', () => {
+  const { expect, data } = cds.test(__dirname + '/resources')
+  data.autoIsolation(true)
+
   describe('entity', () => {
     test.skip('missing', () => {
       throw new Error('not supported')
@@ -14,6 +19,20 @@ describe('UPDATE', () => {
   describe('where', () => {
     test.skip('missing', () => {
       throw new Error('not supported')
+    })
+  })
+
+  describe('deep update', () => {
+    test('huge deep update does not cause sql exception', async () => {
+      // sqlite limit of placeholders is 32766 -> 9. of https://www.sqlite.org/limits.html
+      await INSERT.into('compositions.Travel').entries({
+        ID: 4711,
+        bookings: (new Array(33000).fill(0).map((_, i) => ({ ID: i})))
+      })
+
+      // deep update that has to read all entries
+      const result = await UPDATE('compositions.Travel[ID=4711]').set({ bookings: [{ID: 1, name: 'foo' }]})
+      expect(result).not.to.be.undefined
     })
   })
 })

--- a/test/compliance/resources/db/compositions/index.cds
+++ b/test/compliance/resources/db/compositions/index.cds
@@ -1,0 +1,20 @@
+namespace compositions;
+
+entity Supplement {
+  key ID : Integer;
+  name  : String(111);
+  booking : Association to Booking;
+}
+
+entity Booking {
+  key ID : Integer;
+  name   : String(111);
+  travel: Association to Travel;
+  supplements  : Composition of many Supplement on supplements.booking = $self;
+}
+
+entity Travel {
+  key ID : Integer;
+  name   : String(111);
+  bookings  : Composition of many Booking on bookings.travel = $self;
+}

--- a/test/compliance/resources/db/index.cds
+++ b/test/compliance/resources/db/index.cds
@@ -1,5 +1,6 @@
 using from './basic';
 using from './complex';
+using from './compositions';
 using from './edge';
 using from './hana';
 using from './timestamps';


### PR DESCRIPTION
We've received a ticket for old db implementation that the deep update does not accept payloads with lots of children.
This test ensures that our new implementation is (and stays) capable of it.

The max number of placeholders for sqlite is 32766 which is documented here: https://www.sqlite.org/limits.html
The max number of placeholders for hana is ? → from experience somewhat above 3000
The max number of placeholders for postgres is 65536 → https://github.com/brianc/node-postgres/issues/2579 