### PR TITLE
fix(cqn4sql): expand structured keys in on-conditions

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1748,7 +1748,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           else {
             const lhsLeafArt = lhs.ref && lhs.$refLinks[lhs.$refLinks.length - 1].definition
             const rhsLeafArt = rhs.ref && rhs.$refLinks[rhs.$refLinks.length - 1].definition
-            if (lhsLeafArt?.target || rhsLeafArt?.target) {
+            if (lhsLeafArt?.target && rhsLeafArt?.target || lhsLeafArt?.elements && rhsLeafArt?.elements) {
               if (rhs.$refLinks[0].definition !== assocRefLink.definition) {
                 rhs.ref.unshift(targetSideRefLink.alias)
                 rhs.$refLinks.unshift(targetSideRefLink)

--- a/db-service/test/bookshop/db/schema.cds
+++ b/db-service/test/bookshop/db/schema.cds
@@ -398,3 +398,13 @@ entity PartialStructuredKey {
     author : Association to Authors;
     accessGroup : Composition of AccessGroups;
   }
+
+entity Unmanaged {
+  key struct: {
+    leaf: Int16;
+    toBook: Association to Books;
+  };
+  field: Integer;
+  // needs to be expanded in join-conditions
+  toSelf: Association to Unmanaged on struct = toSelf.struct;
+}

--- a/db-service/test/cqn4sql/tupleExpansion.test.js
+++ b/db-service/test/cqn4sql/tupleExpansion.test.js
@@ -404,4 +404,19 @@ describe('Structural comparison', () => {
       )
     })
   })
+  it('Struct needs to be unfolded in on-condition of join', () => {
+    const queryString = `SELECT from bookshop.Unmanaged {
+      toSelf.field
+    }`
+
+    const expected = CQL`SELECT from bookshop.Unmanaged as Unmanaged
+    left join bookshop.Unmanaged as toSelf
+    on Unmanaged.struct_leaf = toSelf.struct_leaf and Unmanaged.struct_toBook_ID = toSelf.struct_toBook_ID {
+      toSelf.field as toSelf_field
+    }
+    `
+    // const unfolded = cds.compile.for.nodejs(JSON.parse(JSON.stringify(model)))
+    const res = cqn4sql(CQL(queryString), model)
+      expect(res).to.eql(expected)
+  })
 })


### PR DESCRIPTION
this was forgotten and becomes especially important with universal csn in the context of lean draft. Where a `SiblingEntity` association might have a structured key comparison in the on condition.