### PR TITLE
test: Validate missing output converter for aggregate functions

### DIFF
--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -284,8 +284,22 @@ describe('SELECT', () => {
   })
 
   describe('groupby', () => {
-    test.skip('missing', () => {
-      throw new Error('not supported')
+    test('aggregate functions', async () => {
+      const [{ min, max }] = await cds.run(CQL`
+        SELECT
+          min(dateTime),
+          max(dateTime)
+        FROM basic.projection.dateTime
+        WHERE dateTime != null
+      `)
+
+      const [{ dateTime: minMatch }, { dateTime: maxMatch }] = await Promise.all([
+        SELECT.one.from('basic.projection.dateTime').where(`dateTime = `, new Date(min)),
+        SELECT.one.from('basic.projection.dateTime').where(`dateTime = `, new Date(max)),
+      ])
+
+      assert.strictEqual(min, minMatch, 'Ensure that the min result is equal to direct access')
+      assert.strictEqual(max, maxMatch, 'Ensure that the max result is equal to direct access')
     })
   })
 


### PR DESCRIPTION
Currently `cqn.elements` does not provide the correct type for functions. Therefor it is not possible to apply the correct output converter.

As example the current `DateTime` type requires an output converter to remove the additional sub second precision.
```cql
SELECT dateTime from dateTime -- returns in format 1970-01-01T00:00:00Z
SELECT min(dateTime from dateTime -- returns in format 1970-01-01T00:00:00.000Z
```