### PR TITLE
fix: Restore former deep upsert behavior / error

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -632,7 +632,8 @@ class CQN2SQLRenderer {
       if (keys.includes(c)) return false //> keys go into ON CONFLICT clause
       let e = elements[c]
       if (!e) return true //> pass through to native SQL columns not in CDS model
-      if (e.virtual) return true
+      if (e.virtual) return true //> skip virtual elements
+      if (e.value) return true //> skip calculated elements
       // if (e.isAssociation) return true //> this breaks a a test in @sap/cds -> need to follow up how to correctly handle deep upserts
       else return true
     }).map(c => `${this.quote(c)} = excluded.${this.quote(c)}`)

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -629,9 +629,9 @@ class CQN2SQLRenderer {
 
     let updateColumns = q.UPSERT.entries ? Object.keys(q.UPSERT.entries[0]) : this.columns
     updateColumns = updateColumns.filter(c => {
+      if (keys.includes(c)) return false //> keys go into ON CONFLICT clause
       let e = elements[c]
       if (!e) return true //> pass through to native SQL columns not in CDS model
-      if (e.key) return true //> keys go into ON CONFLICT clause
       if (e.virtual) return true
       // if (e.isAssociation) return true //> this breaks a a test in @sap/cds -> need to follow up how to correctly handle deep upserts
       else return true

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -624,13 +624,18 @@ class CQN2SQLRenderer {
     const elements = q.target?.elements || {}
     let sql = this.INSERT({ __proto__: q, INSERT: UPSERT })
     let keys = q.target?.keys
-    if (!keys) return (this.sql = sql) // REVISIT: We should converge q.target and q._target
+    if (!keys) return this.sql = sql
     keys = Object.keys(keys).filter(k => !keys[k].isAssociation)
 
     let updateColumns = q.UPSERT.entries ? Object.keys(q.UPSERT.entries[0]) : this.columns
-    updateColumns = updateColumns
-      .filter(c => c in elements && !elements[c].virtual && !elements[c].value && !elements[c].isAssociation && !keys.includes(c))
-      .map(c => `${this.quote(c)} = excluded.${this.quote(c)}`)
+    updateColumns = updateColumns.filter(c => {
+      let e = elements[c]
+      if (!e) return true //> pass through to native SQL columns not in CDS model
+      if (e.key) return true //> keys go into ON CONFLICT clause
+      if (e.virtual) return true
+      // if (e.isAssociation) return true //> this breaks a a test in @sap/cds -> need to follow up how to correctly handle deep upserts
+      else return true
+    }).map(c => `${this.quote(c)} = excluded.${this.quote(c)}`)
 
     // temporal data
     keys.push(...Object.values(q.target.elements).filter(e => e['@cds.valid.from']).map(e => e.name))


### PR DESCRIPTION
Excluding associations from UPSERT broke a test in @sap/cds, so this PR restores the former behavior for the time being which let updates to associations slip through and fail with a database error. 

We need to follow up on what the correct behavior should be...