### PR TITLE
Reduce localized views

### DIFF
--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -2,6 +2,7 @@
 const cqn4sql = require('../../lib/cqn4sql')
 const cds = require('@sap/cds/lib')
 const { expect } = cds.test
+const transitive_ = !cds.unfold || 'transitive_localized_views' in cds.env.sql && cds.env.sql.transitive_localized_views !== false
 
 
 /**
@@ -1321,28 +1322,30 @@ describe('cap issue', () => {
     // the described scenario didn't work because in a localized scenario, the localized `foo`
     // association (pointing to `localized.Foo`) was compared to the non-localized version
     // of the association (pointing to `Foo`) and hence, the alias was not properly replaced
-    const cqn = CQL`SELECT from Foo:boos { ID } where exists foo.specialOwners[owner2_userID = $user.id] or exists foo.activeOwners[owner_userID = $user.id]`
-    cqn.SELECT.localized = true
-    let query = cqn4sql(cqn, model)
-    // cleanup
-    delete cqn.SELECT.localized
-    const localized_ = cds.unfold ? '' : 'localized.'
-    expect(query).to.deep.equal(CQL(`
-    SELECT from localized.Boo as boos { boos.ID }
-        WHERE EXISTS (
-          SELECT 1 from localized.Foo as Foo3 where Foo3.ID = boos.foo_ID
-        ) and
-        (
-          EXISTS (
-            SELECT 1 from localized.Foo as foo where foo.ID = boos.foo_ID
-              and EXISTS ( SELECT 1 from ${localized_}SpecialOwner2 as specialOwners where specialOwners.foo_ID = foo.ID and specialOwners.owner2_userID = $user.id )
-          )
-          or EXISTS (
-            SELECT 1 from localized.Foo as foo2 where foo2.ID = boos.foo_ID
-              and EXISTS ( SELECT 1 from ${localized_}ActiveOwner as activeOwners where activeOwners.foo_ID = foo2.ID and activeOwners.owner_userID = $user.id )
+    let q = SELECT.localized `from Foo:boos { ID }
+      where exists foo.specialOwners[owner2_userID = $user.id]
+      or exists foo.activeOwners[owner_userID = $user.id]
+    `
+    let q2 = cqn4sql(q, model)
+    expect(cds.clone(q2)).to.deep.equal(CQL(`
+      SELECT from localized.Boo as boos { boos.ID } WHERE EXISTS (
+        SELECT 1 from localized.Foo as Foo3 WHERE Foo3.ID = boos.foo_ID
+      ) AND (
+        EXISTS (
+          SELECT 1 from localized.Foo as foo WHERE foo.ID = boos.foo_ID AND EXISTS (
+            SELECT 1 from ${transitive_?'localized.':''}SpecialOwner2 as specialOwners
+            WHERE specialOwners.foo_ID = foo.ID and specialOwners.owner2_userID = $user.id
           )
         )
-      `))
+        OR
+        EXISTS (
+          SELECT 1 from localized.Foo as foo2 WHERE foo2.ID = boos.foo_ID AND EXISTS (
+            SELECT 1 from ${transitive_?'localized.':''}ActiveOwner as activeOwners
+            WHERE activeOwners.foo_ID = foo2.ID and activeOwners.owner_userID = $user.id
+          )
+        )
+      )
+    `))
   })
 })
 describe('comparisons of associations in on condition of elements needs to be expanded', () => {

--- a/sqlite/test/queries-without-models.test.js
+++ b/sqlite/test/queries-without-models.test.js
@@ -1,3 +1,4 @@
+const impl = require.resolve('../index')
 const cds = require('@sap/cds/lib')
 const { expect } = cds.test
 
@@ -6,7 +7,7 @@ if (!cds.DatabaseService.prototype.isDatabaseService) describe = describe.skip
 
 describe('Queries without models', () => {
   beforeAll(async () => {
-    let db = await cds.connect.to('db', { kind: 'better-sqlite' })
+    let db = cds.db = await cds.connect.to({ impl })
     await db.run(['CREATE table T1 (a,b)', 'CREATE table T2 (c,d,e)'])
   })
 
@@ -49,7 +50,7 @@ describe('Queries without models', () => {
 describe('Queries not in models', () => {
   beforeAll(async () => {
     let model = cds.linked(`entity Foo { key ID : UUID; bar: String }`)
-    let db = (cds.db = await cds.connect.to({ kind: 'better-sqlite', model }))
+    let db = cds.db = await cds.connect.to({ impl, model })
     await db.run(['CREATE table T1 (a,b)', 'CREATE table T2 (c,d,e)'])
   })
 


### PR DESCRIPTION
Adds support for new option `cds.env.sql.transitive_localized_views` to skip generating localized views for entities which don't have own localized elements, but only associations to such.
  - `undefined`: such views are not generated for new db services
  - `false`: they will never be generated
  - `true` they will always be generated
