### PR TITLE
fix(search): search on aggregated results in HAVING clause 

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -181,10 +181,9 @@ function cqn4sql(originalQuery, model) {
 
     if (inferred.SELECT.search) {
       // Search target can be a navigation, in that case use _target to get the correct entity
-      const where = transformSearchToWhere(inferred.SELECT.search, transformedFrom)
-      if (where) {
-        transformedQuery.SELECT.where = where
-      }
+      const { where, having } = transformSearch(inferred.SELECT.search, transformedFrom) || {}
+      if (where) transformedQuery.SELECT.where = where
+      else if (having) transformedQuery.SELECT.having = having
     }
     return transformedQuery
   }
@@ -204,20 +203,26 @@ function cqn4sql(originalQuery, model) {
   }
 
   /**
-   * Transforms a search expression to a WHERE clause for a SELECT operation.
+   * Transforms a search expression into a WHERE or HAVING clause for a SELECT operation, depending on the context of the query.
+   * The function decides whether to use a WHERE or HAVING clause based on the presence of aggregated columns in the search criteria.
    *
-   * @param {object} search - The search expression which shall be applied to the searchable columns on the query source.
+   * @param {object} search - The search expression to be applied to the searchable columns within the query source.
    * @param {object} from - The FROM clause of the CQN statement.
    *
-   * @returns {(Object|Array|undefined)} - If the target of the query contains searchable elements, the function returns an array that represents the WHERE clause.
-   *     If the SELECT query already contains a WHERE clause, this array includes the existing clause and appends an AND condition with the new 'contains' clause.
-   *     If the SELECT query does not contain a WHERE clause, the returned array solely consists of the 'contains' clause.
-   *     If the target entity of the query does not contain searchable elements, the function returns null.
+   * @returns {(Object|Array|null)} - The function returns an object representing the WHERE or HAVING clause of the query:
+   *     - If the target of the query contains searchable elements, an array representing the WHERE or HAVING clause is returned.
+   *       This includes appending to an existing clause with an AND condition or creating a new clause solely with the 'contains' clause.
+   *     - If the SELECT query does not initially contain a WHERE or HAVING clause, the returned object solely consists of the 'contains' clause.
+   *     - If the target entity of the query does not contain searchable elements, the function returns null.
    *
+   * Note: The WHERE clause is used for filtering individual rows before any aggregation occurs.
+   * The HAVING clause is utilized for conditions on aggregated data, applied after grouping operations.
    */
-  function transformSearchToWhere(search, from) {
+  function transformSearch(search, from) {
     const entity = getDefinition(from.$refLinks[0].definition.target) || from.$refLinks[0].definition
-    const searchIn = computeColumnsToBeSearched(inferred, entity, from.as)
+    // pass transformedQuery because we may need to search in the columns directly
+    // in case of aggregation
+    const searchIn = computeColumnsToBeSearched(transformedQuery, entity, from.as)
     if (searchIn.length > 0) {
       const xpr = search
       const contains = {
@@ -228,10 +233,33 @@ function cqn4sql(originalQuery, model) {
         ],
       }
 
-      if (transformedQuery.SELECT.where) {
-        return [asXpr(transformedQuery.SELECT.where), 'and', contains]
+      // if the query is grouped and the queries columns contain an aggregate function,
+      // we must put the search term into the `having` clause, as the search expression
+      // is defined on the aggregated result, not on the individual rows
+      let prop = 'where'
+      // ANSI SQL aggregate functions
+      const aggregateFunctions = {
+        AVG: 1,
+        COUNT: 1,
+        MAX: 1,
+        MIN: 1,
+        SUM: 1,
+        EVERY: 1,
+        ANY: 1,
+        SOME: 1,
+        STDDEV_POP: 1,
+        STDDEV_SAMP: 1,
+        VAR_POP: 1,
+        VAR_SAMP: 1,
+        COLLECT: 1,
+        FUSION: 1,
+        INTERSECTION: 1,
+      }
+      if (inferred.SELECT.groupBy && searchIn.some(c => c.func in aggregateFunctions)) prop = 'having'
+      if (transformedQuery.SELECT[prop]) {
+        return { [prop]: [asXpr(transformedQuery.SELECT.where), 'and', contains] }
       } else {
-        return [contains]
+        return { [prop]: [contains] }
       }
     } else {
       return null
@@ -849,7 +877,8 @@ function cqn4sql(originalQuery, model) {
       } else if (pseudos.elements[col.ref?.[0]]) {
         res.push({ ...col })
       } else if (col.ref) {
-        if (col.$refLinks.some(link => getDefinition(link.definition.target)?.['@cds.persistence.skip'] === true)) continue
+        if (col.$refLinks.some(link => getDefinition(link.definition.target)?.['@cds.persistence.skip'] === true))
+          continue
         if (col.ref.length > 1 && col.ref[0] === '$self' && !col.$refLinks[0].definition.kind) {
           const dollarSelfReplacement = calculateDollarSelfColumn(col)
           res.push(...getTransformedOrderByGroupBy([dollarSelfReplacement], inOrderBy))
@@ -1738,7 +1767,8 @@ function cqn4sql(originalQuery, model) {
               if (res === '$self')
                 // next is resolvable in entity
                 return prev
-              const definition = prev?.elements?.[res] || getDefinition(prev?.target)?.elements[res] || pseudos.elements[res]
+              const definition =
+                prev?.elements?.[res] || getDefinition(prev?.target)?.elements[res] || pseudos.elements[res]
               const target = getParentEntity(definition)
               thing.$refLinks[i] = { definition, target, alias: definition.name }
               return prev?.elements?.[res] || getDefinition(prev?.target)?.elements[res] || pseudos.elements[res]

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -120,4 +120,15 @@ describe('Replace attribute search by search predicate', () => {
       search((books.createdBy, books.modifiedBy, books.anotherText, books.title, books.descr, books.currency_code, books.dedication_text, books.dedication_sub_foo, books.dedication_dedication), ('x' OR 'y')) `,
     )
   })
+  it('Search with aggregated column and groupby', () => {
+    let query = SELECT.from('bookshop.Books')
+      .columns({ args: [{ xpr: [{ ref: ['stock'] }] }], as: 'foo', func: 'count' })
+      .groupBy('title')
+      .search('foo')
+
+    let res = cqn4sql(query, model)
+    expect(JSON.parse(JSON.stringify(res.SELECT.where))).to.not.deep.equal([
+      { func: 'search', args: [{ args: [{ xpr: [{ ref: ['stock'] }] }], as: 'foo', func: 'count' }, { val: 'foo' }] },
+    ])
+  })
 })

--- a/test/scenarios/bookshop/index.js
+++ b/test/scenarios/bookshop/index.js
@@ -1,3 +1,4 @@
+require('./search.test')
 require('./read.test')
 require('./insert.test')
 require('./delete.test')

--- a/test/scenarios/bookshop/search.test.js
+++ b/test/scenarios/bookshop/search.test.js
@@ -1,0 +1,19 @@
+const cds = require('../../cds.js')
+const bookshop = require('path').resolve(__dirname, '../../bookshop')
+
+describe('Bookshop - Search', () => {
+  const { expect } = cds.test(bookshop)
+
+  // search expression operating on aggregated results, must be put into the having clause
+  describe('with aggregate function', () => {
+    test('min', async () => {
+      const { Books } = cds.entities
+      let res = await SELECT.from(Books)
+        .columns({ args: [{ ref: ['title'] }], as: 'firstInAlphabet', func: 'MIN' })
+        .groupBy('title')
+        .search('Cat')
+      expect(res.length).to.be.eq(1)
+    })
+  })
+
+})


### PR DESCRIPTION
Although this use case is probably not really common or makes much sense, there were some failing `cds` tests which should be fixed by this.

---

If the query contains a `group by`, the search is performed on the queries
columns. If one of those columns is an aggregate function,
we must put the search term in the `HAVING` clause instead of `WHERE`.
Since the logical processing order of SQL queries is `FROM -> WHERE -> GROUP BY -> HAVING -> SELECT -> ORDER BY` the aggregated results are not accessible in the `WHERE` clause.

This led to an error:

```sql
> Uncaught SqliteError: misuse of aggregate: COUNT() in:
SELECT
 COUNT(Books.stock) AS foo
FROM
  sap_capire_bookshop_Books AS Books
WHERE
  (IFNULL(INSTR(LOWER(COUNT(stock)), LOWER(?)), 0))
GROUP BY Books.title
```

With this change, the searchable columns of the query are
checked against the  aggregate functions of the ANSI SQL standard.
If one is found and the query contains a `group by` (which should then
always be the case), the search expression is put into the `HAVING` clause.