### PR TITLE
fix: `TypeError` for `cds bind` in MTX scenario

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -29,7 +29,7 @@ class HANAService extends SQLService {
 
   // REVISIT: Add multi tenant factory when clarified
   get factory() {
-    const driver = drivers[this.options.driver || this.options.credentials.driver]?.driver || drivers.default.driver
+    const driver = drivers[this.options.driver || this.options.credentials?.driver]?.driver || drivers.default.driver
     const isMultitenant = 'multiTenant' in this.options ? this.options.multiTenant : cds.env.requires.multitenancy
     const service = this
     return {


### PR DESCRIPTION
With `@cap-js/hana` I get the following error (in `dev/cds-mtxs/test/bookshop`):
```
cds run --profile hana --resolve-bindings
```

```
TypeError: Cannot read properties of undefined (reading 'driver')
    at get factory [as factory] (/Users/D061687/Desktop/dev/cds-dbs/hana/lib/HANAService.js:32:76)
    at <instance_members_initializer> (/Users/D061687/Desktop/dev/cds-dbs/db-service/lib/common/DatabaseService.js:18:54)
    at new DatabaseService (/Users/D061687/Desktop/dev/cds-dbs/db-service/lib/common/DatabaseService.js:8:1)
    at new SQLService (/Users/D061687/Desktop/dev/cds-dbs/db-service/lib/SQLService.js:321:5)
    at new HANAService (/Users/D061687/Desktop/dev/cds-dbs/hana/lib/HANAService.js:16:1)
    at _use (/Users/D061687/Desktop/dev/cds/lib/srv/factory.js:23:42)
    at _use (/Users/D061687/Desktop/dev/cds/lib/srv/factory.js:26:42)
    at _use (/Users/D061687/Desktop/dev/cds/lib/srv/factory.js:27:63)
    at async connect.to (/Users/D061687/Desktop/dev/cds/lib/srv/cds-connect.js:48:11)
    at async cds_server (/Users/D061687/Desktop/dev/cds/server.js:34:33)
/Users/D061687/Desktop/dev/cds-dbs/hana/lib/HANAService.js:32
    const driver = drivers[this.options.driver || this.options.credentials.driver]?.driver || drivers.default.driver
```

This PR fixes the `TypeError`.

Explanation:
The `await cds.connect.to ('db')` is called here before `cds bind` resolves the `credentials` property. In an MTX scenario this doesn't matter though, as the credentials are fetched from Service Manager at runtime. Subsequent subscriptions etc. also work fine with this patch.