### PR TITLE
chore: keep sorting props `asc`, `desc`, `nulls`

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -889,6 +889,9 @@ function cqn4sql(originalQuery, model) {
               return c.as === col.ref[0] || c.ref?.at(-1) === col.ref[0]
             })
             if (referredCol) {
+              // keep sort and nulls properties
+              referredCol.sort = col.sort
+              referredCol.nulls = col.nulls
               col = referredCol
               if (definition.kind === 'element') {
                 tableAlias = getQuerySourceName(col)

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -445,14 +445,12 @@ describe('table alias access', () => {
       ORDER BY Books.title, Books.title`)
     })
     it('same as above but descriptors like "asc", "desc" etc. must be kept', () => {
-      // as down the line we always use collation expressions for localized sorting
-      // we must prepend the table alias.
-      // The simple reference will be wrapped in the expression and hence, expression name resolution rules kick in
-      // see also https://github.com/cap-js/cds-dbs/issues/543
-      const query = SELECT.localized
-        .from('bookshop.Books')
-        .columns('title', 'title as foo', 'author.name as author')
-        .orderBy('title asc', 'foo desc')
+      const query = CQL`SELECT from bookshop.Books { 
+        title,
+        title as foo,
+        author.name as author
+      } order by title asc nulls first, foo desc nulls last`
+      query.SELECT.localized = true
       let res = cqn4sql(query, model)
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`
       SELECT from bookshop.Books as Books
@@ -462,7 +460,7 @@ describe('table alias access', () => {
         Books.title as foo,
         author.name as author
       }
-      ORDER BY Books.title asc, Books.title desc`)
+      ORDER BY Books.title asc nulls first, Books.title desc nulls last`)
     })
     it('for localized sorting, replace string expression', () => {
       const query = CQL(`SELECT from bookshop.Books {

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -444,6 +444,26 @@ describe('table alias access', () => {
       }
       ORDER BY Books.title, Books.title`)
     })
+    it('same as above but descriptors like "asc", "desc" etc. must be kept', () => {
+      // as down the line we always use collation expressions for localized sorting
+      // we must prepend the table alias.
+      // The simple reference will be wrapped in the expression and hence, expression name resolution rules kick in
+      // see also https://github.com/cap-js/cds-dbs/issues/543
+      const query = SELECT.localized
+        .from('bookshop.Books')
+        .columns('title', 'title as foo', 'author.name as author')
+        .orderBy('title asc', 'foo desc')
+      let res = cqn4sql(query, model)
+      expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`
+      SELECT from bookshop.Books as Books
+      left join bookshop.Authors as author on author.ID = Books.author_ID
+      {
+        Books.title,
+        Books.title as foo,
+        author.name as author
+      }
+      ORDER BY Books.title asc, Books.title desc`)
+    })
     it('for localized sorting, replace string expression', () => {
       const query = CQL(`SELECT from bookshop.Books {
         'simple string' as foo: cds.String,


### PR DESCRIPTION
this is a fix for #546, where those properties in some cases got lost.