### PR TITLE
chore(renovate): ignore `saplabs/hanaexpress`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "ignoreDeps": ["amannn/action-semantic-pull-request", "martinbeentjes/npm-get-version-action"]
+  "ignoreDeps": ["saplabs/hanaexpress", "amannn/action-semantic-pull-request", "martinbeentjes/npm-get-version-action"]
 }


### PR DESCRIPTION
for now, we don't update as this seems to break
hana tests: https://github.com/cap-js/cds-dbs/actions/runs/8158113823/job/22299286592