### PR TITLE
fix: `INSERT` with first `undefined` value

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -465,10 +465,11 @@ class CQN2SQLRenderer {
 
       let sepsub = ''
       for (const key in row) {
+        let val = row[key]
+        if (val === undefined) continue
         const keyJSON = `${sepsub}${JSON.stringify(key)}:`
         if (!sepsub) sepsub = ','
 
-        let val = row[key]
         if (val instanceof Readable) {
           buffer += `${keyJSON}"`
 
@@ -484,7 +485,6 @@ class CQN2SQLRenderer {
 
           buffer += '"'
         } else {
-          if (val === undefined) continue
           if (elements[key]?.type in BINARY_TYPES) {
             val = transformBase64(val)
           }

--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -16,8 +16,8 @@ describe('Bookshop - Insert', () => {
 
   test('insert with undefined value works', async () => {
     const { Books } = cds.entities('sap.capire.bookshop')
-    const insert = INSERT({ stock: undefined, ID: 223, title: 'Harry Potter' }).into(Books)
-    const resp = await cds.run(insert)
-    expect(resp.results[0].changes).to.be.eq(1)
+    await cds.run(INSERT({ stock: undefined, ID: 223, title: 'Harry Potter' }).into(Books))
+    const result = await SELECT.from(Books).where({ ID: 223 })
+    expect(result.length).to.be.eq(1)
   })
 })

--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -16,8 +16,7 @@ describe('Bookshop - Insert', () => {
 
   test('insert with undefined value works', async () => {
     const { Books } = cds.entities('sap.capire.bookshop')
-    await cds.run(INSERT({ stock: undefined, ID: 223, title: 'Harry Potter' }).into(Books))
-    const result = await SELECT.from(Books).where({ ID: 223 })
-    expect(result.length).to.be.eq(1)
+    const resp = await cds.run(INSERT({ stock: undefined, ID: 223, title: 'Harry Potter' }).into(Books))
+    expect(resp | 0).to.be.eq(1)
   })
 })

--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -13,4 +13,11 @@ describe('Bookshop - Insert', () => {
     // expect(err instanceof Error).to.be.true
     expect(err.message).to.be.eq('ENTITY_ALREADY_EXISTS')
   })
+
+  test('insert with undefined value works', async () => {
+    const { Books } = cds.entities('sap.capire.bookshop')
+    const insert = INSERT({ stock: undefined, ID: 223, title: 'Harry Potter' }).into(Books)
+    const resp = await cds.run(insert)
+    expect(resp.results[0].changes).to.be.eq(1)
+  })
 })


### PR DESCRIPTION
`INSERT({ stock: undefined, ID: 223, title: 'Harry Potter' }).into(Books)` had led to `SqliteError: malformed JSON`