### PR TITLE
fix: fill in keys from where also for CREATE

### DIFF
--- a/db-service/lib/fill-in-keys.js
+++ b/db-service/lib/fill-in-keys.js
@@ -57,7 +57,7 @@ const generateUUIDandPropagateKeys = (entity, data, event) => {
 module.exports = async function fill_in_keys(req, next) {
   // REVISIT dummy handler until we have input processing
   if (!req.target || !this.model || req.target._unresolved) return next()
-  if (req.event === 'UPDATE') {
+  if (req.event === 'UPDATE' || req.event === 'CREATE') {
     // REVISIT for deep update we need to inject the keys first
     enrichDataWithKeysFromWhere (req.data, req, this)
   }


### PR DESCRIPTION
for a request like 
```
.post(`/Orders(ID=${rootID},IsActiveEntity=true)/items`)
```
we need to propagate `rootID` to the `items` insert as foreign key.

fixes `'cds/tests/_runtime/odata/__tests__/integration/draft-create.test.js',` for `ucsn2`