### PR TITLE
fix: optimize foreign key access in a join relevant path

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1133,9 +1133,10 @@ function cqn4sql(originalQuery, model) {
             // directly resolves to the foreign key, we must not append the fk name to the column alias
             // e.g. `assoc.fk as FOO` => columns.alias = FOO
             //      `assoc as FOO`    => columns.alias = FOO_fk
+            let columnAliasWithFlatFk
             if (!(column.as && fkElement === column.$refLinks?.at(-1).definition))
-              columnAlias = `${columnAlias}_${fk.ref.join('_')}`
-            flatColumn = { ref: [fkBaseName], as: columnAlias }
+              columnAliasWithFlatFk = `${columnAlias}_${fk.as || fk.ref.join('_')}`
+            flatColumn = { ref: [fkBaseName], as: columnAliasWithFlatFk || columnAlias }
           } else flatColumn = { ref: [fkBaseName] }
           if (tableAlias) flatColumn.ref.unshift(tableAlias)
 

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1353,11 +1353,17 @@ function cqn4sql(originalQuery, model) {
             // in that case, we have a baseLink `books` which we need to resolve the following steps
             // however, the correct table alias has been assigned to the `author` step
             // hence we need to ignore the alias of the `$baseLink`
-            const refHasOwnAssoc =
+            const lastAssoc =
               token.isJoinRelevant && [...token.$refLinks].reverse().find(l => l.definition.isAssociation)
-            const tableAlias = getQuerySourceName(token, refHasOwnAssoc || $baseLink)
-            if ((!$baseLink || refHasOwnAssoc) && token.isJoinRelevant) {
-              result.ref = [tableAlias, getFullName(token.$refLinks[token.$refLinks.length - 1].definition)]
+            const tableAlias = getQuerySourceName(token, (!lastAssoc?.onlyForeignKeyAccess && lastAssoc) || $baseLink)
+            if ((!$baseLink || lastAssoc) && token.isJoinRelevant) {
+              const nonJoinRelevantAssoc = [...token.$refLinks].reverse().findIndex(l => l.definition.isAssociation && l.onlyForeignKeyAccess)
+              let name
+              if(nonJoinRelevantAssoc) // calculate fk name
+                name = token.ref.slice(nonJoinRelevantAssoc, token.ref.length).join('_')
+              else
+                name = getFullName(token.$refLinks[token.$refLinks.length - 1 ].definition)
+              result.ref = [tableAlias, name]
             } else if (tableAlias) {
               result.ref = [tableAlias, token.flatName]
             } else {

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1357,7 +1357,7 @@ function cqn4sql(originalQuery, model) {
               token.isJoinRelevant && [...token.$refLinks].reverse().find(l => l.definition.isAssociation)
             const tableAlias = getQuerySourceName(token, (!lastAssoc?.onlyForeignKeyAccess && lastAssoc) || $baseLink)
             if ((!$baseLink || lastAssoc) && token.isJoinRelevant) {
-              const nonJoinRelevantAssoc = [...token.$refLinks].reverse().findIndex(l => l.definition.isAssociation && l.onlyForeignKeyAccess)
+              const nonJoinRelevantAssoc = [...token.$refLinks].findIndex(l => l.definition.isAssociation && l.onlyForeignKeyAccess)
               let name
               if(nonJoinRelevantAssoc) // calculate fk name
                 name = token.ref.slice(nonJoinRelevantAssoc, token.ref.length).join('_')

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -181,6 +181,7 @@ class JoinTree {
         col.$refLinks[i].alias = node.$refLink.alias
         col.$refLinks[i].definition = node.$refLink.definition
         col.$refLinks[i].target = node.$refLink.target
+        col.$refLinks[i].onlyForeignKeyAccess = node.$refLink.onlyForeignKeyAccess
       } else {
         if (col.expand && !col.ref[i + 1]) {
           node.$refLink.onlyForeignKeyAccess = false

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -201,7 +201,7 @@ class JoinTree {
         const elements =
           node.$refLink?.definition.isAssociation &&
           (node.$refLink.definition.elements || node.$refLink.definition.foreignKeys)
-        if (node.$refLink && (!elements || !(child.$refLink.alias in elements)))
+        if (node.$refLink && (!elements || !(child.$refLink.definition.name in elements)))
           // foreign key access
           node.$refLink.onlyForeignKeyAccess = false
 

--- a/db-service/test/cqn4sql/A2J/classes.cds
+++ b/db-service/test/cqn4sql/A2J/classes.cds
@@ -7,8 +7,8 @@ entity Classrooms {
 
 entity Pupils {
     key ID        : Integer;
-        classroom : Association to many ClassRoomPupil
-                        on classroom.pupil = $self
+        classrooms : Association to many ClassRoomPupil
+                        on classrooms.pupil = $self
 }
 
 entity ClassRoomPupil {

--- a/db-service/test/cqn4sql/A2J/classes.cds
+++ b/db-service/test/cqn4sql/A2J/classes.cds
@@ -1,17 +1,32 @@
 // test many-to-many relations
 entity Classrooms {
     key ID     : Integer;
+        name: String;
+        info: {
+            capacity: Integer;
+            location: String;
+        };
         pupils : Association to many ClassRoomPupil
                      on pupils.classroom = $self
 }
 
 entity Pupils {
-    key ID        : Integer;
+    key ID         : Integer;
         classrooms : Association to many ClassRoomPupil
-                        on classrooms.pupil = $self
+                         on classrooms.pupil = $self
 }
 
 entity ClassRoomPupil {
     key classroom : Association to Classrooms;
     key pupil     : Association to Pupils;
+}
+// -----------------------------------------------------
+
+entity ForeignKeyIsAssoc {
+    key ID         : Integer;   
+        my: Association to TeachersRoom;
+}
+
+entity TeachersRoom {
+    key room: Association to Classrooms { ID as number, name, info.location };
 }

--- a/db-service/test/cqn4sql/A2J/classes.cds
+++ b/db-service/test/cqn4sql/A2J/classes.cds
@@ -1,0 +1,17 @@
+// test many-to-many relations
+entity Classrooms {
+    key ID     : Integer;
+        pupils : Association to many ClassRoomPupil
+                     on pupils.classroom = $self
+}
+
+entity Pupils {
+    key ID        : Integer;
+        classroom : Association to many ClassRoomPupil
+                        on classroom.pupil = $self
+}
+
+entity ClassRoomPupil {
+    key classroom : Association to Classrooms;
+    key pupil     : Association to Pupils;
+}

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -49,11 +49,11 @@ describe('Unfolding Association Path Expressions to Joins', () => {
     expect(query).to.deep.equal(expected)
   })
   it('in select, three assocs, last navigates to foreign key', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID, books.genre.parent.ID }`, model)
+    let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID, books.genre.parent.ID as foo }`, model)
     const expected = CQL`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID
-        { Authors.ID, genre.parent_ID as books_genre_parent_ID }
+        { Authors.ID, genre.parent_ID as foo }
       `
     expect(query).to.deep.equal(expected)
   })
@@ -1221,7 +1221,7 @@ describe('optimize fk access', () => {
   beforeAll(async () => {
     model = cds.model = await cds.load(__dirname + '/A2J/classes').then(cds.linked)
   })
-  it.skip('two step path ends in foreign key simple ref', () => {
+  it('two step path ends in foreign key simple ref', () => {
     const query = CQL`SELECT from Classrooms {
       pupils.pupil.ID as studentCount,
     } where Classrooms.ID = 1`

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -1221,6 +1221,18 @@ describe('optimize fk access', () => {
   beforeAll(async () => {
     model = cds.model = await cds.load(__dirname + '/A2J/classes').then(cds.linked)
   })
+  it.only('association (with multiple, structured, renamed fks) is key', () => {
+    const query = CQL`SELECT from ForeignKeyIsAssoc {
+      my.room as teachersRoom,
+    }`
+    const expected = CQL`SELECT from ForeignKeyIsAssoc as ForeignKeyIsAssoc {
+                          ForeignKeyIsAssoc.my_room_number as teachersRoom_number,
+                          ForeignKeyIsAssoc.my_room_name as teachersRoom_name,
+                          ForeignKeyIsAssoc.my_room_location as teachersRoom_info_location
+                        }`
+
+    expect(cqn4sql(query, model)).to.deep.equal(expected)
+  })
   it('two step path ends in foreign key simple ref', () => {
     const query = CQL`SELECT from Classrooms {
       pupils.pupil.ID as studentCount,

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -1215,3 +1215,21 @@ describe('comparisons of associations in on condition of elements needs to be ex
     expect(query).to.eql(expected)
   })
 })
+
+describe('optimize fk access', () => {
+  let model
+  beforeAll(async () => {
+    model = cds.model = await cds.load(__dirname + '/A2J/classes').then(cds.linked)
+  })
+  it('two step path ends in foreign key', () => {
+    const query = CQL`SELECT from Classrooms {
+      count(pupils.pupil.ID) as studentCount,
+    } where Classrooms.ID = 1`
+    const expected = CQL`SELECT from Classrooms as Classrooms left join ClassRoomPupil as pupils
+                        on pupils.classroom_ID = Classrooms.ID {
+                          count(pupils.pupil_ID) as studentCount
+                        } where Classrooms.ID = 1`
+
+   expect(cqn4sql(query, model)).to.deep.equal(expected)
+  })
+})

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -1221,7 +1221,7 @@ describe('optimize fk access', () => {
   beforeAll(async () => {
     model = cds.model = await cds.load(__dirname + '/A2J/classes').then(cds.linked)
   })
-  it.only('association (with multiple, structured, renamed fks) is key', () => {
+  it('association (with multiple, structured, renamed fks) is key', () => {
     const query = CQL`SELECT from ForeignKeyIsAssoc {
       my.room as teachersRoom,
     }`


### PR DESCRIPTION
if the path resolves to a foreign key, we should not create a join for the last association, instead we shortcut to the foreign key. This was not considered for join relevant paths. 

fix #479