### PR TITLE
fix(hana): Allow custom fuzzy search cqn

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -866,7 +866,7 @@ class HANAService extends SQLService {
           if (up in caseOperators) break
           continue
         }
-        if (cur.func === 'CONTAINS') return true
+        if (cur.func?.toUpperCase() === 'CONTAINS' && cur.args?.length > 2) return true
         if ('_internal' in cur) return true
         if ('xpr' in cur) return this.is_comparator(cur)
       }

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -855,6 +855,7 @@ class HANAService extends SQLService {
           if (up in caseOperators) break
           continue
         }
+        if ('func' in cur && cur.func === 'CONTAINS') return true
         if ('xpr' in cur) return this.is_comparator(cur)
       }
       return false
@@ -1243,6 +1244,9 @@ const compareOperators = {
   'IS NOT': 1,
   'EXISTS': 1,
   'BETWEEN': 1,
+  'CONTAINS': 1,
+  'MEMBER OF': 1,
+  'LIKE_REGEXPR': 1,
 }
 
 module.exports = HANAService

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -855,7 +855,7 @@ class HANAService extends SQLService {
           if (up in caseOperators) break
           continue
         }
-        if ('func' in cur && cur.func === 'CONTAINS') return true
+        if (cur.func === 'CONTAINS') return true
         if ('xpr' in cur) return this.is_comparator(cur)
       }
       return false

--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -21,7 +21,7 @@ const StandardFunctions = {
   count: x => `count(${x || '*'})`,
   countdistinct: x => `count(distinct ${x || '*'})`,
   average: x => `avg(${x})`,
-  contains: (...args) => `(CASE WHEN coalesce(locate(${args}),0)>0 THEN TRUE ELSE FALSE END)`,
+  contains: (...args) => args.length > 2 ? `CONTAINS(${args})` : `(CASE WHEN coalesce(locate(${args}),0)>0 THEN TRUE ELSE FALSE END)`,
   search: function (ref, arg) {
     if (!('val' in arg)) throw `HANA only supports single value arguments for $search`
     const refs = ref.list || [ref],

--- a/hana/test/fuzzy.cds
+++ b/hana/test/fuzzy.cds
@@ -1,0 +1,1 @@
+using {sap.capire.bookshop.Books as Books} from '../../test/bookshop/db/schema.cds';

--- a/hana/test/fuzzy.test.js
+++ b/hana/test/fuzzy.test.js
@@ -1,0 +1,19 @@
+const cds = require('../../test/cds')
+
+describe('Fuzzy search', () => {
+  const { expect } = cds.test(__dirname, 'fuzzy.cds')
+
+  test('select', async () => {
+    const { Books } = cds.entities('sap.capire.bookshop')
+    const res = await SELECT.from(Books).where({
+      func: 'contains',
+      args: [
+        { list: [{ ref: ['title'] }, { ref: ['descr'] }] },
+        { val: 'poem' },
+        { func: 'FUZZY', args: [{ val: 0.8 }, { val: 'similarCalculationMode=searchCompare' }] }
+      ]
+    })
+
+    expect(res).to.have.property('length').to.be.eq(1)
+  })
+})


### PR DESCRIPTION
With the old database service it was possible to define a custom fuzzy search cqn.

The test implements it like:

```js
{
  func: 'CONTAINS',
  args: [
    { list: [{ ref: ['ID'] }, { ref: ['NAME'] }] },
    { val: hanaSearchTerm },
    { func: 'FUZZY', args: [{ val: 0.8 }, { val: 'similarCalculationMode=searchCompare' }] }
  ]
}
```

But according the HANA documentation this is incorrect. As `CONTIANS` is not a function it is actually a `predicate`. Which would be defined like:

```js
{
  xpr: [
    'CONTAINS',
    {
      xpr: [
        { list: [{ ref: ['ID'] }, { ref: ['NAME'] }] },
        { val: hanaSearchTerm },
        'FUZZY',
        {xpr: [[{ val: 0.8 }, { val: 'similarCalculationMode=searchCompare' }]]}
      ]
    }
  ]
}
```

Additionally the `contains` function from the OData spec clashes with the HANA internal function name. Which means that the custom code has to adjust the function name to `CONTAINS` to avoid the function from being rewritten into the OData spec compliant variant.