### PR TITLE
fix(`cqn4sql`): only transform list if necessary

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1276,7 +1276,10 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
             transformedTokenStream.push({ list: [] })
           }
         } else {
-          transformedTokenStream.push({ list: getTransformedTokenStream(token.list, $baseLink) })
+          const { list } = token
+          if (list.every(e => e.val)) // no need for transformation
+            transformedTokenStream.push({ list })
+          else transformedTokenStream.push({ list: getTransformedTokenStream(list, $baseLink) })
         }
       } else if (tokenStream.length === 1 && token.val && $baseLink) {
         // infix filter - OData variant w/o mentioning key --> flatten out and compare each leaf to token.val

--- a/db-service/test/cqn4sql/DELETE.test.js
+++ b/db-service/test/cqn4sql/DELETE.test.js
@@ -107,6 +107,82 @@ describe('DELETE', () => {
     expect(query.DELETE).to.deep.equal(expected.DELETE)
   })
 
+  it('dont mess up everything', () => {
+    const query = {
+      DELETE: {
+        from: {
+          ref: [
+            {
+              id: 'bookshop.Books',
+              where: [
+                {
+                  ref: ['ID'],
+                },
+                'in',
+                {
+                  list: [
+                    {
+                      val: 'b6248f67-6f8b-4816-a096-0b65c2349143',
+                    },
+                  ],
+                },
+              ],
+            },
+            'author',
+          ],
+        },
+      },
+    }
+
+    const expected = {
+      DELETE: {
+        from: {
+          ref: ['bookshop.Authors'],
+          as: 'author',
+        },
+        where: [
+          'exists',
+          {
+            SELECT: {
+              from: {
+                ref: ['bookshop.Books'],
+                as: 'Books',
+              },
+              columns: [
+                {
+                  val: 1,
+                },
+              ],
+              where: [
+                {
+                  ref: ['Books', 'author_ID'],
+                },
+                '=',
+                {
+                  ref: ['author', 'ID'],
+                },
+                'and',
+                {
+                  ref: ['Books', 'ID'],
+                },
+                'in',
+                {
+                  list: [
+                    {
+                      val: 'b6248f67-6f8b-4816-a096-0b65c2349143',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    const res = cqn4sql(query)
+    expect(res).to.deep.equal(expected)
+  })
+
   it('DELETE with assoc filter and where exists expansion', () => {
     const { DELETE } = cds.ql
     let d = DELETE.from('bookshop.Reproduce[author = null and ID = 99]:accessGroup')

--- a/db-service/test/cqn4sql/DELETE.test.js
+++ b/db-service/test/cqn4sql/DELETE.test.js
@@ -107,7 +107,7 @@ describe('DELETE', () => {
     expect(query.DELETE).to.deep.equal(expected.DELETE)
   })
 
-  it('dont mess up everything', () => {
+  it('in a list with exactly one val, dont transform to key comparison', () => {
     const query = {
       DELETE: {
         from: {


### PR DESCRIPTION
because of odata special magic, a tokenstream with `length === 1` which only has a value, is transformed into a full key tuple comparison, e.g. to make this possible: `select from bookshop.Books[42]`. If we now have a list, with exactly one entry, the same logic kicked in and transformed the single value in the token stream to such a key comparison.

to fix this, we now skip processing of lists which only consist of values, which circumvents the described issue.