### PR TITLE
test: Add missing types to compliance test suite

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -165,12 +165,14 @@ class CQN2SQLRenderer {
   /** @type {Object<string,import('@sap/cds/apis/csn').Definition>} */
   static TypeMap = {
     // Utilizing cds.linked inheritance
+    UUID: () => `NVARCHAR(36)`,
     String: e => `NVARCHAR(${e.length || 5000})`,
     Binary: e => `VARBINARY(${e.length || 5000})`,
-    Int64: () => 'BIGINT',
-    Int32: () => 'INTEGER',
+    UInt8: () => 'TINYINT',
     Int16: () => 'SMALLINT',
-    UInt8: () => 'SMALLINT',
+    Int32: () => 'INT',
+    Int64: () => 'BIGINT',
+    Integer: () => 'INT',
     Integer64: () => 'BIGINT',
     LargeString: () => 'NCLOB',
     LargeBinary: () => 'BLOB',
@@ -178,12 +180,11 @@ class CQN2SQLRenderer {
     Composition: () => false,
     array: () => 'NCLOB',
     // HANA types
-    /* Disabled as these types are linked to normal cds types
-    'cds.hana.TINYINT': () => 'REAL',
+    'cds.hana.TINYINT': () => 'TINYINT',
     'cds.hana.REAL': () => 'REAL',
     'cds.hana.CHAR': e => `CHAR(${e.length || 1})`,
     'cds.hana.ST_POINT': () => 'ST_POINT',
-    'cds.hana.ST_GEOMETRY': () => 'ST_GEO',*/
+    'cds.hana.ST_GEOMETRY': () => 'ST_GEOMETRY',
   }
 
   // DROP Statements ------------------------------------------------

--- a/test/cds.js
+++ b/test/cds.js
@@ -1,3 +1,19 @@
+// REVISIT: enable UInt8 type
+const typeCheck = require('@sap/cds-compiler/lib/checks/checkForTypes.js')
+typeCheck.type = function () { }
+
+// REVISIT: enable cds.hana types
+const typeMapping = require('@sap/cds-compiler/lib/render/utils/common.js')
+typeMapping.cdsToSqlTypes.postgres = {
+  ...typeMapping.cdsToSqlTypes.postgres,
+  // Fill in failing cds.hana types for postgres
+  'cds.hana.CLOB': 'BYTEA',
+  'cds.hana.BINARY': 'BYTEA',
+  'cds.hana.TINYINT': 'SMALLINT',
+  'cds.hana.ST_POINT': 'POINT',
+  'cds.hana.ST_GEOMETRY': 'POLYGON',
+}
+
 const cds = require('@sap/cds/lib')
 module.exports = cds
 
@@ -70,7 +86,7 @@ cds.test = Object.setPrototypeOf(function () {
         const hash = createHash('sha1')
         const isolateName = (require.main.filename || 'test_tenant') + isolateCounter++
         hash.update(isolateName)
-        isolate = {
+        ret.data.isolation = isolate = {
           // Create one database for each overall test execution
           database: process.env.TRAVIS_JOB_ID || process.env.GITHUB_RUN_ID || require('os').userInfo().username || 'test_db',
           // Create one tenant for each test suite
@@ -105,6 +121,10 @@ cds.test = Object.setPrototypeOf(function () {
   global.afterAll(async () => {
     // Clean database connection pool
     await cds.db?.disconnect?.()
+
+    if (isolate) {
+      await cds.db?.tenant?.(isolate, true)
+    }
 
     // Clean cache
     delete cds.services._pending.db

--- a/test/compliance/CREATE.test.js
+++ b/test/compliance/CREATE.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const  { Readable } = require('stream')
+const { Readable } = require('stream')
 const { buffer } = require('stream/consumers')
 const cds = require('../cds.js')
 const fspath = require('path')
@@ -59,7 +59,7 @@ describe('CREATE', () => {
               })
             }
           })
-          .catch(() => {})
+          .catch(() => { })
 
         await db.run(async tx => {
           deploy = Promise.resolve()
@@ -79,7 +79,7 @@ describe('CREATE', () => {
               },
             }),
           )
-          await deploy.catch(() => {})
+          await deploy.catch(() => { })
         })
       })
 
@@ -101,7 +101,7 @@ describe('CREATE', () => {
               })
             }
           })
-          .catch(() => {})
+          .catch(() => { })
 
         await db.disconnect()
       })
@@ -165,7 +165,7 @@ describe('CREATE', () => {
                   } catch (e) {
                     if (throws === false) throw e
                     // Check for error test cases
-                    assert.equal(e.message, throws, 'Ensure that the correct error message is being thrown.')
+                    assert.match(e.message, throws, 'Ensure that the correct error message is being thrown.')
                     return
                   }
 
@@ -181,7 +181,7 @@ describe('CREATE', () => {
                   const sel = await tx.run({
                     SELECT: {
                       from: { ref: [table] },
-                      columns 
+                      columns
                     },
                   })
 

--- a/test/compliance/resources/db/basic/literals.cds
+++ b/test/compliance/resources/db/basic/literals.cds
@@ -4,9 +4,15 @@ entity globals {
     bool : Boolean;
 }
 
+entity uuid {
+    uuid : UUID;
+}
+
 entity number {
-    integer   : Integer;
-    integer64 : Integer64;
+    integer8  : UInt8;
+    integer16 : Int16;
+    integer32 : Int32;
+    integer64 : Int64;
     double    : cds.Double;
     // Decimal: (p,s) p = 1 - 38, s = 0 - p
     // p = number of total decimal digits

--- a/test/compliance/resources/db/basic/literals/basic.literals.number.js
+++ b/test/compliance/resources/db/basic/literals/basic.literals.number.js
@@ -1,12 +1,53 @@
 module.exports = [
   {
-    integer: null,
+    integer8: null,
   },
   {
-    integer: -2147483648,
+    integer8: 0,
   },
   {
-    integer: 2147483647,
+    integer8: 255,
+  },
+  /* REVISIT: UInt8 is not allowed to be over/under flow 0-255
+  {
+    integer8: -1,
+    '!': /./,
+  },
+  {
+    integer8: 256,
+    '!': /./,
+  },
+  */
+  {
+    integer16: null,
+  },
+  {
+    integer16: 32767,
+  },
+  {
+    integer16: -32768,
+  },
+  /* REVISIT: UInt16 is not allowed to be over/under flow -32768 - 32767
+  {
+    integer16: 32768,
+    '!': /./,
+  },
+  {
+    integer16: -32769,
+    '!': /./,
+  },
+  */
+  {
+    integer32: null,
+  },
+  {
+    integer32: -2147483648,
+  },
+  {
+    integer32: 2147483647,
+  },
+  {
+    integer64: null,
   },
   {
     integer64: '9223372036854775806',
@@ -38,7 +79,7 @@ module.exports = [
     '=float': /^-9007199254740991/
   },
   {
-    float: '9007199254740991', 
+    float: '9007199254740991',
     '=float': /^9007199254740991/
   }
   /* Ignoring transformations

--- a/test/compliance/resources/db/hana/index.cds
+++ b/test/compliance/resources/db/hana/index.cds
@@ -1,4 +1,4 @@
 // namespace edge.hana; // Would overwrite default hana namespace
 
-// using from './literals';
+using from './literals';
 using from './funcs';

--- a/test/compliance/resources/db/hana/literals/edge.hana.literals.HANA_ST.js
+++ b/test/compliance/resources/db/hana/literals/edge.hana.literals.HANA_ST.js
@@ -2,15 +2,16 @@
 module.exports = [
   {
     point: null,
-  },
+  },/*
   {
     point: 'POINT(1 1)',
   },
   {
     point: '0101000000000000000000F03F000000000000F03F',
-  },
+  },*/
   {
     // GeoJSON specification: https://www.rfc-editor.org/rfc/rfc7946
     point: '{"x":1,"y":1,"spatialReference":{"wkid":4326}}',
+    '=point': /\{\W*"x"\W*:\W*1\W*,\W*"y"\W*:\W*1(,.*)?\}/,
   },
 ]


### PR DESCRIPTION
While investigating a bug report for `@cap-js/hana` it was not possible to deploy the data locally. As the insert type for `UInt8` was missing. This is a result of the `UInt8` type not being supported on the `Postgres` dialect of the compiler. This PR enables the `UInt8` data type and `cds.hana.*` data types inside our test suite. Allowing the compliance test suite to add the currently missing data types.