### PR TITLE
fix(`cqn4sql`): be robust against `$self.<element>` references

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -918,7 +918,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
       if (q.SELECT.from.uniqueSubqueryAlias) return
       const last = q.SELECT.from.ref.at(-1)
       const uniqueSubqueryAlias = inferred.joinTree.addNextAvailableTableAlias(
-        getLastStringSegment(last.id||last),
+        getLastStringSegment(last.id || last),
         originalQuery.outerQueries,
       )
       Object.defineProperty(q.SELECT.from, 'uniqueSubqueryAlias', { value: uniqueSubqueryAlias })
@@ -976,8 +976,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
      */
     function isManagedAssocInFlatMode(e) {
       return (
-        e.isAssociation && e.keys
-        && (model.meta.transformation === 'odata' || model.meta.unfolded?.includes('structs'))
+        e.isAssociation && e.keys && (model.meta.transformation === 'odata' || model.meta.unfolded?.includes('structs'))
       )
     }
   }
@@ -1038,7 +1037,8 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
     let leafAssoc
     let element = $refLinks ? $refLinks[$refLinks.length - 1].definition : column
     if (isWildcard && element.type === 'cds.LargeBinary') return []
-    if (element.on && !element.keys) return [] // unmanaged doesn't make it into columns
+    if (element.on && !element.keys)
+      return [] // unmanaged doesn't make it into columns
     else if (element.virtual === true) return []
     else if (!isJoinRelevant && flatName) baseName = flatName
     else if (isJoinRelevant) {
@@ -1276,7 +1276,8 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           }
         } else {
           const { list } = token
-          if (list.every(e => e.val)) // no need for transformation
+          if (list.every(e => e.val))
+            // no need for transformation
             transformedTokenStream.push({ list })
           else transformedTokenStream.push({ list: getTransformedTokenStream(list, $baseLink) })
         }
@@ -1813,8 +1814,12 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           result.splice(i, 3, ...(wrapInXpr ? [asXpr(backlinkOnCondition)] : backlinkOnCondition))
           i += wrapInXpr ? 1 : backlinkOnCondition.length // skip inserted tokens
         } else if (lhs.ref) {
-          if (lhs.ref[0] === '$self') result[i].ref.splice(0, 1, targetSideRefLink.alias)
-          else if (lhs.ref.length > 1) {
+          if (lhs.ref[0] === '$self') { // $self in ref of length > 1
+            // if $self is followed by association, the alias of the association must be used
+            if (lhs.$refLinks[1].definition.isAssociation) result[i].ref.splice(0, 1)
+            // otherwise $self points to the entity itself
+            else result[i].ref.splice(0, 1, targetSideRefLink.alias)
+          } else if (lhs.ref.length > 1) {
             if (
               !(lhs.ref[0] in pseudos.elements) &&
               lhs.ref[0] !== assocRefLink.alias &&
@@ -1826,7 +1831,8 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
                 // first step is the association itself -> use it's name as it becomes the table alias
                 result[i].ref.splice(0, 1, assocRefLink.alias)
               } else if (
-                definition.name in (targetSideRefLink.definition.elements || targetSideRefLink.definition._target.elements)
+                definition.name in
+                (targetSideRefLink.definition.elements || targetSideRefLink.definition._target.elements)
               ) {
                 // first step is association which refers to its foreign key by dot notation
                 result[i].ref = [targetSideRefLink.alias, lhs.ref.join('_')]

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1817,7 +1817,7 @@ function cqn4sql(originalQuery, model = cds.context?.model || cds.model) {
           if (lhs.ref[0] === '$self') { // $self in ref of length > 1
             // if $self is followed by association, the alias of the association must be used
             if (lhs.$refLinks[1].definition.isAssociation) result[i].ref.splice(0, 1)
-            // otherwise $self points to the entity itself
+            // otherwise $self is replaced by the alias of the entity
             else result[i].ref.splice(0, 1, targetSideRefLink.alias)
           } else if (lhs.ref.length > 1) {
             if (

--- a/db-service/test/bookshop/db/schema.cds
+++ b/db-service/test/bookshop/db/schema.cds
@@ -28,7 +28,7 @@ entity Books : managed {
     dedication: String; // same name as struct
   };
   coAuthor_ID_unmanaged: Integer;
-  coAuthorUnmanaged: Association to Authors on coAuthorUnmanaged.ID = coAuthor_ID_unmanaged;
+  coAuthorUnmanaged: Association to Authors on $self.coAuthorUnmanaged.ID = $self.coAuthor_ID_unmanaged;
 }
 
 entity BooksWithWeirdOnConditions {

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -720,11 +720,7 @@ describe('EXISTS predicate in infix filter', () => {
   })
 })
 
-/**
- * @TODO Review the mean tests and verify, that the resulting cqn 4 sql is valid.
- *       Especially w.r.t. to table aliases and bracing.
- */
-describe('Path in FROM which ends on association must be transformed to where exists', () => {
+describe('Scoped queries', () => {
   let model
   beforeAll(async () => {
     model = cds.model = await cds.load(__dirname + '/../bookshop/srv/cat-service').then(cds.linked)
@@ -813,6 +809,13 @@ describe('Path in FROM which ends on association must be transformed to where ex
     let query = cqn4sql(CQL`SELECT from bookshop.Books:author { name }`, model)
     expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as author { author.name }
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
+      )`)
+  })
+  it('unmanaged to one with (multiple) $self in on-condition', () => {
+    // $self in refs of length > 1 can just be ignored semantically
+    let query = cqn4sql(CQL`SELECT from bookshop.Books:coAuthorUnmanaged { name }`, model)
+    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as coAuthorUnmanaged { coAuthorUnmanaged.name }
+        WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where coAuthorUnmanaged.ID = Books.coAuthor_ID_unmanaged
       )`)
   })
   it('handles FROM path with association with explicit table alias', () => {


### PR DESCRIPTION
if a `ref` of length > 1, has `ref[0] === 'self'`, the `$self` can just be ignored. `$self` comparisons have only special semantics if compared to an association. With this change, we become more robust in that regard and do not prepend wrong table aliases for the case `$self.<assoc>.<element>` - in that case, we must ensure that the alias of the association is used and not the alias of the entity. Follow up #468 