### PR TITLE
deps: require `>= sap/cds@7.9.0`

### DIFF
--- a/db-service/package.json
+++ b/db-service/package.json
@@ -29,8 +29,7 @@
     "test": "jest --silent"
   },
   "peerDependencies": {
-    "@sap/cds": ">=7.9",
-    "@sap/cds-compiler": ">=4.9"
+    "@sap/cds": ">=7.9"
   },
   "license": "SEE LICENSE"
 }

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -29,7 +29,8 @@
     "test": "jest --silent"
   },
   "peerDependencies": {
-    "@sap/cds": ">=7.9"
+    "@sap/cds": ">=7.9",
+    "@sap/cds-compiler": ">=4.9"
   },
   "license": "SEE LICENSE"
 }

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -29,7 +29,7 @@
     "test": "jest --silent"
   },
   "peerDependencies": {
-    "@sap/cds": ">=7.6"
+    "@sap/cds": ">=7.9"
   },
   "license": "SEE LICENSE"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "npm": ">=8"
       },
       "peerDependencies": {
-        "@sap/cds": ">=7.9"
+        "@sap/cds": ">=7.9",
+        "@sap/cds-compiler": ">=4.9"
       }
     },
     "hana": {
@@ -1256,9 +1257,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.8.0.tgz",
-      "integrity": "sha512-C8IkzNfdMIzG136K/VvOmG65d8UnR9lcZF5q/c//Jp2/RZIZvwFvO5HHPre19+YWhuwJXbIMb3kc5x9CW9ZLNw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.9.0.tgz",
+      "integrity": "sha512-eX1+mpL4z/UVNa5blIuqguWF3txIBOw7OCuVOnCQMStNhHXxbnTnDRZrh7+S4AH9kxT0DmJXMHR6JN44xzzprg==",
       "dependencies": {
         "antlr4": "4.9.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,7 @@
         "npm": ">=8"
       },
       "peerDependencies": {
-        "@sap/cds": ">=7.9",
-        "@sap/cds-compiler": ">=4.9"
+        "@sap/cds": ">=7.9"
       }
     },
     "hana": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "npm": ">=8"
       },
       "peerDependencies": {
-        "@sap/cds": ">=7.6"
+        "@sap/cds": ">=7.9"
       }
     },
     "hana": {
@@ -1238,9 +1238,9 @@
       }
     },
     "node_modules/@sap/cds": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-7.8.0.tgz",
-      "integrity": "sha512-eprPzuSZsLnA4O9aU2Xgt1s7g0906fr2rZZQb76vRDwY1j/IXvRV4ijTB4nmy2RCQRMHXVQ2P5RuFCS/P/5cMw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-7.9.0.tgz",
+      "integrity": "sha512-vjCmTVvaVKGxZoMWWnb0sEZD8JJtANX3lFWTbMppKGpSXeqRDmL4ORdVyAVSroAtIsVcBGvkMqe2XfGtuYos5g==",
       "dependencies": {
         "@cap-js/cds-types": "<1",
         "@sap/cds-compiler": "^4",


### PR DESCRIPTION
this is needed for https://github.com/cap-js/cds-dbs/pull/590

deps: require `>= sap/cds-compiler@4.9`