### PR TITLE
fix: only consider persisted columns for simple operations

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -749,7 +749,9 @@ class CQN2SQLRenderer {
     if (_with) _add(_with, x => this.expr(x))
     function _add(data, sql4) {
       for (let c in data) {
-        if (!elements || (c in elements && !elements[c].virtual)) {
+        const columnExistsInDatabase =
+          c in elements && !elements[c].virtual && !elements[c].isAssociation && !elements[c].value
+        if (!elements || columnExistsInDatabase) {
           if (cds.unfold && elements?.[c].is_struct) continue // skip structs from universal csn
           columns.push({ name: c, sql: sql4(data[c]) })
         }

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -751,7 +751,7 @@ class CQN2SQLRenderer {
       for (let c in data) {
         const columnExistsInDatabase =
           elements && c in elements && !elements[c].virtual && !elements[c].isAssociation && !elements[c].value
-        if (columnExistsInDatabase) {
+        if (!elements || columnExistsInDatabase) {
           columns.push({ name: c, sql: sql4(data[c]) })
         }
       }

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -750,9 +750,8 @@ class CQN2SQLRenderer {
     function _add(data, sql4) {
       for (let c in data) {
         const columnExistsInDatabase =
-          c in elements && !elements[c].virtual && !elements[c].isAssociation && !elements[c].value
-        if (!elements || columnExistsInDatabase) {
-          if (cds.unfold && elements?.[c].is_struct) continue // skip structs from universal csn
+          elements && c in elements && !elements[c].virtual && !elements[c].isAssociation && !elements[c].value
+        if (!columnExistsInDatabase) {
           columns.push({ name: c, sql: sql4(data[c]) })
         }
       }

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -751,7 +751,7 @@ class CQN2SQLRenderer {
       for (let c in data) {
         const columnExistsInDatabase =
           elements && c in elements && !elements[c].virtual && !elements[c].isAssociation && !elements[c].value
-        if (!columnExistsInDatabase) {
+        if (columnExistsInDatabase) {
           columns.push({ name: c, sql: sql4(data[c]) })
         }
       }

--- a/test/bookshop/db/data/sap.capire.bookshop-Authors.csv
+++ b/test/bookshop/db/data/sap.capire.bookshop-Authors.csv
@@ -1,5 +1,5 @@
-ID;name;dateOfBirth;placeOfBirth;dateOfDeath;placeOfDeath
-101;Emily Brontë;1818-07-30;Thornton, Yorkshire;1848-12-19;Haworth, Yorkshire
-107;Charlotte Brontë;1818-04-21;Thornton, Yorkshire;1855-03-31;Haworth, Yorkshire
-150;Edgar Allen Poe;1809-01-19;Boston, Massachusetts;1849-10-07;Baltimore, Maryland
-170;Richard Carpenter;1929-08-14;King’s Lynn, Norfolk;2012-02-26;Hertfordshire, England
+ID;name;dateOfBirth;placeOfBirth;dateOfDeath;placeOfDeath; city; street;
+101;Emily Brontë;1818-07-30;Thornton, Yorkshire;1848-12-19;Haworth, Yorkshire; Bradford; 1 Main Street
+107;Charlotte Brontë;1818-04-21;Thornton, Yorkshire;1855-03-31;Haworth, Yorkshire; Bradford; 2 Main Street
+150;Edgar Allen Poe;1809-01-19;Boston, Massachusetts;1849-10-07;Baltimore, Maryland; Baltimore; 1 Main Street
+170;Richard Carpenter;1929-08-14;King’s Lynn, Norfolk;2012-02-26;Hertfordshire, England; London; 1 Main Street

--- a/test/bookshop/db/schema.cds
+++ b/test/bookshop/db/schema.cds
@@ -12,6 +12,8 @@ entity Books : managed {
   currency : Currency;
   image : LargeBinary @Core.MediaType : 'image/png';
   footnotes: array of String;
+
+   authorsAddress: String = author.address;
 }
 
 entity Authors : managed {
@@ -22,6 +24,10 @@ entity Authors : managed {
   placeOfBirth : String;
   placeOfDeath : String;
   books  : Association to many Books on books.author = $self;
+
+  street: String;
+  city: String;
+  address: String = street || ', ' || city;
 }
 
 /** Hierarchically organized Code List for Genres */

--- a/test/scenarios/bookshop/update.test.js
+++ b/test/scenarios/bookshop/update.test.js
@@ -10,7 +10,7 @@ const admin = {
 describe('Bookshop - Update', () => {
   const { expect, PUT } = cds.test(bookshop)
 
-  test('Update Book', async () => {
+  test.only('Update Book', async () => {
     const res = await PUT(
       '/admin/Books(201)', // was Books(2) -> UPSERT
       {

--- a/test/scenarios/bookshop/update.test.js
+++ b/test/scenarios/bookshop/update.test.js
@@ -10,7 +10,7 @@ const admin = {
 describe('Bookshop - Update', () => {
   const { expect, PUT } = cds.test(bookshop)
 
-  test.only('Update Book', async () => {
+  test('Update Book', async () => {
     const res = await PUT(
       '/admin/Books(201)', // was Books(2) -> UPSERT
       {


### PR DESCRIPTION
it doesnt make sense to `UPDATE`, `DELETE` or to `INSERT` a virtual element, which only exists during runtime, such as:

- `virtual` elements
- calculated elements
- associations
