### PR TITLE
fix: Allow SELECT.join queries again with full infer call

### DIFF
--- a/db-service/lib/SQLService.js
+++ b/db-service/lib/SQLService.js
@@ -114,6 +114,9 @@ class SQLService extends DatabaseService {
    * @type {Handler}
    */
   async onSELECT({ query, data }) {
+    if (!query.target) {
+      try { this.infer(query) } catch (e) { /**/ }
+    }
     if (query.target && !query.target._unresolved) {
       // Will return multiple rows with objects inside
       query.SELECT.expand = 'root'


### PR DESCRIPTION
Currently the `@sap/cds` infer does not support `SELECT.join` queries. The `Query.target` for `join` queries always returns `undefined`. So when trying to identify `unresolved` queries the output converters where no longer being applied to `join` queries.

There have been discussions about adding `join` support to the `@sap/cds` infer function. If this will be available soon it might already solve this issue. If this still takes longer it might be required to add this quick fix.