### PR TITLE
chore(renovate): disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
   "ignoreDeps": ["saplabs/hanaexpress", "amannn/action-semantic-pull-request", "martinbeentjes/npm-get-version-action"]
 }


### PR DESCRIPTION
Dashboard can be found here: https://github.com/cap-js/cds-dbs/issues/502

---

I think, we don't need it.