### PR TITLE
fix(ucsn): Support $self.<element> in on conditions

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1774,13 +1774,13 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
             // naive assumption: if first step is the association itself, all following ref steps must be resolvable
             // within target `assoc.assoc.fk` -> `assoc.assoc_fk`
             else if (
-              lhs.$refLinks[0].definition ===
+              lhs.$refLinks[0]?.definition ===
               getParentEntity(assocRefLink.definition).elements[assocRefLink.definition.name]
             )
               result[i].ref = [assocRefLink.alias, lhs.ref.slice(1).join('_')]
             // naive assumption: if the path starts with an association which is not the association from
             // which the on-condition originates, it must be a foreign key and hence resolvable in the source
-            else if (lhs.$refLinks[0].definition.target) result[i].ref = [result[i].ref.join('_')]
+            else if (lhs.$refLinks[0]?.definition.target) result[i].ref = [result[i].ref.join('_')]
           }
         }
         if (backlink) {


### PR DESCRIPTION
In contrast to 4odata, on conditions are not rewritten in universal csn. 
In particular `on foo.id = $self.foo_id` is not rewritten to `on foo.id = foo_id` as in 4odata. 

@patricebender : **please double-check** whether this fix is correct. 
Find info about fixed tests in jest.config-usn.js.
