### PR TITLE
feat(sqlite): Enable sqlite to run inside workers

### DIFF
--- a/sqlite/lib/SQLiteWorker.js
+++ b/sqlite/lib/SQLiteWorker.js
@@ -1,0 +1,51 @@
+const { parentPort } = require('worker_threads')
+const sqlite = require('better-sqlite3')
+const $session = Symbol('dbc.session')
+
+const db = function (database) {
+  const dbc = new sqlite(database)
+
+  const deterministic = { deterministic: true }
+  dbc.function('session_context', key => dbc?.[$session]?.[key])
+  dbc.function('regexp', deterministic, (re, x) => (RegExp(re).test(x) ? 1 : 0))
+  dbc.function('ISO', deterministic, d => d && new Date(d).toISOString())
+
+  // define date and time functions in js to allow for throwing errors
+  const isTime = /^\d{1,2}:\d{1,2}:\d{1,2}$/
+  const hasTimezone = /([+-]\d{1,2}:?\d{0,2}|Z)$/
+  const toDate = (d, allowTime = false) => {
+    const date = new Date(allowTime && isTime.test(d) ? `1970-01-01T${d}Z` : hasTimezone.test(d) ? d : d + 'Z')
+    if (Number.isNaN(date.getTime())) throw new Error(`Value does not contain a valid ${allowTime ? 'time' : 'date'} "${d}"`)
+    return date
+  }
+  dbc.function('year', deterministic, d => d === null ? null : toDate(d).getUTCFullYear())
+  dbc.function('month', deterministic, d => d === null ? null : toDate(d).getUTCMonth() + 1)
+  dbc.function('day', deterministic, d => d === null ? null : toDate(d).getUTCDate())
+  dbc.function('hour', deterministic, d => d === null ? null : toDate(d, true).getUTCHours())
+  dbc.function('minute', deterministic, d => d === null ? null : toDate(d, true).getUTCMinutes())
+  dbc.function('second', deterministic, d => d === null ? null : toDate(d, true).getUTCSeconds())
+
+  dbc.cache = {}
+
+  if (!dbc.memory) dbc.pragma('journal_mode = WAL')
+  return dbc
+}
+
+const references = {}
+let counter = 1
+
+const keepTypes = { undefined: 1, prepare: 1 }
+parentPort.on('message', ({ id, ref, fn, args }) => {
+  try {
+    const keep = fn in keepTypes
+    const result = ref ? references[ref][fn](...args) : db(...args)
+    if (keep) {
+      const refId = counter++
+      references[refId] = result
+      return parentPort.postMessage({ id, ref: refId })
+    }
+    parentPort.postMessage({ id, result })
+  } catch (error) {
+    parentPort.postMessage({ id, error })
+  }
+});

--- a/sqlite/lib/SQLiteWorkerWrapper.js
+++ b/sqlite/lib/SQLiteWorkerWrapper.js
@@ -1,0 +1,81 @@
+const { Worker } = require('worker_threads');
+
+const _promise = function () {
+  const tmp = {}
+  return Object.assign(new Promise(function (resolve, reject) {
+    tmp.resolve = resolve
+    tmp.reject = reject
+  }), tmp)
+}
+
+class SQLiteWorkerWrapper {
+  constructor(...args) {
+    this._counter = 0
+    this._worker = new Worker(__dirname + '/SQLiteWorker.js')
+    this._proms = {}
+    this._ready = this._send({ args })
+
+    this._worker.on('online', () => { })
+    this._worker.on('message', (result) => {
+      const prom = this._proms[result.id]
+      if (result.error) {
+        return prom.reject(result.error)
+      }
+      prom.resolve(result)
+    })
+  }
+
+  async _send({ ref, fn, args }) {
+    if (!ref) {
+      if (this._ref) ref = this._ref
+      if (this._ready) ref = (await this._ready).ref
+    }
+    const prom = _promise()
+    const id = this._counter++
+    this._proms[id] = prom
+    try {
+      this._worker.postMessage({ id, ref, fn, args });
+    } catch (err) {
+      setImmediate(() => { prom.reject(err) })
+    }
+    return prom
+  }
+
+  async exec(...args) {
+    const { result } = this._send({ fn: 'exec', args })
+    return result
+  }
+
+  async prepare(...args) {
+    const { ref } = await this._send({ fn: 'prepare', args })
+    return new SQLiteWorkerWrapperStmt(this, ref)
+  }
+
+  close() {
+    this._worker.terminate()
+  }
+}
+
+class SQLiteWorkerWrapperStmt {
+  constructor(parent, ref) {
+    this._parent = parent
+    this._ref = ref
+  }
+
+  async run(...args) {
+    const { result } = await this._parent._send({ ref: this._ref, fn: 'run', args })
+    return result
+  }
+
+  async get(...args) {
+    const { result } = await this._parent._send({ ref: this._ref, fn: 'get', args })
+    return result
+  }
+
+  async all(...args) {
+    const { result } = await this._parent._send({ ref: this._ref, fn: 'all', args })
+    return result
+  }
+}
+
+module.exports = SQLiteWorkerWrapper


### PR DESCRIPTION
In certain scenarios it _might_ be beneficial to use sqlite in disk mode and have multiple worker threads processing the queries.