### PR TITLE
test: use profiles instead of hard-coding configs in test

### DIFF
--- a/test/bookshop/package.json
+++ b/test/bookshop/package.json
@@ -22,6 +22,11 @@
   "cds": {
     "requires": {
       "db": "sql"
+    },
+    "features": {
+      "[new-odata-adapter]": {
+        "odata_new_adapter": true
+      }
     }
   }
 }

--- a/test/cds.js
+++ b/test/cds.js
@@ -36,6 +36,8 @@ let isolateCounter = 0
 // Overwrite cds.test with autoIsolation logic
 cds.test = Object.setPrototypeOf(function () {
 
+  let ret = cdsTest(...arguments)
+
   global.beforeAll(() => {
     try {
       const testSource = /(.*[\\/])test[\\/]/.exec(require.main.filename)?.[1]
@@ -47,8 +49,6 @@ cds.test = Object.setPrototypeOf(function () {
       cds.env.requires.db = require('@cap-js/sqlite/test/service')
     }
   })
-
-  let ret = cdsTest(...arguments)
 
   global.beforeAll(async () => {
     // Setup isolation after cds has prepare the project (e.g. cds.model)

--- a/test/scenarios/bookshop/funcs.test.js
+++ b/test/scenarios/bookshop/funcs.test.js
@@ -1,9 +1,8 @@
 const cds = require('../../cds.js')
 const bookshop = require('path').resolve(__dirname, '../../bookshop')
-cds.env.features.odata_new_adapter = true
 
 describe('Bookshop - Functions', () => {
-  const { expect, GET } = cds.test(bookshop)
+  const { expect, GET } = cds.test(bookshop, '--profile', 'new-odata-adapter')
 
   describe('String Functions', () => {
     test('concat', async () => {


### PR DESCRIPTION
accessing cds.env too early leads to unwanted side effects.
Instead of setting the value in the test, we should use profiles.

In addition, we should ensure that cds.test is always run first within our tests.