### PR TITLE
fix(hana): Reference column alias in order by

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -313,7 +313,7 @@ class HANAService extends SQLService {
         if (q.SELECT?.from) return walkAlias(q.SELECT?.from)
         return q.as
       }
-      q.as ??= walkAlias(q)
+      q.as = walkAlias(q)
       const alias = q.alias = `${parent ? parent.alias + '.' : ''}${q.as}`
       const src = q
 
@@ -343,7 +343,7 @@ class HANAService extends SQLService {
             if (!c.ref) {
               c.as = `$$ORDERBY_${i}$$`
               columns.push(c)
-              return { ref: [c.as], sort: c.sort }
+              return { __proto__: c, ref: [c.as], sort: c.sort }
             }
             if (c.ref?.length === 2) {
               const ref = c.ref + ''
@@ -352,7 +352,7 @@ class HANAService extends SQLService {
                 c.as = `$$${c.ref.join('.')}$$`
                 columns.push(c)
               }
-              return { ref: [this.column_name(match || c)], sort: c.sort }
+              return { __proto__: c, ref: [this.column_name(match || c)], sort: c.sort }
             }
             return c
           })
@@ -467,7 +467,7 @@ class HANAService extends SQLService {
 
                 x.SELECT.from = {
                   join: 'inner',
-                  args: [{ ref: [parent.alias], as: parent.as }, x.SELECT.from],
+                  args: [x.SELECT.from, { ref: [parent.alias], as: parent.as }],
                   on: x.SELECT.where,
                   as: x.SELECT.from.as,
                 }

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -352,7 +352,7 @@ class HANAService extends SQLService {
                 c.as = `$$${c.ref.join('.')}$$`
                 columns.push(c)
               }
-              return { ref: [this.column_name(c)], sort: c.sort }
+              return { ref: [this.column_name(match || c)], sort: c.sort }
             }
             return c
           })
@@ -1050,10 +1050,10 @@ class HANAService extends SQLService {
     return super.dispatch(req)
   }
 
-  async onCall({ query, data }, name, schema) {    
-      const outParameters = await this._getProcedureMetadata(name, schema)              
-      const ps = await this.prepare(query)
-      return ps.proc(data, outParameters)     
+  async onCall({ query, data }, name, schema) {
+    const outParameters = await this._getProcedureMetadata(name, schema)
+    const ps = await this.prepare(query)
+    return ps.proc(data, outParameters)
   }
 
   async onPlainSQL(req, next) {
@@ -1069,7 +1069,7 @@ class HANAService extends SQLService {
         throw err
       }
     }
-    
+
     const proc = this._getProcedureNameAndSchema(req.query)
     if (proc && proc.name) return this.onCall(req, proc.name, proc.schema)
 
@@ -1179,12 +1179,12 @@ class HANAService extends SQLService {
     const query = `SELECT PARAMETER_NAME FROM SYS.PROCEDURE_PARAMETERS WHERE SCHEMA_NAME = ${
         schema?.toUpperCase?.() === 'SYS' ? `'SYS'` : 'CURRENT_SCHEMA'
       } AND PROCEDURE_NAME = '${name}' AND PARAMETER_TYPE IN ('OUT', 'INOUT') ORDER BY POSITION`
-    return await super.onPlainSQL({ query, data: [] })   
+    return await super.onPlainSQL({ query, data: [] })
   }
 
   _getProcedureNameAndSchema(sql) {
     // name delimited with "" allows any character
-    const match = sql    
+    const match = sql
       .match(
         /^\s*call \s*(("(?<schema_delimited>\w+)"\.)?("(?<delimited>.+)")|(?<schema_undelimited>\w+\.)?(?<undelimited>\w+))\s*\(/i
       )

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -342,11 +342,13 @@ class HANAService extends SQLService {
           orderBy.forEach(c => {
             if (c.ref?.length === 2) {
               const ref = c.ref + ''
-              if (!columns.find(c => c.ref + '' === ref)) {
+              const match = columns.find(col => col.ref + '' === ref)
+              if (!match) {
+                c.as = `$$${c.ref.join('.')}$$`
                 const clone = { __proto__: c, ref: c.ref }
                 columns.push(clone)
               }
-              c.ref = [c.ref[1]]
+              c.ref = [this.column_name(match || c)]
             }
           })
         }


### PR DESCRIPTION
When having an order by clause which references a column which is renamed for the actual result. This change makes sure that the alias is considered. Additionally if ordered column is not being selected it will expose it with an internal alias.

While fixing most cases there is a strange gap. Which fails with the cryptic error message: `additionalMatFields.empty()`