### PR TITLE
chore: return normal results for lock queries

### DIFF
--- a/db-service/lib/SQLService.js
+++ b/db-service/lib/SQLService.js
@@ -117,12 +117,7 @@ class SQLService extends DatabaseService {
     if (!query.target) {
       try { this.infer(query) } catch (e) { /**/ }
     }
-    if (
-      query.target
-      && !query.target._unresolved
-      && !query.SELECT.forUpdate
-      && !query.SELECT.forShareLock
-    ) {
+    if (query.target && !query.target._unresolved) {
       // Will return multiple rows with objects inside
       query.SELECT.expand = 'root'
     }

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -110,26 +110,34 @@ class HANAService extends SQLService {
     if (!query.target) {
       try { this.infer(query) } catch (e) { /**/ }
     }
-    if (
-      !query.target
-      || query.target._unresolved
-      || query.SELECT.forUpdate
-      || query.SELECT.forShareLock
-    ) {
+    if (!query.target || query.target._unresolved) {
       return super.onSELECT(req)
     }
 
-    // REVISIT: disable this for queries like (SELECT 1)
-    // Will return multiple rows with objects inside
-    query.SELECT.expand = 'root'
-    const { cqn, temporary, blobs, withclause, values } = this.cqn2sql(query, data)
+    const isLockQuery = query.SELECT.forUpdate || query.SELECT.forShareLock
+    if (!isLockQuery) {
+      // REVISIT: disable this for queries like (SELECT 1)
+      // Will return multiple rows with objects inside
+      query.SELECT.expand = 'root'
+    }
+
+    const { cqn, sql, temporary, blobs, withclause, values } = this.cqn2sql(query, data)
     delete query.SELECT.expand
 
     // REVISIT: add prepare options when param:true is used
-    const sqlScript = this.wrapTemporary(temporary, withclause, blobs)
+    const sqlScript = isLockQuery ? sql : this.wrapTemporary(temporary, withclause, blobs)
     let rows = (values?.length || blobs.length > 0)
       ? await (await this.prepare(sqlScript, blobs.length)).all(values || [])
       : await this.exec(sqlScript)
+
+    if (isLockQuery) {
+      // Fetch actual locked results
+      const resultQuery = query.clone()
+      resultQuery.SELECT.forUpdate = undefined
+      resultQuery.SELECT.forShareLock = undefined
+      return this.onSELECT({ query: resultQuery, __proto__: req })
+    }
+
     if (rows.length) {
       rows = this.parseRows(rows)
     }

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -309,11 +309,7 @@ describe('SELECT', () => {
     })
   })
 
-  const generalLockTest = (lock, shared = false) => {
-    const lock4 = bool => {
-      return lock.clone().where([{ ref: ['bool'] }, '=', { val: bool }])
-    }
-
+  const generalLockTest = (lock4, shared = false) => {
     const isSQLite = () => cds.db.options.impl === '@cap-js/sqlite'
 
     const setMax = max => {
@@ -345,6 +341,12 @@ describe('SELECT', () => {
 
     describe('pool max = 1', () => {
       setMax(1)
+      test('output converters apply to for update', async () => {
+        const query = lock4(true)
+        const [result] = await query
+        expect(result).to.have.all.keys(Object.keys(query.elements))
+      })
+
       test('two locks on a single table', async () => {
         const tx1 = await cds.tx()
         const tx2 = await cds.tx()
@@ -420,21 +422,28 @@ describe('SELECT', () => {
   }
 
   describe('forUpdate', () => {
-    const lock = SELECT.from('basic.projection.globals').forUpdate({
-      of: ['bool'],
-      wait: 0,
-    })
+    const boolLock = SELECT.from('basic.projection.globals')
+      .forUpdate({
+        of: ['bool'],
+        wait: 0,
+      })
 
-    generalLockTest(lock)
+    generalLockTest(bool => boolLock.clone()
+      .where([{ ref: ['bool'] }, '=', { val: bool }])
+    )
   })
 
   describe('forShareLock', () => {
-    const lock = SELECT.from('basic.projection.globals').forShareLock({
-      of: ['bool'],
-      wait: 0,
-    })
+    const boolLock = SELECT.from('basic.projection.globals')
+      .forShareLock({
+        of: ['bool'],
+        wait: 0,
+      })
 
-    generalLockTest(lock, true)
+    generalLockTest(bool => boolLock.clone()
+      .where([{ ref: ['bool'] }, '=', { val: bool }]),
+      true
+    )
   })
 
   describe('search', () => {

--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -89,7 +89,20 @@ describe('Bookshop - Read', () => {
       .columns('a.name', 'b.title')
       .where('b.ID in', s)
       .orderBy('b.ID')
-    expect(res).to.deep.eq({"name": "Emily Brontë", "title": "Wuthering Heights"})
+    expect(res).to.deep.eq({ "name": "Emily Brontë", "title": "Wuthering Heights" })
+  })
+
+  test('forUpdate query from path expression', async () => {
+    const { Books } = cds.entities('sap.capire.bookshop')
+    const query = SELECT([{ ref: ['ID'] }])
+      .from({ ref: [{ id: Books.name, where: [{ ref: ['ID'] }, '=', { val: 201 }] }, 'author'] })
+      .forUpdate({
+        of: ['ID'],
+        wait: 0,
+      })
+
+    const forUpdateResults = await cds.run(query)
+    expect(forUpdateResults).to.deep.eq([{ ID: 101 }])
   })
 
   test('Expand Book', async () => {


### PR DESCRIPTION
When using `forUpdate` or `forShareLock` now `sqlite` and `postgres` will both use normal `root` queries. While for HANA it will first execute the lock SQL and then execute the query with the lock removed. As HANA does not allow locks when using sub queries. 

Example:
```SQL
SELECT ID FROM (SELECT * FROM Books) FOR UDPATE ID NO WAIT -- cannot identify Books as the lock target table
```

When using expands in lock queries only the lock on the root table is guaranteed.