### PR TITLE
feat: static deep operations

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -303,6 +303,8 @@ class CQN2SQLRenderer {
     if (from.SELECT) return _aliased(`(${this.SELECT(from)})`)
     if (from.join)
       return `${this.from(from.args[0])} ${from.join} JOIN ${this.from(from.args[1])} ON ${this.where(from.on)}`
+    if (from.func)
+      return this.func(from)
   }
 
   /**
@@ -586,7 +588,7 @@ class CQN2SQLRenderer {
     const columns = (this.columns = (INSERT.columns || ObjectKeys(elements)).filter(
       c => c in elements && !elements[c].virtual && !elements[c].isAssociation,
     ))
-    this.sql = `INSERT INTO ${entity}${alias ? ' as ' + this.quote(alias) : ''} (${columns}) ${this.SELECT(
+    this.sql = `INSERT INTO ${this.quote(entity)}${alias ? ' as ' + this.quote(alias) : ''} (${columns}) ${this.SELECT(
       cqn4sql(INSERT.as),
     )}`
     this.entries = [this.values]
@@ -656,7 +658,7 @@ class CQN2SQLRenderer {
    * @returns {string} SQL
    */
   UPDATE(q) {
-    const { entity, with: _with, data, where } = q.UPDATE    
+    const { entity, with: _with, data, where } = q.UPDATE
     const elements = q.target?.elements
     let sql = `UPDATE ${this.name(entity.ref?.[0] || entity)}`
     if (entity.as) sql += ` AS ${entity.as}`
@@ -813,8 +815,8 @@ class CQN2SQLRenderer {
       case 'object':
         if (val === null) return 'NULL'
         if (val instanceof Date) return `'${val.toISOString()}'`
-        if (val instanceof Readable) ; // go on with default below
-        else if (Buffer.isBuffer(val)) ; // go on with default below
+        if (val instanceof Readable); // go on with default below
+        else if (Buffer.isBuffer(val)); // go on with default below
         else if (is_regexp(val)) val = val.source
         else val = JSON.stringify(val)
       case 'string': // eslint-disable-line no-fallthrough

--- a/db-service/lib/deep-queries.js
+++ b/db-service/lib/deep-queries.js
@@ -35,6 +35,8 @@ async function onDeep(req, next) {
     if (query.UPDATE) return this.onUPDATE({ query })
     if (query.DELETE) return this.onSIMPLE({ query })
   }))
+
+  if (query.kind === 'UPDATE') return beforeData.length
   return res[0] ?? 0 // TODO what todo with multiple result responses?
 }
 

--- a/db-service/lib/deep2flat.js
+++ b/db-service/lib/deep2flat.js
@@ -1,0 +1,112 @@
+const cds = require('@sap/cds/lib')
+const { Readable } = require('stream')
+
+const OP = {}
+
+module.exports = function (q) {
+  const kind = q.kind || Object.keys(q)[0]
+  const ret = OP[kind].call(this, q)
+  if (ret?.length > 1) {
+    const func = new Function(['Readable', 'children'], ret)
+    return func
+  }
+}
+
+OP.INSERT = function (q, path = [], targets = {}) {
+  const kind = q.kind || Object.keys(q)[0]
+  const INSERT = q[kind] || q.INSERT || q.UPSERT
+  const { target } = q
+  // Only INSERT.entries get deep logic
+  if (INSERT.rows) return ''
+  const { compositions } = target
+
+  let into = INSERT.into
+  if (typeof into === 'string') into = { ref: [into] }
+
+  if (path.find(c => c.name === q.target.name)) return ''
+  const isRoot = path.length === 0
+  path.push(q.target)
+  targets[q.target.name] = (targets[q.target.name] || 0) + 1
+
+  const label = `l${path.length}`
+  let js = `{
+  ${isRoot ? `toStream = entries => {
+  const stream = Readable.from(this.class.CQN2SQL.prototype.INSERT_entries_stream(entries))
+  stream.type = 'json'
+  return stream
+}` : ''}
+  ${isRoot ? 'const entries = {}' : ''}
+  ${isRoot ? `entries[${JSON.stringify(target.name)}] = children` : ''}
+  const parents = children`
+
+  const needDeep = {}
+  for (const c in compositions) {
+    const t = compositions[c].target
+    if (targets[t] === undefined) {
+      needDeep[t] = true
+      targets[t] = 0
+    }
+  }
+
+  // Compute all compositions
+  for (const c in compositions) {
+    const element = compositions[c]
+    const target = cds.model.definitions[element.target] // REVISIT: element._target is the actual reference
+
+    const ins = cds.ql.UPSERT.into({ ref: [...into.ref, c] })
+    const next = needDeep[target.name] ? OP.INSERT.call(this, ins, path, targets).replace(/\n/g, '\n  ') : ''
+    /* TODO: for UPDATE / UPSERT
+    const del = cds.ql.DELETE.from({
+      ref: [...into.ref, {
+        id: c,
+        where: ['not', { list: ObjectKeys(target.keys).map(k => ({ ref: [k] })) }, 'in', { list: [] }]
+      }]
+    })
+    */
+    js = `${js}
+  ${label}:{
+    const children = entries[${JSON.stringify(target.name)}] ??= []
+    for(const p of parents) {
+      const child = p[${JSON.stringify(c)}]
+      if(!child) continue // TODO: throw clear error when child is not the correct type
+      ${element.is2one ? 'c = child' : 'for(const c of child) {'}
+        ${element._foreignKeys.map(l => `c[${JSON.stringify(l.childElement.name)}] = p[${JSON.stringify(l.parentElement.name)}]`).join('      \n')}
+        children.push(c)
+      ${element.is2one ? '' : '}'}
+    }
+    ${next ? `if(!children.length) break ${label}` : ''}
+    ${next}
+  }
+`
+  }
+
+  // Remove current target from path
+  path.pop()
+
+  if (isRoot) {
+    const queries = Object.keys(targets).map(t => {
+      const { sql } = this.cqn2sql(cds.ql.INSERT([]).into(t))
+      return `this._insert({
+  sql: ${JSON.stringify(sql)},
+  entries: [[toStream(entries[${JSON.stringify(t)}])]],
+  cqn: {INSERT:{into:{ref:[${JSON.stringify(t)}]}}}
+})`
+    })
+    js = `${js}
+  return Promise.all([
+  ${queries.join(',\n')}
+  ])
+}`
+  } else {
+    js = `${js}
+}`
+  }
+
+  return js
+}
+
+OP.UPDATE = ({ UPDATE, target, elements }) => {
+  return []
+}
+
+const ObjectKeys = o => (o && [...ObjectKeys(o.__proto__), ...Object.keys(o)]) || []

--- a/test/scenarios/bookshop/delete.test.js
+++ b/test/scenarios/bookshop/delete.test.js
@@ -16,7 +16,7 @@ describe('Bookshop - Delete', () => {
       { ID: 998 },
       {
         ID: 1,
-        toB: {
+        toB: [{
           ID: 12,
           toA: [{ ID: 121 }],
           toC: [
@@ -35,11 +35,11 @@ describe('Bookshop - Delete', () => {
               ],
             },
           ],
-        },
-        toC: {
+        }],
+        toC: [{
           ID: 13,
           toA: [{ ID: 13 }],
-        },
+        }],
       },
     ])
     const del = DELETE.from('sap.capire.bookshop.A').where('ID = 1')


### PR DESCRIPTION
Currently all deep operations are calculated on the fly and rely on reading the current state of the database and calculating the difference. This PR targets to no longer calculate the deep operation every time and instead prepares all action based up on the metadata. Creating a `js` function for `SQLite` and a `SQL` procedure for `HANA`.

For the `INSERT` case it is only possible that all deep operations will with `INSERT` statements as well. As it is required that the root entry does not exist in the database and therefor all `compositions` cannot exist on the database either.

For the `UPDATE` and `UPSERT` case it is required to split it into the correct `UPDATE`. `UPSERT` and `DELETE` queries. As the entries might already exist on the database and require to be removed accordingly.
