### PR TITLE
fix(`order by`): reject non-fk traversals of own columns in order by

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -336,7 +336,12 @@ function infer(originalQuery, model) {
         let $baseLink
         // first check if token ref is resolvable in query elements
         if (columns) {
-          const e = queryElements[token.ref?.[0]]
+          const firstStep = token.ref?.[0].id || token.ref?.[0]
+          const targetsCol = columns.some(c => {
+            const columnName = c.as || c.flatName || c.ref?.at(-1).id || c.ref?.at(-1) || c.func
+            return columnName === firstStep
+          })
+          const e = targetsCol && queryElements[token.ref?.[0]]
           const isAssocExpand = e?.$assocExpand // expand on structure can be addressed
           if (e && !isAssocExpand) $baseLink = { definition: { elements: queryElements }, target: inferred }
         } else {
@@ -467,7 +472,7 @@ function infer(originalQuery, model) {
      */
 
     function inferQueryElement(column, insertIntoQueryElements = true, $baseLink = null, context) {
-      const { inExists, inExpr, inNestedProjection, inCalcElement, baseColumn } = context || {}
+      const { inExists, inExpr, inNestedProjection, inCalcElement, baseColumn, inInfixFilter } = context || {}
       if (column.param || column.SELECT) return // parameter references are only resolved into values on execution e.g. :val, :1 or ?
       if (column.args) column.args.forEach(arg => inferQueryElement(arg, false, $baseLink, context)) // e.g. function in expression
       if (column.list) column.list.forEach(arg => inferQueryElement(arg, false, $baseLink, context))
@@ -604,10 +609,11 @@ function infer(originalQuery, model) {
               inferQueryElement(token, false, column.$refLinks[i], {
                 inExists: skipJoinsForFilter,
                 inExpr: !!token.xpr,
+                inInfixFilter: true,
               })
             } else if (token.func) {
               token.args?.forEach(arg =>
-                inferQueryElement(arg, false, column.$refLinks[i], { inExists: skipJoinsForFilter, inExpr: true }),
+                inferQueryElement(arg, false, column.$refLinks[i], { inExists: skipJoinsForFilter, inExpr: true, inInfixFilter: true, }),
               )
             }
           })
@@ -668,7 +674,7 @@ function infer(originalQuery, model) {
          * @param {CSN.Element} assoc if this is an association, the next step must be a foreign key of the element.
          */
         function rejectNonFkAccess(assoc) {
-          if (!inNestedProjection && !inCalcElement && assoc.target) {
+          if (inInfixFilter && !inNestedProjection && !inCalcElement && assoc.target) {
             // only fk access in infix filter
             const nextStep = column.ref[i + 1]?.id || column.ref[i + 1]
             // no unmanaged assoc in infix filter path
@@ -678,7 +684,7 @@ function infer(originalQuery, model) {
               )
             // no non-fk traversal in infix filter in non-exists path
             if (nextStep && !assoc.on && !isForeignKeyOf(nextStep, assoc))
-              throw new Error(`Only foreign keys of "${assoc.name}" can be accessed in infix filter`)
+              throw new Error(`Only foreign keys of "${assoc.name}" can be accessed in infix filter, not "${nextStep}"`)
           }
         }
       })
@@ -727,8 +733,10 @@ function infer(originalQuery, model) {
       function resolveInline(col, namePrefix = col.as || col.flatName) {
         const { inline, $refLinks } = col
         const $leafLink = $refLinks[$refLinks.length - 1]
-        if(!$leafLink.definition.target && !$leafLink.definition.elements) {
-          throw new Error(`Unexpected “inline” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`)
+        if (!$leafLink.definition.target && !$leafLink.definition.elements) {
+          throw new Error(
+            `Unexpected “inline” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`,
+          )
         }
         let elements = {}
         inline.forEach(inlineCol => {
@@ -783,8 +791,10 @@ function infer(originalQuery, model) {
       function resolveExpand(col) {
         const { expand, $refLinks } = col
         const $leafLink = $refLinks?.[$refLinks.length - 1] || inferred.SELECT.from.$refLinks.at(-1) // fallback to anonymous expand
-        if(!$leafLink.definition.target && !$leafLink.definition.elements) {
-          throw new Error(`Unexpected “expand” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`)
+        if (!$leafLink.definition.target && !$leafLink.definition.elements) {
+          throw new Error(
+            `Unexpected “expand” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`,
+          )
         }
         const target = getDefinition($leafLink.definition.target)
         if (target) {

--- a/db-service/test/cds-infer/negative.test.js
+++ b/db-service/test/cds-infer/negative.test.js
@@ -368,23 +368,23 @@ describe('negative', () => {
 
     it('expand on `.items` not possible', () => {
       expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name, emails { address } }`, model)).to.throw(
-        "Unexpected “expand” on “emails”; can only be used after a reference to a structure, association or table alias"
+        'Unexpected “expand” on “emails”; can only be used after a reference to a structure, association or table alias',
       )
     })
     it('expand on scalar not possible', () => {
       expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name { address } }`, model)).to.throw(
-        "Unexpected “expand” on “name”; can only be used after a reference to a structure, association or table alias"
+        'Unexpected “expand” on “name”; can only be used after a reference to a structure, association or table alias',
       )
     })
 
     it('inline on `.items` not possible', () => {
       expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name, emails.{ address } }`, model)).to.throw(
-        "Unexpected “inline” on “emails”; can only be used after a reference to a structure, association or table alias"
+        'Unexpected “inline” on “emails”; can only be used after a reference to a structure, association or table alias',
       )
     })
     it('inline on scalar not possible', () => {
       expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name.{ address } }`, model)).to.throw(
-        "Unexpected “inline” on “name”; can only be used after a reference to a structure, association or table alias"
+        'Unexpected “inline” on “name”; can only be used after a reference to a structure, association or table alias',
       )
     })
   })
@@ -404,6 +404,22 @@ describe('negative', () => {
           model,
         ),
       ).to.throw(/Only foreign keys of "author" can be accessed in infix filter/)
+    })
+  })
+
+  describe('order by', () => {
+    it('reject join relevant path via queries own columns', () => {
+      let query = CQL`SELECT from bookshop.Books  {
+        ID,
+        author,
+        coAuthor as co
+      }
+      order by
+        Books.author,
+        co.name`
+      expect(() => {
+        cqn4sql(query, model)
+      }).to.throw(/Can follow managed association “co” only to the keys of its target, not to “name”/)
     })
   })
 })

--- a/db-service/test/cqn4sql/flattening.test.js
+++ b/db-service/test/cqn4sql/flattening.test.js
@@ -651,22 +651,25 @@ describe('Flattening', () => {
         co_ID
       `)
     })
-    // TODO
-    it('same as above but navigation along column in order by', () => {
+    it('same as above but navigation to foreign key in order by', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books  { ID, author, coAuthor as co }
-        order by Books.author, co.name`,
+        CQL`SELECT from bookshop.Books  {
+          ID,
+          author,
+          coAuthor as co
+        }
+        order by
+          Books.author,
+          co.ID`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
-      left join bookshop.Authors as co on co.ID = Books.coAuthor_ID
-      {
+      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.author_ID,
         Books.coAuthor_ID as co_ID
       } order by
         Books.author_ID,
-        co.name
+        co_ID
       `)
     })
 
@@ -852,5 +855,4 @@ describe('Flattening', () => {
       )
     })
   })
-
 })

--- a/db-service/test/cqn4sql/flattening.test.js
+++ b/db-service/test/cqn4sql/flattening.test.js
@@ -651,6 +651,24 @@ describe('Flattening', () => {
         co_ID
       `)
     })
+    // TODO
+    it('same as above but navigation along column in order by', () => {
+      let query = cqn4sql(
+        CQL`SELECT from bookshop.Books  { ID, author, coAuthor as co }
+        order by Books.author, co.name`,
+        model,
+      )
+      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+      left join bookshop.Authors as co on co.ID = Books.coAuthor_ID
+      {
+        Books.ID,
+        Books.author_ID,
+        Books.coAuthor_ID as co_ID
+      } order by
+        Books.author_ID,
+        co.name
+      `)
+    })
 
     it('rejects managed association with multiple FKs in ORDER BY clause', () => {
       expect(() =>

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -553,7 +553,8 @@ describe('table alias access', () => {
       { SimpleBook.ID, SimpleBook.title, SimpleBook.author_ID } order by author.name`
       expect(query).to.deep.equal(expected)
     })
-    it('same as above but author is explicit column', () => {
+    // doesnt work, can't join with the query source itself
+    it.skip('same as above but author is explicit column', () => {
       let input = CQL`SELECT from bookshop.SimpleBook { *, author } order by author.name`
       let query = cqn4sql(input, model)
       const expected = CQL`SELECT from bookshop.SimpleBook as SimpleBook left join bookshop.Authors as author on author.ID = SimpleBook.author_ID

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -545,6 +545,22 @@ describe('table alias access', () => {
       let query = cqn4sql(input, model)
       expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { func() as func } order by func`)
     })
+
+    it('do not try to resolve ref in columns if columns consists of star', () => {
+      let input = CQL`SELECT from bookshop.SimpleBook { * } order by author.name`
+      let query = cqn4sql(input, model)
+      const expected = CQL`SELECT from bookshop.SimpleBook as SimpleBook left join bookshop.Authors as author on author.ID = SimpleBook.author_ID
+      { SimpleBook.ID, SimpleBook.title, SimpleBook.author_ID } order by author.name`
+      expect(query).to.deep.equal(expected)
+    })
+    it('same as above but author is explicit column', () => {
+      let input = CQL`SELECT from bookshop.SimpleBook { *, author } order by author.name`
+      let query = cqn4sql(input, model)
+      const expected = CQL`SELECT from bookshop.SimpleBook as SimpleBook left join bookshop.Authors as author on author.ID = SimpleBook.author_ID
+      { SimpleBook.ID, SimpleBook.title, SimpleBook.author_ID } order by author.name`
+      expect(query).to.deep.equal(expected)
+    })
+  
   })
 
   describe('replace usage of implicit aliases in subqueries', () => {


### PR DESCRIPTION
`refs` in `order by` can address queries own columns, if such a `ref` traverses an association to a non-foreign key field as in this example: 

```sql
SELECT from bookshop.Books as foo {
        ID,
        author,
        coAuthor as co
      }
      order by
        co.name -- join with query "foo" not possible
```

we must reject the traversal, as the join partner of `Authors` is the query itself

### other changes:

fix(`order by`): do not mistake simple name with infix filter
  another fix do not mistake simple name with infix filter: If
  the query has `columns` but they solely consist of `*`, 
  `cqn4sql` wrongly assumed that an association traversal has to be resolved in the queries elements, this lead to a 
  confusing error complaining that only foreign key of assocs can be traversed in infix filters.
