### PR TITLE
fix: flat update with arbitrary where clauses

### DIFF
--- a/db-service/lib/deep-queries.js
+++ b/db-service/lib/deep-queries.js
@@ -265,4 +265,5 @@ module.exports = {
   onDeep,
   getDeepQueries,
   getExpandForDeep,
+  hasDeep,
 }

--- a/db-service/lib/fill-in-keys.js
+++ b/db-service/lib/fill-in-keys.js
@@ -1,4 +1,5 @@
 const cds = require('@sap/cds')
+const { hasDeep } = require('../lib/deep-queries')
 
 // REVISIT: very deep & fragile dependencies to internal modules -> copy these into here
 const propagateForeignKeys = require('@sap/cds/libx/_runtime/common/utils/propagateForeignKeys')
@@ -58,9 +59,7 @@ module.exports = async function fill_in_keys(req, next) {
   // REVISIT dummy handler until we have input processing
   if (!req.target || !this.model || req.target._unresolved) return next()
   // only for deep update
-  const containsObjectOrArray = obj =>
-    Object.values(obj).some(val => Array.isArray(val) || (typeof val === 'object' && val !== null))
-  if (req.event === 'UPDATE' && containsObjectOrArray(req.data)) {
+  if (req.event === 'UPDATE' && hasDeep(req.query, req.target)) {
     // REVISIT for deep update we need to inject the keys first
     enrichDataWithKeysFromWhere(req.data, req, this)
   }

--- a/db-service/lib/fill-in-keys.js
+++ b/db-service/lib/fill-in-keys.js
@@ -57,9 +57,12 @@ const generateUUIDandPropagateKeys = (entity, data, event) => {
 module.exports = async function fill_in_keys(req, next) {
   // REVISIT dummy handler until we have input processing
   if (!req.target || !this.model || req.target._unresolved) return next()
-  if (req.event === 'UPDATE') {
+  // only for deep update
+  const containsObjectOrArray = obj =>
+    Object.values(obj).some(val => Array.isArray(val) || (typeof val === 'object' && val !== null))
+  if (req.event === 'UPDATE' && containsObjectOrArray(req.data)) {
     // REVISIT for deep update we need to inject the keys first
-    enrichDataWithKeysFromWhere (req.data, req, this)
+    enrichDataWithKeysFromWhere(req.data, req, this)
   }
 
   // REVISIT no input processing for INPUT with rows/values

--- a/test/compliance/UPDATE.test.js
+++ b/test/compliance/UPDATE.test.js
@@ -1,3 +1,6 @@
+const cds = require('../cds.js')
+const Books = 'complex.Books'
+
 describe('UPDATE', () => {
   describe('entity', () => {
     test.skip('missing', () => {
@@ -12,6 +15,36 @@ describe('UPDATE', () => {
   })
 
   describe('where', () => {
+    cds.test(__dirname + '/resources')
+    test('flat with or on key', async () => {
+      const entires = [
+        {
+          ID: 5,
+          title: 'foo',
+        },
+        {
+          ID: 6,
+          title: 'bar',
+        },
+      ]
+
+      const insert = await cds.run(INSERT.into(Books).entries(entires))
+      expect(insert.affectedRows).toEqual(2)
+
+      const update = await cds.run(
+        UPDATE.entity(Books)
+          .set({
+            title: 'foo',
+          })
+          .where({
+            ID: 5,
+            or: {
+              ID: 6,
+            },
+          }),
+      )
+      expect(update).toEqual(2)
+    })
     test.skip('missing', () => {
       throw new Error('not supported')
     })


### PR DESCRIPTION
Flat update with or on keys in where resulted in error `UNIQUE_CONSTRAINT_VIOLATION`.
Solution: Only enrich data with keys from where for deep update.