### PR TITLE
feat(hana): Add views with parameters support for HANA

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -303,10 +303,26 @@ class CQN2SQLRenderer {
   from(from) {
     const { ref, as } = from
     const _aliased = as ? s => s + ` as ${this.quote(as)}` : s => s
-    if (ref) return _aliased(this.quote(this.name(ref[0])))
+    if (ref) {
+      const z = ref[0]
+      if (z.args) {
+        return _aliased(`${this.quote(this.name(z))}${this.from_args(z.args)}`)
+      }
+      return _aliased(this.quote(this.name(z)))
+    }
     if (from.SELECT) return _aliased(`(${this.SELECT(from)})`)
     if (from.join)
       return `${this.from(from.args[0])} ${from.join} JOIN ${this.from(from.args[1])} ON ${this.where(from.on)}`
+  }
+
+  /**
+   * Renders a FROM clause into generic SQL
+   * @param {import('./infer/cqn').ref['ref'][0]['args']} args
+   * @returns {string} SQL
+   */
+  from_args(args) {
+    args
+    cds.error`Parameterized views are not supported by ${this.constructor.name}`
   }
 
   /**

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -652,6 +652,10 @@ class HANAService extends SQLService {
       return (this.sql = `DROP ${isView ? 'VIEW' : 'TABLE'} ${this.name(target.name)}`)
     }
 
+    from_args(args) {
+      return `(${ObjectKeys(args).map(k => `${this.quote(k)} => ${this.expr(args[k])}`)})`
+    }
+
     orderBy(orderBy, localized) {
       return orderBy.map(
         localized

--- a/hana/test/param-views.cds
+++ b/hana/test/param-views.cds
@@ -1,0 +1,15 @@
+using {sap.capire.bookshop.Books as Books} from '../../test/bookshop/db/schema.cds';
+
+namespace sap.capire.bookshop;
+
+entity ParamBooks(available : Integer) as
+    select from Books {
+        ID,
+        title,
+        stock,
+        // Take foreign key for author association
+        author.ID as author_ID,
+        // author, Compiler does not like associations in parameterized views
+    }
+    where
+        stock <= :available;

--- a/hana/test/param-views.test.js
+++ b/hana/test/param-views.test.js
@@ -1,0 +1,53 @@
+const cds = require('../../test/cds')
+
+describe('Parameterized view', () => {
+  const { expect } = cds.test(__dirname, 'param-views.cds')
+
+  const tests = [
+    // ===== required queries =====
+    {
+      available: { val: 0 },
+      books: 0,
+    }, {
+      // all books with <= 12 stock
+      available: { val: 12 },
+      books: 2,
+    }, {
+      // all books (with <= 1000 stock)
+      available: { val: 1000 },
+      books: 5,
+    },
+    // ===== just works queries =====
+    {
+      // all books with <= 22 stock
+      available: CXL`11 * 2`,
+      books: 3,
+    }, {
+      // the book with the least stock
+      available: SELECT`min(stock)`.from('sap.capire.bookshop.Books'),
+      books: 1,
+    }
+  ]
+
+  test.each(tests)('select', async ({ available, books }) => {
+    const { ParamBooks, Books } = cds.entities('sap.capire.bookshop')
+
+    // Apply author association to parameterized view
+    ParamBooks.elements.author = Books.elements.author
+
+    const root = {
+      id: ParamBooks.name,
+      args: { available }
+    }
+
+    const [booksRes, authorsRes, expandRes] = await Promise.all([
+      SELECT.from({ ref: [root] }),
+      SELECT.from({ ref: [root, 'author'] }),
+      SELECT`ID,stock,author{ID}`.from({ ref: [root] }),
+    ])
+
+    expect(booksRes).to.have.property('length').to.be.eq(books)
+    const authorKeys = expandRes.map(r => r.author.ID)
+    expect(authorsRes.filter(r => authorKeys.includes(r.ID))).to.have.property('length').to.be.eq(authorsRes.length)
+  })
+})


### PR DESCRIPTION
Added support for selecting from views with parameters.

Examples:
```js
SELECT.from({ref:[{
  id: view,
  args: {
    arg1: {val: 0},
    arg2: CXL`1 + 1`,
    arg3: SELECT`min(col)`.from(view),
    ...
  }
}]})
```

Changes from the `@sap/hana` service.

1. Added support for all valid `expr` for arguments as defined in the `CQN` type
1. Added support for association / compositions (does not compile)
    - Expanding associations / compositions as columns 
    - Path expressions inside the `from` clause