### PR TITLE
fix: Throw 'new Error' instead of string on $search with multiple words

### DIFF
--- a/db-service/lib/cql-functions.js
+++ b/db-service/lib/cql-functions.js
@@ -21,7 +21,7 @@ const StandardFunctions = {
    * @returns {string}
    */
   search: function (ref, arg) {
-    if (!('val' in arg)) throw `Only single value arguments are allowed for $search`
+    if (!('val' in arg)) throw new Error(`Only single value arguments are allowed for $search`)
     const refs = ref.list || [ref],
       { toString } = ref
     return '(' + refs.map(ref2 => this.contains(this.tolower(toString(ref2)), this.tolower(arg))).join(' or ') + ')'


### PR DESCRIPTION
This patch improves the error handling for #127 by showing a slightly better understandable error message to the user.

Before:
<img width="622" alt="image" src="https://github.com/cap-js/cds-dbs/assets/12449/370b718c-0efe-4c45-b0bb-afa7ad1549a0">

After:
<img width="620" alt="image" src="https://github.com/cap-js/cds-dbs/assets/12449/032c340a-758d-43eb-825e-2b3b5afc22b8">

Seems like CAP expects an Error instance these days, because it accesses error.message.
`Parameter 'error.message' must be type of 'string'`

# CDS setup
@sap/cds: 7.3.1
@sap/cds-compiler: 4.3.2
@sap/cds-dk (global): 7.3.2
@sap/cds-fiori: 1.1.0
@sap/cds-foss: 4.0.2
@sap/cds-mtxs: 1.12.1
@sap/eslint-plugin-cds: 2.6.3
Node.js: v18.19.1
cds-dbs: 1.3.1
