### PR TITLE
fix: mass insert for unknown entities

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -165,7 +165,7 @@ class HANAService extends SQLService {
       const results = await (entries
         ? HANAVERSION <= 2
           ? entries.reduce((l, c) => l.then(() => ps.run(c)), Promise.resolve(0))
-          : ps.run(entries[0])
+          : entries.length > 1 ? await ps.runBatch(entries) : await ps.run(entries[0])
         : ps.run())
       return new this.class.InsertResults(cqn, results)
     } catch (err) {

--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -19,4 +19,21 @@ describe('Bookshop - Insert', () => {
     const resp = await cds.run(INSERT({ stock: undefined, ID: 223, title: 'Harry Potter' }).into(Books))
     expect(resp | 0).to.be.eq(1)
   })
+
+  test('mass insert on unknown entities', async () => {
+    const books = 'sap_capire_bookshop_Books'
+    let affectedRows = await INSERT.into(books)
+      .entries([{
+        ID: 4711,
+        createdAt: (new Date()).toISOString(),
+      }, {
+        ID: 4712,
+        createdAt: (new Date()).toISOString(),
+      }])
+    expect(affectedRows | 0).to.be.eq(2)
+    
+    const res = await SELECT.from('sap.capire.bookshop.Books').where('ID in', [4711, 4712])
+    expect(res).to.have.length(2)
+  })
+    
 })


### PR DESCRIPTION
The fix was not required for the pipeline as the hana version is <= 2.
Local testing with hana cloud reveals that runBatch can be used and does the job for both drivers.