### PR TITLE
fix: assign artificial alias if selecting from anonymous subquery

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1576,12 +1576,13 @@ function cqn4sql(originalQuery, model) {
       return { transformedFrom }
     } else if (from.SELECT) {
       transformedFrom = transformSubquery(from)
-      if (from.as)
+      if (from.as) {
         // preserve explicit TA
         transformedFrom.as = from.as
-      // select from anonymous query, use artificial alias
-      else
+      } else {
+        // select from anonymous query, use artificial alias
         transformedFrom.as = Object.keys(originalQuery.sources)[0]
+      }
       return { transformedFrom }
     } else {
       return _transformFrom()

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1579,6 +1579,9 @@ function cqn4sql(originalQuery, model) {
       if (from.as)
         // preserve explicit TA
         transformedFrom.as = from.as
+      // select from anonymous query, use artificial alias
+      else
+        transformedFrom.as = Object.keys(originalQuery.sources)[0]
       return { transformedFrom }
     } else {
       return _transformFrom()

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -125,7 +125,7 @@ function infer(originalQuery, model) {
     } else if (from.SELECT) {
       const subqueryInFrom = infer(from, model) // we need the .elements in the sources
       // if no explicit alias is provided, we make up one
-      const subqueryAlias = from.as || subqueryInFrom.joinTree.addNextAvailableTableAlias('__select__')
+      const subqueryAlias = from.as || subqueryInFrom.joinTree.addNextAvailableTableAlias('__select__', subqueryInFrom.outerQueries)
       querySources[subqueryAlias] = { definition: from }
     } else if (typeof from === 'string') {
       // TODO: Create unique alias, what about duplicates?

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -123,8 +123,10 @@ function infer(originalQuery, model) {
     } else if (from.args) {
       from.args.forEach(a => inferTarget(a, querySources))
     } else if (from.SELECT) {
-      infer(from, model) // we need the .elements in the sources
-      querySources[from.as || ''] = { definition: from }
+      const subqueryInFrom = infer(from, model) // we need the .elements in the sources
+      // if no explicit alias is provided, we make up one
+      const subqueryAlias = from.as || subqueryInFrom.joinTree.addNextAvailableTableAlias('__select__')
+      querySources[subqueryAlias] = { definition: from }
     } else if (typeof from === 'string') {
       // TODO: Create unique alias, what about duplicates?
       const definition = getDefinition(from) || cds.error`"${from}" not found in the definitions of your model`

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -169,6 +169,7 @@ class JoinTree {
         if (
           r.queryArtifact === head.target ||
           r.queryArtifact === head.target.target /** might as well be a query for order by */
+          // r.queryArtifact.target === head.target /** selecting from sub-select*/
         )
           node = r
       })
@@ -176,6 +177,7 @@ class JoinTree {
       i += 1 // skip first step which is table alias
     }
 
+    if(!node) return 
     while (i < col.ref.length) {
       const step = col.ref[i]
       const { where, args } = step

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -169,7 +169,6 @@ class JoinTree {
         if (
           r.queryArtifact === head.target ||
           r.queryArtifact === head.target.target /** might as well be a query for order by */
-          // r.queryArtifact.target === head.target /** selecting from sub-select*/
         )
           node = r
       })
@@ -177,7 +176,8 @@ class JoinTree {
       i += 1 // skip first step which is table alias
     }
 
-    if(!node) return 
+    // if no root node was found, the column is selected from a subquery
+    if(!node) return
     while (i < col.ref.length) {
       const step = col.ref[i]
       const { where, args } = step

--- a/db-service/test/bookshop/db/booksWithExpr.cds
+++ b/db-service/test/bookshop/db/booksWithExpr.cds
@@ -84,3 +84,10 @@ entity LBooks {
   width : Decimal;
   area : Decimal = length * width;
 }
+
+entity Simple {
+  key ID: Integer;
+  name: String;
+  my: Association to Simple;
+  myName: String = my.name;
+}

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -509,6 +509,58 @@ describe('Unfolding calculated elements in select list', () => {
     expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)
   })
 
+  // TODO
+  
+  it.skip('wildcard select from subquery', () => {
+    let query = cqn4sql(
+      CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } )`,
+      model,
+    )
+    const expected = CQL`
+    SELECT from (
+      SELECT from booksCalc.Simple as Simple
+      left join booksCalc.Simple as my on my.ID = Simple.my_ID 
+        {
+          Simple.ID,
+          Simple.name,
+          Simple.my_ID,
+          my.name as myName
+        }
+    ) {
+      ID,
+      name,
+      my_ID,
+      myName
+    }
+    `
+    expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)
+  })
+  it.skip('wildcard select from subquery + join relevant path expression', () => {
+    let query = cqn4sql(
+      CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } ) {
+        my.name as otherName
+      }`,
+      model,
+    )
+    const expected = CQL`
+    SELECT from (
+      SELECT from booksCalc.Simple as Simple
+      left join booksCalc.Simple as my on my.ID = Simple.my_ID 
+        {
+          Simple.ID,
+          Simple.name,
+          Simple.my_ID
+        }
+    ) {
+      ID,
+      name,
+      my_ID,
+      myName
+    }
+    `
+    expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)
+  })
+
   it('replacement for calculated element is considered for wildcard expansion', () => {
     let query = cqn4sql(
       CQL`SELECT from booksCalc.Books { *, volume as ctitle } excluding { length, width, height, stock, price, youngAuthorName }`,

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -509,9 +509,7 @@ describe('Unfolding calculated elements in select list', () => {
     expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)
   })
 
-  // TODO
-  
-  it.skip('wildcard select from subquery', () => {
+  it('wildcard select from subquery', () => {
     let query = cqn4sql(
       CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } )`,
       model,
@@ -526,16 +524,17 @@ describe('Unfolding calculated elements in select list', () => {
           Simple.my_ID,
           my.name as myName
         }
-    ) {
-      ID,
-      name,
-      my_ID,
-      myName
+    ) as __select__ {
+      __select__.ID,
+      __select__.name,
+      __select__.my_ID,
+      __select__.myName
     }
     `
     expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)
   })
-  it.skip('wildcard select from subquery + join relevant path expression', () => {
+
+  it('wildcard select from subquery + join relevant path expression', () => {
     let query = cqn4sql(
       CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } ) {
         my.name as otherName
@@ -545,17 +544,15 @@ describe('Unfolding calculated elements in select list', () => {
     const expected = CQL`
     SELECT from (
       SELECT from booksCalc.Simple as Simple
-      left join booksCalc.Simple as my on my.ID = Simple.my_ID 
+      left join booksCalc.Simple as my2 on my2.ID = Simple.my_ID 
         {
           Simple.ID,
           Simple.name,
-          Simple.my_ID
+          Simple.my_ID,
+          my2.name as myName
         }
-    ) {
-      ID,
-      name,
-      my_ID,
-      myName
+    ) as __select__ left join booksCalc.Simple as my on my.ID = __select__.my_ID {
+      my.name as otherName
     }
     `
     expect(JSON.parse(JSON.stringify(query))).to.deep.equal(expected)


### PR DESCRIPTION
This is necessary if we expose an association in the inner query and traverse it in the outer query:

```cds
select from (select from Books) { author.name }
```

to come up with a proper join node, we must add a table alias around the subquery in from.
I came up with `__select__` as artifical name. To make it always unique, I request a unique alias from the subquery based on `__select__`, the subquery knows all outer aliases and is able to calculate a universally unique alias.

bugs found in #590