### PR TITLE
chore: use `cds.compiler.to.<…>.keywords` instead of requiring compiler

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -6,7 +6,7 @@ const { SQLService } = require('@cap-js/db-service')
 const drivers = require('./drivers')
 const cds = require('@sap/cds')
 const collations = require('./collations.json')
-const keywords = require('@sap/cds-compiler').to.hdi.keywords
+const keywords = cds.compiler.to.hdi.keywords
 // keywords come as array
 const hanaKeywords = keywords.reduce((prev, curr) => {
   prev[curr] = 1

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -5,7 +5,7 @@ const $session = Symbol('dbc.session')
 const convStrm = require('stream/consumers')
 const { Readable } = require('stream')
 
-const keywords = require('@sap/cds-compiler').to.sql.sqlite.keywords
+const keywords = cds.compiler.to.sql.sqlite.keywords
 // keywords come as array
 const sqliteKeywords = keywords.reduce((prev, curr) => {
   prev[curr] = 1


### PR DESCRIPTION
same will be done for postgres once available.

follow-up #525 #526