### PR TITLE
fix: INSERT entries containing undefined values

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -479,10 +479,11 @@ class CQN2SQLRenderer {
 
           buffer += '"'
         } else {
+          if (val === undefined) continue
           if (elements[key]?.type in BINARY_TYPES) {
             val = transformBase64(val)
           }
-          buffer += `${keyJSON}${val === undefined ? 'null' : JSON.stringify(val)}`
+           buffer += `${keyJSON}${JSON.stringify(val)}`
         }
       }
       buffer += '}'

--- a/test/compliance/resources/db/basic/literals/basic.literals.string.js
+++ b/test/compliance/resources/db/basic/literals/basic.literals.string.js
@@ -12,6 +12,20 @@ module.exports = [
     blob: null,
   },
   {
+    string: undefined,
+    char: undefined,
+    short: undefined,
+    medium: undefined,
+    large: undefined,
+    blob: undefined,
+    '=string': null,
+    '=char': null,
+    '=short': null,
+    '=medium': null,
+    '=large': null,
+    '=blob': null,
+  },
+  {
     string: 'Simple String',
   },
   {


### PR DESCRIPTION
`undefined` values in `INSERT.entries ` were previously replaced with `null` leading to the problem with fields with `default` values.