### PR TITLE
feat: support path expressions for parameterized entities

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1614,8 +1614,10 @@ function cqn4sql(originalQuery, model) {
       // adjust ref & $refLinks after associations have turned into where exists subqueries
       transformedFrom.$refLinks.splice(0, transformedFrom.$refLinks.length - 1)
 
-      const args = from.ref.at(-1).args
-      const id = localized(transformedFrom.$refLinks[0].target)
+      let args = from.ref.at(-1).args
+      const subquerySource = transformedFrom.$refLinks[0].target
+      if(subquerySource.params && !args) args = {}
+      const id = localized(subquerySource)
       transformedFrom.ref = [args ? { id, args } : id]
 
       return { transformedWhere, transformedFrom }
@@ -1966,7 +1968,9 @@ function cqn4sql(originalQuery, model) {
       on.push(...['and', ...(hasLogicalOr(filter) ? [asXpr(filter)] : filter)])
     }
 
-    const id = localized(assocTarget(nextDefinition) || nextDefinition)
+    const subquerySource = assocTarget(nextDefinition) || nextDefinition
+    const id = localized(subquerySource)
+    if(subquerySource.params && !customArgs) customArgs = {}
     const SELECT = {
       from: {
         ref: [customArgs ? { id, args: customArgs } : id],

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -255,9 +255,12 @@ function cqn4sql(originalQuery, model) {
      */
     const alreadySeen = new Map()
     inferred.joinTree._roots.forEach(r => {
-      const args = r.queryArtifact.SELECT
-        ? [{ SELECT: transformSubquery(r.queryArtifact).SELECT, as: r.alias }]
-        : [{ ref: [localized(r.queryArtifact)], as: r.alias }]
+      const args = []
+      if (r.queryArtifact.SELECT) args.push({ SELECT: transformSubquery(r.queryArtifact).SELECT, as: r.alias })
+      else {
+        const id = localized(r.queryArtifact)
+        args.push({ ref: [r.args ? { id, args: r.args } : id], as: r.alias })
+      }
       from = { join: 'left', args, on: [] }
       r.children.forEach(c => {
         from = joinForBranch(from, c)
@@ -683,7 +686,7 @@ function cqn4sql(originalQuery, model) {
     // select from books { { * } as bar }
     // only possible if there is exactly one query source
     if (!baseRef.length) {
-      const [tableAlias, {definition }] = Object.entries(inferred.sources)[0]
+      const [tableAlias, { definition }] = Object.entries(inferred.sources)[0]
       baseRef.push(tableAlias)
       baseRefLinks.push({ definition, source: definition })
     }

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1266,7 +1266,7 @@ function cqn4sql(originalQuery, model) {
               }”`,
             )
           }
-          whereExistsSubSelects.push(getWhereExistsSubquery(current, next, step.where, true))
+          whereExistsSubSelects.push(getWhereExistsSubquery(current, next, step.where, true, step.args))
         }
 
         const whereExists = { SELECT: whereExistsSubqueries(whereExistsSubSelects) }

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -94,7 +94,8 @@ function infer(originalQuery, model) {
   function inferTarget(from, querySources) {
     const { ref } = from
     if (ref) {
-      const first = ref[0].id || ref[0]
+      const { id, args } = ref[0]
+      const first = id || ref[0]
       let target = getDefinition(first, model)
       if (!target) throw new Error(`"${first}" not found in the definitions of your model`)
       if (ref.length > 1) {
@@ -113,7 +114,7 @@ function infer(originalQuery, model) {
         from.as ||
         (ref.length === 1 ? first.match(/[^.]+$/)[0] : ref[ref.length - 1].id || ref[ref.length - 1])
       if (alias in querySources) throw new Error(`Duplicate alias "${alias}"`)
-      querySources[alias] = { definition: target }
+      querySources[alias] = { definition: target, args }
       const last = from.$refLinks.at(-1)
       last.alias = alias
     } else if (from.args) {

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -51,7 +51,8 @@ class Node {
     /** @type {where} - An optional condition to be applied to this node. */
     this.where = where
     /** @type {args} - optional parameter object to be applied to this node. */
-    if(!args && $refLink.definition._target?.params) args = {} // if no args are provided, provide empty argument list
+    const targetHasParams = $refLink.definition._target?.params || $refLink.definition._target?.['@cds.persistence.udf']
+    if (!args && targetHasParams) args = {} // if no args are provided, provide empty argument list
     this.args = args
     /** @type {children} - A Map of children nodes belonging to this node. */
     this.children = new Map()
@@ -70,7 +71,8 @@ class Root {
     /** @type {queryArtifact} - The artifact used to make the query. */
     this.queryArtifact = definition
     /** @type {args} - optional parameter object to be applied to this node. */
-    if(!args && definition.params) args = {} // if no args are provided, provide empty argument list
+    const definitionHasParams = definition.params || definition['@cds.persistence.udf']
+    if (!args && definitionHasParams) args = {} // if no args are provided, provide empty argument list
     this.args = args
     /** @type {alias} - The alias of the artifact. */
     this.alias = alias

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -51,6 +51,7 @@ class Node {
     /** @type {where} - An optional condition to be applied to this node. */
     this.where = where
     /** @type {args} - optional parameter object to be applied to this node. */
+    if(!args && $refLink.definition._target?.params) args = {} // if no args are provided, provide empty argument list
     this.args = args
     /** @type {children} - A Map of children nodes belonging to this node. */
     this.children = new Map()
@@ -65,10 +66,11 @@ class Root {
    * @param {[alias, queryArtifact]} querySource
    */
   constructor(querySource) {
-    const [alias, { definition, args }] = querySource
+    let [alias, { definition, args }] = querySource
     /** @type {queryArtifact} - The artifact used to make the query. */
     this.queryArtifact = definition
     /** @type {args} - optional parameter object to be applied to this node. */
+    if(!args && definition.params) args = {} // if no args are provided, provide empty argument list
     this.args = args
     /** @type {alias} - The alias of the artifact. */
     this.alias = alias

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -69,7 +69,7 @@ class Root {
     /** @type {queryArtifact} - The artifact used to make the query. */
     this.queryArtifact = definition
     /** @type {args} - optional parameter object to be applied to this node. */
-    this.args = definition
+    this.args = args
     /** @type {alias} - The alias of the artifact. */
     this.alias = alias
     /** @type {parent} - The parent Node of this root, null for the root Node. */
@@ -103,7 +103,6 @@ class JoinTree {
      */
     this._queryAliases = new Map()
     Object.entries(sources).forEach(entry => {
-      const [id, { definition }] = entry
       const alias = this.addNextAvailableTableAlias(entry[0])
       this._roots.set(alias, new Root(entry))
     })

--- a/db-service/test/cds-infer/elements.test.js
+++ b/db-service/test/cds-infer/elements.test.js
@@ -202,8 +202,8 @@ describe('infer elements', () => {
       let query = CQL`SELECT from bookshop.Books, bookshop.Receipt`
       let inferred = _inferred(query)
       let { Books, Receipt } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
-      expect(inferred).to.have.nested.property('sources.Receipt', Receipt)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
+      expect(inferred.sources).to.have.nested.property('Receipt.definition', Receipt)
       // eslint-disable-next-line no-unused-vars
       const { image, ...BooksElementsWithoutBlob } = Books.elements
       expect(inferred.elements).to.deep.equal({ ...BooksElementsWithoutBlob, ...Receipt.elements }) // combined elements
@@ -213,8 +213,8 @@ describe('infer elements', () => {
       let query = CQL`SELECT from bookshop.Books, bookshop.Receipt { * }`
       let inferred = _inferred(query)
       let { Books, Receipt } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
-      expect(inferred).to.have.nested.property('sources.Receipt', Receipt)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
+      expect(inferred.sources).to.have.nested.property('Receipt.definition', Receipt)
       // eslint-disable-next-line no-unused-vars
       const { image, ...BooksElementsWithoutBlob } = Books.elements
       expect(inferred.elements).to.deep.equal({ ...BooksElementsWithoutBlob, ...Receipt.elements }) // combined elements
@@ -258,7 +258,7 @@ describe('infer elements', () => {
       let inferred = _inferred(query)
 
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       let expectedElements = {
         Two: {},
         subquery: {},
@@ -276,7 +276,7 @@ describe('infer elements', () => {
       let inferred = _inferred(query)
 
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       let expectedElements = {
         Two: {},
         subquery: {},
@@ -298,7 +298,7 @@ describe('infer elements', () => {
       let inferred = _inferred(query)
 
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       let expectedElements = {
         net: {},
       }
@@ -310,7 +310,7 @@ describe('infer elements', () => {
       let inferred = _inferred(query)
 
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       let expectedElements = {
         noType: {},
       }
@@ -336,7 +336,7 @@ describe('infer elements', () => {
     }`)
       let inferred = _inferred(query)
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       expect(inferred.elements).to.deep.equal({
         price: {
           type: 'cds.Integer',
@@ -385,7 +385,7 @@ describe('infer elements', () => {
       let query = CQL`SELECT from bookshop.Books { cast(cast(ID as Integer) as String) as IDS, cast(ID as bookshop.DerivedFromDerivedString) as IDCustomType }`
       let inferred = _inferred(query)
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       let expectedElements = {
         IDS: {
           type: 'cds.String',
@@ -427,7 +427,7 @@ describe('infer elements', () => {
       let inferred = _inferred(query)
 
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       // blobs are not part of the query elements
       // eslint-disable-next-line no-unused-vars
       const { image, ...BooksElementsWithoutBlob } = Books.elements
@@ -469,7 +469,7 @@ describe('infer elements', () => {
       let query = CQL`SELECT from bookshop.Books { 5 * 5 as price, *, 1 + 1 as ID, author.name as author }` // TODO: take care of order
       let inferred = _inferred(query)
       let { Books } = model.entities
-      expect(inferred).to.have.nested.property('sources.Books', Books)
+      expect(inferred.sources).to.have.nested.property('Books.definition', Books)
       // eslint-disable-next-line no-unused-vars
       let { image, ...expectedElements } = Books.elements
       Object.assign(expectedElements, {

--- a/db-service/test/cds-infer/source.test.js
+++ b/db-service/test/cds-infer/source.test.js
@@ -51,7 +51,7 @@ describe('scoped queries', () => {
     let inferred = _inferred(query)
 
     let { Authors } = model.entities
-    expect(inferred).to.have.nested.property('sources.author', Authors)
+    expect(inferred.sources).to.have.nested.property('author.definition', Authors)
     expect(inferred.elements).to.deep.equal({
       ID: Authors.elements.ID,
     })
@@ -61,13 +61,13 @@ describe('scoped queries', () => {
     let query = CQL`SELECT from bookshop.Books:author.books`
     let inferred = _inferred(query)
     let { Books } = model.entities
-    expect(inferred).to.have.nested.property('sources.books', Books)
+    expect(inferred.sources).to.have.nested.property('books.definition', Books)
   })
   it('multiple assocs with filter', () => {
     let query = CQL`SELECT from bookshop.Books[201]:author[111].books`
     let inferred = _inferred(query)
     let { Books } = model.entities
-    expect(inferred).to.have.nested.property('sources.books', Books)
+    expect(inferred.sources).to.have.nested.property('books.definition', Books)
   })
 })
 describe('subqueries', () => {
@@ -81,7 +81,7 @@ describe('subqueries', () => {
     let inferred = _inferred(query)
 
     let { Books } = model.entities
-    expect(inferred).to.have.nested.property('sources.Bar.sources.Books', Books)
+    expect(inferred.sources).to.have.nested.property('Bar.definition.sources.Books.definition', Books)
     expect(inferred.elements).to.deep.equal({
       barID: Books.elements.ID,
     })
@@ -93,7 +93,7 @@ describe('subqueries', () => {
     let inferred = _inferred(query)
 
     let { Books } = model.entities
-    expect(inferred.sources).to.have.nested.property('Bar.sources.Books', Books)
+    expect(inferred.sources).to.have.nested.property('Bar.definition.sources.Books.definition', Books)
     expect(inferred.elements).to.deep.equal({
       ID: Books.elements.ID,
       author: Books.elements.author,
@@ -151,7 +151,7 @@ describe('multiple sources', () => {
 
     // same base entity, addressable via both aliases
     expect(inferred.target).to.deep.equal(inferred)
-    expect(inferred.sources['firstBook']).to.deep.equal(inferred.sources['secondBook']).to.deep.equal(Books)
+    expect(inferred.sources['firstBook'].definition).to.deep.equal(inferred.sources['secondBook'].definition).to.deep.equal(Books)
 
     expect(inferred.elements).to.deep.equal({
       firstBookID: Books.elements.ID,

--- a/db-service/test/cqn4sql/model/withParameters.cds
+++ b/db-service/test/cqn4sql/model/withParameters.cds
@@ -5,7 +5,14 @@ entity Books {
     author: Association to Authors;
 };
 
-entity Authors {
+@cds.persistence.exists
+entity Authors(P1: Integer, P2: String(100)) {
+    key ID    : Integer;
+        name  : String;
+};
+
+@cds.persistence.exists
+entity AuthorsUDF {
     key ID    : Integer;
         name  : String;
 };

--- a/db-service/test/cqn4sql/model/withParameters.cds
+++ b/db-service/test/cqn4sql/model/withParameters.cds
@@ -12,6 +12,14 @@ entity Authors(P1: Integer, P2: String(100)) {
 };
 
 @cds.persistence.exists
+@cds.persistence.udf
+entity BooksUDF {
+    key ID     : Integer;
+    author: Association to AuthorsUDF;
+};
+
+@cds.persistence.exists
+@cds.persistence.udf
 entity AuthorsUDF {
     key ID    : Integer;
         name  : String;

--- a/db-service/test/cqn4sql/with-parameters.test.js
+++ b/db-service/test/cqn4sql/with-parameters.test.js
@@ -74,7 +74,7 @@ describe('entities and views with parameters', () => {
       const query = cqn4sql(cqn, model)
       const expected = CQL`
       SELECT FROM PBooks(P1: 42, P2: 45) as PBooks
-      left join Authors(P1: 1) as author on author.ID = PBooks.author_ID
+      left join Authors(P1: dummy) as author on author.ID = PBooks.author_ID
         {
           author.name as author
         }

--- a/db-service/test/cqn4sql/with-parameters.test.js
+++ b/db-service/test/cqn4sql/with-parameters.test.js
@@ -19,10 +19,32 @@ describe('Repetitive calls to cqn4sql must work', () => {
     const expected = SELECT.from('PBooks(P1: 1, P2: 2) as PBooks').columns('PBooks.ID')
     expect(query).to.deep.equal(expected)
   })
+  it('follow association to entity with params', () => {
+    const query = cqn4sql(SELECT.from('Books').columns('author(P1: 1, P2: 2).name as author'), model)
+    const expected = CQL`
+      SELECT FROM Books as Books left join Authors(P1:1, P2: 2) as author
+        on author.ID = Books.author_ID {
+          author.name as author
+        }
+    `
+    expect(query).to.deep.equal(expected)
+  })
+  it.skip('select from entity with params and follow association to entity with params', () => {
+    const query = cqn4sql(SELECT.from('PBooks(P1: 42, P2: 45)').columns('author(P1: 1, P2: 2).name as author'), model)
+    const expected = CQL`
+      SELECT FROM PBooks(P1: 42, P2: 45) as PBooks left join Authors(P1:1, P2: 2) as author
+        on author.ID = PBooks.author_ID {
+          author.name as author
+        }
+    `
+    expect(query).to.deep.equal(expected)
+  })
   it.skip('select from view with param which has subquery as param', () => {
     // subqueries at this location are not supported by the compiler, yet
     const query = cqn4sql(SELECT.from('PBooks(P1: 1, P2: (SELECT ID from Books))').columns('ID'), model)
-    const expected = SELECT.from('PBooks(P1: 1, P2: (SELECT Books.ID from Books as Books)) as PBooks').columns('PBooks.ID')
+    const expected = SELECT.from('PBooks(P1: 1, P2: (SELECT Books.ID from Books as Books)) as PBooks').columns(
+      'PBooks.ID',
+    )
     expect(query).to.deep.equal(expected)
   })
   // will be done in another change

--- a/db-service/test/cqn4sql/with-parameters.test.js
+++ b/db-service/test/cqn4sql/with-parameters.test.js
@@ -99,6 +99,23 @@ describe('Repetitive calls to cqn4sql must work', () => {
     expected.SELECT.from.args[1].ref[0].args = {}
     expect(query).to.deep.equal(expected)
   })
+  it('empty argument list for UDF', () => {
+    const cqn = CQL`SELECT from BooksUDF {
+      author.name as author,
+    }`
+    const query = cqn4sql(cqn, model)
+    const expected = CQL`
+      SELECT FROM BooksUDF(P1: dummy) as BooksUDF
+      left join AuthorsUDF(P1: dummy) as author on author.ID = BooksUDF.author_ID
+        {
+          author.name as author
+        }
+    `
+    // manually remove the param from argument list because compiler does not allow empty args for cqn
+    expected.SELECT.from.args[0].ref[0].args = {}
+    expected.SELECT.from.args[1].ref[0].args = {}
+    expect(query).to.deep.equal(expected)
+  })
   it.skip('select from view with param which has subquery as param', () => {
     // subqueries at this location are not supported by the compiler, yet
     const query = cqn4sql(SELECT.from('PBooks(P1: 1, P2: (SELECT ID from Books))').columns('ID'), model)

--- a/db-service/test/cqn4sql/with-parameters.test.js
+++ b/db-service/test/cqn4sql/with-parameters.test.js
@@ -66,6 +66,39 @@ describe('Repetitive calls to cqn4sql must work', () => {
     `
     expect(query).to.deep.equal(expected)
   })
+  it('empty argument list if no params provided for association', () => {
+    const cqn = CQL`SELECT from PBooks(P1: 42, P2: 45) {
+            author.name as author,
+    }`
+    const query = cqn4sql(cqn, model)
+    const expected = CQL`
+      SELECT FROM PBooks(P1: 42, P2: 45) as PBooks
+      left join Authors(P1: 1) as author on author.ID = PBooks.author_ID
+        {
+          author.name as author
+        }
+    `
+    // manually remove the param from argument list because compiler does not allow empty args for cqn
+    expected.SELECT.from.args[1].ref[0].args = {}
+    expect(query).to.deep.equal(expected)
+  })
+  it('empty argument list if no params provided for entity and association', () => {
+    const cqn = CQL`SELECT from PBooks {
+            author.name as author,
+    }`
+    const query = cqn4sql(cqn, model)
+    const expected = CQL`
+      SELECT FROM PBooks(P1: dummy) as PBooks
+      left join Authors(P1: dummy) as author on author.ID = PBooks.author_ID
+        {
+          author.name as author
+        }
+    `
+    // manually remove the param from argument list because compiler does not allow empty args for cqn
+    expected.SELECT.from.args[0].ref[0].args = {}
+    expected.SELECT.from.args[1].ref[0].args = {}
+    expect(query).to.deep.equal(expected)
+  })
   it.skip('select from view with param which has subquery as param', () => {
     // subqueries at this location are not supported by the compiler, yet
     const query = cqn4sql(SELECT.from('PBooks(P1: 1, P2: (SELECT ID from Books))').columns('ID'), model)

--- a/db-service/test/cqn4sql/with-parameters.test.js
+++ b/db-service/test/cqn4sql/with-parameters.test.js
@@ -29,7 +29,7 @@ describe('Repetitive calls to cqn4sql must work', () => {
     `
     expect(query).to.deep.equal(expected)
   })
-  it.skip('select from entity with params and follow association to entity with params', () => {
+  it('select from entity with params and follow association to entity with params', () => {
     const query = cqn4sql(SELECT.from('PBooks(P1: 42, P2: 45)').columns('author(P1: 1, P2: 2).name as author'), model)
     const expected = CQL`
       SELECT FROM PBooks(P1: 42, P2: 45) as PBooks left join Authors(P1:1, P2: 2) as author


### PR DESCRIPTION
consider `args` in a `ref` for path expression. If no arguments are provided, but we navigate along a parameterized entity, we provide an empty argument list (same for `@cds.persistence.udf`)
 
→This is in line with the compiler behavior 