### PR TITLE
fix: dont insert structured elements

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -692,7 +692,8 @@ class CQN2SQLRenderer {
     if (_with) _add(_with, x => this.expr(x))
     function _add(data, sql4) {
       for (let c in data) {
-        if (!elements || (c in elements && !elements[c].virtual)) {
+        const alreadyFlat = elements[c].elements && cds.model.meta.unfolded?.includes('structs')
+        if (!alreadyFlat && (!elements || (c in elements && !elements[c].virtual))) {
           columns.push({ name: c, sql: sql4(data[c]) })
         }
       }


### PR DESCRIPTION
for `ucsn2` the `taget.elements` include the structures as well as the leafs.

```cds
placeOfPrinting : GeoPosition;
…
  type GeoPosition {
    latitude : Double;
    longitude : Double;
  }
```

--> do not insert `placeOfPrinting` as part of the `UPDATE`

fixes `'cds/tests/_runtime/rest/__tests__/update.test.js'`