### PR TITLE
feat: Add `sql.js` fallback for `sqlite` in `wasm`

### DIFF
--- a/sqlite/lib/sql.js.js
+++ b/sqlite/lib/sql.js.js
@@ -1,0 +1,84 @@
+const initSqlJs = require('sql.js');
+
+const init = initSqlJs({})
+
+class WasmSqlite {
+  constructor(database) {
+    // TODO: load / store database file contents
+    this.ready = init
+      .then(SQL => { this.db = new SQL.Database() })
+
+    this.memory = true
+    this.gc = new FinalizationRegistry(stmt => { stmt.free() })
+  }
+
+  prepare(sql) {
+    const stmt = this.db.prepare(sql)
+    const ret = {
+      run: (params) => {
+        try {
+          stmt.bind(params)
+          stmt.step()
+          return { changes: this.db.getRowsModified(stmt) }
+        } catch (err) {
+          if (err.message.indexOf('NOT NULL constraint failed:') === 0) {
+            err.code = 'SQLITE_CONSTRAINT_NOTNULL'
+          }
+          throw err
+        }
+      },
+      get: (params) => {
+        const columns = stmt.getColumnNames()
+        stmt.bind(params)
+        stmt.step()
+        const row = stmt.get()
+        const ret = {}
+        for (let i = 0; i < columns.length; i++) {
+          ret[columns[i]] = row[i]
+        }
+        return ret
+      },
+      all: (params) => {
+        const columns = stmt.getColumnNames()
+        const ret = []
+        stmt.bind(params)
+        while (stmt.step()) {
+          const row = stmt.get()
+          const obj = {}
+          for (let i = 0; i < columns.length; i++) {
+            obj[columns[i]] = row[i]
+          }
+          ret.push(obj)
+        }
+        return ret
+      }
+    }
+    this.gc.register(ret, stmt)
+    return ret
+  }
+
+  exec(sql) {
+    try {
+      const { columns, values } = this.db.exec(sql)
+      return !Array.isArray(values) ? values : values.map(val => {
+        const ret = {}
+        for (let i = 0; i < columns.length; i++) {
+          ret[columns[i]] = val[i]
+        }
+        return ret
+      })
+    } catch (err) {
+      // REVISIT: address transaction errors
+      if (sql === 'BEGIN' || sql === 'ROLLBACK') { return }
+      throw err
+    }
+  }
+
+  function(name, config, func) {
+    this.db.create_function(name, func || config)
+  }
+
+  close() { this.db.close() }
+}
+
+module.exports = WasmSqlite

--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -33,6 +33,9 @@
     "@cap-js/db-service": "^1.7.0",
     "better-sqlite3": "^9.3.0"
   },
+  "optionalDependencies": {
+    "sql.js": "^1.10.3"
+  },
   "peerDependencies": {
     "@sap/cds": ">=7.6"
   },


### PR DESCRIPTION
This PR adds support for another `SQLite` driver `sql.js` is a browser orientated driver which compiles `SQLite` to `wasm`.

Enabling the possibility to run cds with `@cap-js/sqlite` in more environments.

For example `better-sqlite3` cannot be loaded into the default `npm` promoted online environment `runkit`:
https://runkit.com/bobdenos/cds-test

```bash
Error: Could not locate the bindings file. Tried:
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/build/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/build/Debug/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/build/Release/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/out/Debug/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/Debug/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/out/Release/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/Release/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/build/default/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/compiled/18.11.0/linux/x64/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/addon-build/release/install-root/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/addon-build/debug/install-root/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/addon-build/default/install-root/better_sqlite3.node
 → /app/available_modules/1713909839000/@cap-js/sqlite/node_modules/better-sqlite3/lib/binding/node-v108-linux-x64/better_sqlite3.node
```

There are some limitations with `sql.js` when comparing to `better-sqlite3`. Which is mostly that it uses more memory and is around 50% slower for running the `@cap-js/sqlite` tests. Where `better-sqlite3` takes `~10` seconds to run all tests. It takes `sql.js` `~14` seconds, but all current tests are green. Which should be good enough for experimentation scenarios.