### PR TITLE
chore: test for xpr support in functions

### DIFF
--- a/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
+++ b/db-service/test/cqn2sql/__snapshots__/select.test.js.snap
@@ -85,6 +85,28 @@ exports[`cqn2sql complex combinations Exists in object mode in complex where 1`]
 
 exports[`cqn2sql complex combinations WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET 1`] = `"SELECT Foo.x + 1 as foo1,Foo.b,Foo.c FROM Foo as Foo WHERE Foo.ID = 111 GROUP BY Foo.x HAVING Foo.x < 9 ORDER BY c ASC LIMIT 11 OFFSET 22"`;
 
+exports[`cqn2sql functions new notation function with multiple xpr 1`] = `"SELECT replace_regexpr(Foo.a,5,? flag ? in ? with ?) as replaced FROM Foo as Foo"`;
+
+exports[`cqn2sql functions new notation function with multiple xpr 2`] = `
+[
+  "A",
+  "i",
+  "ABC-abc-AAA-aaa",
+  "B",
+]
+`;
+
+exports[`cqn2sql functions new notation function with xpr 1`] = `"SELECT replace_regexpr(? flag ? in ? with ?) as replaced FROM Foo as Foo"`;
+
+exports[`cqn2sql functions new notation function with xpr 2`] = `
+[
+  "A",
+  "i",
+  "ABC-abc-AAA-aaa",
+  "B",
+]
+`;
+
 exports[`cqn2sql functions new notation in filter with 1 arg new notation 1`] = `
 {
   "sql": "SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE lower(Foo.c) = ?",

--- a/db-service/test/cqn2sql/select.test.js
+++ b/db-service/test/cqn2sql/select.test.js
@@ -307,6 +307,50 @@ describe('cqn2sql', () => {
   })
 
   describe('functions new notation', () => {
+    test('function with xpr', () => {
+      const { sql, values } = cqn2sql({
+        SELECT: {
+          from: { ref: ['Foo'] },
+          columns: [
+            {
+              func: 'replace_regexpr',
+              args: [
+                {
+                  xpr: [{ val: 'A' }, 'flag', { val: 'i' }, 'in', { val: 'ABC-abc-AAA-aaa' }, 'with', { val: 'B' }],
+                },
+              ],
+              as: 'replaced',
+            },
+          ],
+        },
+      })
+      expect(sql).toMatchSnapshot()
+      expect(values).toMatchSnapshot()
+    })
+
+    test('function with multiple xpr', () => {
+      const { sql, values } = cqn2sql({
+        SELECT: {
+          from: { ref: ['Foo'] },
+          columns: [
+            {
+              func: 'replace_regexpr',
+              args: [
+                { ref: ['a'] },
+                { val: 5 },
+                {
+                  xpr: [{ val: 'A' }, 'flag', { val: 'i' }, 'in', { val: 'ABC-abc-AAA-aaa' }, 'with', { val: 'B' }],
+                },
+              ],
+              as: 'replaced',
+            },
+          ],
+        },
+      })
+      expect(sql).toMatchSnapshot()
+      expect(values).toMatchSnapshot()
+    })
+
     test('in orderby with 1 arg new notation', () => {
       const { sql } = cqn2sql({
         SELECT: {


### PR DESCRIPTION
Xpr with combinations of vals/refs should not have any additional brackets.