### PR TITLE
[WIP] fix(log): respect `sqlite` and `hana` logger IDs

### DIFF
--- a/db-service/lib/SQLService.js
+++ b/db-service/lib/SQLService.js
@@ -1,5 +1,5 @@
 const cds = require('@sap/cds/lib'),
-  DEBUG = cds.debug('sql|db')
+  DEBUG = cds.debug('sqlite|hana|sql|db')
 const { Readable } = require('stream')
 const { resolveView } = require('@sap/cds/libx/_runtime/common/utils/resolveView')
 const DatabaseService = require('./common/DatabaseService')


### PR DESCRIPTION
Hi @danjoa,

Could you please take a look at the following issue?

In `@cap-js/cds-dbs` logging of SQL statements is handled by the base class `SQLService` which presently instantiates a cds logger using the module string `sql|db`. This means logging cannot be enabled for the module names `sqlite` (and `hana`) as was the case previously and as is [documented in capire](https://cap.cloud.sap/docs/node.js/cds-log#configuration).

In the old DB layer, the logger responsible for logging SQLite statements was instantiated using the module string `sqlite|db|sql` and the SAP HANA logger was instantiated using the module string `hana|db|sql`. This allowed logging to be enabled using `DEBUG=sqlite` and `DEBUG=hana` respectively, as well as:

```json
{
  "cds": {
    "log": {
      "levels": {
        "sqlite": "debug",
        "hana": "debug"
      }
    }
  }
}
```

The problem lies in restoring this functionality in the new DB layer, due to the architecture of the new DB layer and the way the `cds.log` API currently works (with regards to picking the first module name in the module string as a logger id and caching the logger instance).

If logging should continue to be handled by the base class `SQLService`, the logger needs to be instantiated with the module string that contains the name of the currently used DB module. This could be done explicitly by passing all module names to the logger, e.g. `sqlite|hana|sql|db`, but this would require knowledge about the child classes in the base class. Additionally this logger would only be able to be configured using the module string `sqlite` (first module as logger id) since the remaining modules are only respected by the env var `DEBUG`, but by the `cds.env.log` configuration. Alternatively something like this could be done ```cds.log(`${cds.requires.db.kind}|db|sql`)```, but this doesn't seem ideal either.

Alternatively logging could be implemented by the child classes themselves, but this would introduce duplicate code that could be avoided in the base class.

Additionally, please note that `SQLService` instantiates a logger using the module string `sql|db` (see [here](https://github.com/cap-js/cds-dbs/blob/55e511471743c0445d41e8297f5530abe167a270/db-service/lib/SQLService.js#L2)) and `CQN2SQLRenderer` instantiates a logger using the module string `sql|sqlite` (see [here](https://github.com/cap-js/cds-dbs/blob/55e511471743c0445d41e8297f5530abe167a270/db-service/lib/cqn2sql.js#L16)). This means that both loggers have the same logger id `sql`, which means that the module `sqlite` is always ignored if `SQLService` is instantiated before `CQN2SQLRenderer` and caches the logger. This means that instantiating loggers with the same logger id is fragile unless the logger is always instantiated with the exact same module string listing all modules.

Do you have any ideas on how to best solve this issue?

Best regards,
Marcel
