### PR TITLE
fix: improved `=` and `!=` with val `null` for HANA and Postgres

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -832,17 +832,31 @@ class CQN2SQLRenderer {
   operator(x, i, xpr) {
 
     // Translate = to IS NULL for rhs operand being NULL literal
-    if (x === '=') return xpr[i + 1]?.val === null ? 'is' : '='
+    if (x === '=') return xpr[i + 1]?.val === null
+      ? _inline_null(xpr[i + 1]) || 'is'
+      : '='
 
     // Translate == to IS NOT NULL for rhs operand being NULL literal, otherwise ...
     // Translate == to IS NOT DISTINCT FROM, unless both operands cannot be NULL
-    if (x === '==') return xpr[i + 1]?.val === null ? 'is' : _not_null(i - 1) && _not_null(i + 1) ? '=' : this.is_not_distinct_from_
+    if (x === '==') return xpr[i + 1]?.val === null
+      ? _inline_null(xpr[i + 1]) || 'is'
+      : _not_null(i - 1) && _not_null(i + 1)
+        ? '='
+        : this.is_not_distinct_from_
 
     // Translate != to IS NULL for rhs operand being NULL literal, otherwise...
     // Translate != to IS DISTINCT FROM, unless both operands cannot be NULL
-    if (x === '!=') return xpr[i + 1]?.val === null ? 'is not' : _not_null(i - 1) && _not_null(i + 1) ? '<>' : this.is_distinct_from_
+    if (x === '!=') return xpr[i + 1]?.val === null
+      ? _inline_null(xpr[i + 1]) || 'is not'
+      : _not_null(i - 1) && _not_null(i + 1)
+        ? '<>'
+        : this.is_distinct_from_
 
     else return x
+
+    function _inline_null(n) {
+      n.param = false
+    }
 
     /** Checks if the operand at xpr[i+-1] can be NULL. @returns true if not */
     function _not_null(i) {

--- a/db-service/test/cqn2sql/expression.test.js
+++ b/db-service/test/cqn2sql/expression.test.js
@@ -39,8 +39,8 @@ describe('expressions', () => {
       },
     }
     const { sql, values } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x IS \?/i)
-    expect(values).toEqual([null])
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x IS NULL/i)
+    expect(values).toEqual([])
   })
 
   // We should never have supported that!
@@ -65,8 +65,8 @@ describe('expressions', () => {
       },
     }
     const { sql, values } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE \? IS \?/i)
-    expect(values).toEqual([null, null])
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE \? IS NULL/i)
+    expect(values).toEqual([null])
   })
 
   test('ref != null', () => {
@@ -77,8 +77,8 @@ describe('expressions', () => {
       },
     }
     const { sql, values } = cqn2sql(cqn)
-    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x IS NOT \?/i)
-    expect(values).toEqual([null])
+    expect(sql).toMatch(/SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE Foo.x IS NOT NULL/i)
+    expect(values).toEqual([])
   })
 
   test('val != val', () => {
@@ -188,8 +188,8 @@ describe('expressions', () => {
     }
     const { sql, values } = cqn2sql(cqn)
     expect({ sql, values }).toEqual({
-      sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x is distinct from ?) or (Foo.x is ?)',
-      values: [5, null]
+      sql: 'SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE (Foo.x is distinct from ?) or (Foo.x is NULL)',
+      values: [5]
     })
   })
 


### PR DESCRIPTION
In the case of Postgres all queries doing `x = null` where being translated to `x is $1` which causes trouble as the operator name is `is null` unlike the SQLite operator which is just `is`.

The Postgres error was already resolved in the HANA Service, but the SQL Execution plan cache optimization caused trouble when comparing with `LOB` type columns. As HANA does not support compare operation on `LOB` columns. There for the only allowed operators on the `LOB` columns is `is (not) null`. Which also causes the issue that SQLite and Postgres are both allowed to execute `null = (LOB)`, but for HANA this causes a SQL error. As `null = ...` always returns null it will always filter everything out. Therefor the HANA Service translate it into `null = null` as the behavior is the same and does not throw a SQL error.