### PR TITLE
fix(`inline`, `expand`): Only accept on structures, assocs or table aliases

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -727,6 +727,9 @@ function infer(originalQuery, model) {
       function resolveInline(col, namePrefix = col.as || col.flatName) {
         const { inline, $refLinks } = col
         const $leafLink = $refLinks[$refLinks.length - 1]
+        if(!$leafLink.definition.target && !$leafLink.definition.elements) {
+          throw new Error(`Unexpected “inline” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`)
+        }
         let elements = {}
         inline.forEach(inlineCol => {
           inferQueryElement(inlineCol, false, $leafLink, { inExpr: true, inNestedProjection: true, baseColumn: col })
@@ -780,6 +783,9 @@ function infer(originalQuery, model) {
       function resolveExpand(col) {
         const { expand, $refLinks } = col
         const $leafLink = $refLinks?.[$refLinks.length - 1] || inferred.SELECT.from.$refLinks.at(-1) // fallback to anonymous expand
+        if(!$leafLink.definition.target && !$leafLink.definition.elements) {
+          throw new Error(`Unexpected “expand” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`)
+        }
         const target = getDefinition($leafLink.definition.target)
         if (target) {
           const expandSubquery = {
@@ -808,8 +814,6 @@ function infer(originalQuery, model) {
             }
           })
           return new cds.struct({ elements })
-        } else {
-          throw new Error(`Unexpected “expand” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`)
         }
       }
 

--- a/db-service/test/bookshop/db/schema.cds
+++ b/db-service/test/bookshop/db/schema.cds
@@ -300,6 +300,9 @@ entity SoccerPlayers {
   key jerseyNumber: Integer;
   name: String;
   team: Association to SoccerTeams;
+  emails: many {
+    address: String;
+  }
 }
 
 entity TestPublisher {

--- a/db-service/test/cds-infer/negative.test.js
+++ b/db-service/test/cds-infer/negative.test.js
@@ -376,6 +376,17 @@ describe('negative', () => {
         "Unexpected “expand” on “name”; can only be used after a reference to a structure, association or table alias"
       )
     })
+
+    it('inline on `.items` not possible', () => {
+      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name, emails.{ address } }`, model)).to.throw(
+        "Unexpected “inline” on “emails”; can only be used after a reference to a structure, association or table alias"
+      )
+    })
+    it('inline on scalar not possible', () => {
+      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name.{ address } }`, model)).to.throw(
+        "Unexpected “inline” on “name”; can only be used after a reference to a structure, association or table alias"
+      )
+    })
   })
 
   describe('infix filters', () => {

--- a/db-service/test/cds-infer/negative.test.js
+++ b/db-service/test/cds-infer/negative.test.js
@@ -365,6 +365,17 @@ describe('negative', () => {
         ),
       ).to.throw(/"title" not found in the elements of "bookshop.Authors"/)
     })
+
+    it('expand on `.items` not possible', () => {
+      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name, emails { address } }`, model)).to.throw(
+        "Unexpected “expand” on “emails”; can only be used after a reference to a structure, association or table alias"
+      )
+    })
+    it('expand on scalar not possible', () => {
+      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name { address } }`, model)).to.throw(
+        "Unexpected “expand” on “name”; can only be used after a reference to a structure, association or table alias"
+      )
+    })
   })
 
   describe('infix filters', () => {


### PR DESCRIPTION
an `expand` or `inline` on a `many` type has no defined behavior, yet.
→ as of now this is an error because the path cant be resolved (expand / inline without `.elements`)

we should reject it with a proper error, just as the compiler does for static views.