### PR TITLE
feat: Add missing `func` cqn structures

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -799,8 +799,8 @@ class CQN2SQLRenderer {
     if (x.param) return wrap(this.param(x))
     if ('ref' in x) return wrap(this.ref(x))
     if ('val' in x) return wrap(this.val(x))
-    if ('xpr' in x) return wrap(this.xpr(x))
     if ('func' in x) return wrap(this.func(x))
+    if ('xpr' in x) return wrap(this.xpr(x))
     if ('list' in x) return wrap(this.list(x))
     if ('SELECT' in x) return wrap(`(${this.SELECT(x)})`)
     else throw cds.error`Unsupported expr: ${x}`
@@ -921,9 +921,32 @@ class CQN2SQLRenderer {
    * @param {import('./infer/cqn').func} param0
    * @returns {string} SQL
    */
-  func({ func, args }) {
-    args = (args || []).map(e => (e === '*' ? e : { __proto__: e, toString: (x = e) => this.expr(x) }))
-    return this.class.Functions[func]?.apply(this.class.Functions, args) || `${func}(${args})`
+  func({ func, args, xpr }) {
+    const wrap = e => (e === '*' ? e : { __proto__: e, toString: (x = e) => this.expr(x) })
+    args = args || []
+    if (Array.isArray(args)) {
+      args = args.map(wrap)
+    } else if (typeof args === 'object') {
+      const org = args
+      const wrapped = {
+        toString: () => {
+          const ret = []
+          for (const prop in org) {
+            ret.push(`${this.quote(prop)} => ${wrapped[prop]}`)
+          }
+          return ret.join(',')
+        }
+      }
+      for (const prop in args) {
+        wrapped[prop] = wrap(args[prop])
+      }
+      args = wrapped
+    } else {
+      cds.error`Invalid arguments provided for function '${func}' (${args})`
+    }
+    const fn = this.class.Functions[func]?.apply(this.class.Functions, args) || `${func}(${args})`
+    if (xpr) return `${fn} ${this.xpr({ xpr })}`
+    return fn
   }
 
   /**

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -492,13 +492,7 @@ function cqn4sql(originalQuery, model) {
       if (col.func) {
         ret = {
           func: col.func,
-          args: col.args && (Array.isArray(col.args)
-            ? getTransformedTokenStream(col.args)
-            : Object.keys(col.args).reduce((ret, prop) => {
-              ret[prop] = getTransformedTokenStream([col.args[prop]])[0]
-              return ret
-            }, {})
-          ),
+          args: getTransformedFunctionArgs(col.args),
           as: col.func, // may be overwritten by the explicit alias
         }
       }
@@ -545,7 +539,7 @@ function cqn4sql(originalQuery, model) {
     } else if (val) {
       res = { val }
     } else if (func) {
-      res = { args: getTransformedTokenStream(value.args, baseLink), func: value.func }
+      res = { args: getTransformedFunctionArgs(value.args, baseLink), func: value.func }
     }
     if (!omitAlias) res.as = column.as || column.name || column.flatName
     return res
@@ -939,7 +933,7 @@ function cqn4sql(originalQuery, model) {
         let transformedColumn
         if (col.SELECT) transformedColumn = transformSubquery(col)
         else if (col.xpr) transformedColumn = { xpr: getTransformedTokenStream(col.xpr) }
-        else if (col.func) transformedColumn = { args: getTransformedTokenStream(col.args), func: col.func }
+        else if (col.func) transformedColumn = { args: getTransformedFunctionArgs(col.args), func: col.func }
         // val
         else transformedColumn = copy(col)
         if (col.sort) transformedColumn.sort = col.sort
@@ -1314,7 +1308,8 @@ function cqn4sql(originalQuery, model) {
             throw new Error(
               `Expecting path “${tokenStream[i + 1].ref
                 .map(idOnly)
-                .join('.')}” following “EXISTS” predicate to end with association/composition, found “${next.definition.type
+                .join('.')}” following “EXISTS” predicate to end with association/composition, found “${
+                next.definition.type
               }”`,
             )
           }
@@ -1439,24 +1434,7 @@ function cqn4sql(originalQuery, model) {
               result.xpr = getTransformedTokenStream(token.xpr, $baseLink)
             }
             if (token.func && token.args) {
-              if (Array.isArray(token.args)) {
-                result.args = token.args.map(t => {
-                  if (!t.val)
-                    // this must not be touched
-                    return getTransformedTokenStream([t], $baseLink)[0]
-                  return t
-                })
-              } else if (typeof token.args === 'object') {
-                result.args = {}
-                for (const prop in token.args) {
-                  const t = token.args[prop]
-                  if (!t.val)
-                    // this must not be touched
-                    result.args[prop] = getTransformedTokenStream([t], $baseLink)[0]
-                  else
-                    result.args[prop] = t
-                }
-              }
+              result.args = getTransformedFunctionArgs(token.args, $baseLink)
             }
           }
 
@@ -1494,7 +1472,8 @@ function cqn4sql(originalQuery, model) {
       // make sure we can compare both structures
       if (flatRhs.length !== flatLhs.length) {
         throw new Error(
-          `Can't compare "${definition.name}" with "${value.$refLinks[value.$refLinks.length - 1].definition.name
+          `Can't compare "${definition.name}" with "${
+            value.$refLinks[value.$refLinks.length - 1].definition.name
           }": the operands must have the same structure`,
         )
       }
@@ -2163,6 +2142,26 @@ function cqn4sql(originalQuery, model) {
       return getLastStringSegment(inferred.$combinedElements[node.ref[0].id || node.ref[0]]?.[0].index)
     }
   }
+  function getTransformedFunctionArgs(args, $baseLink = null) {
+    let result = args
+    if (Array.isArray(args)) {
+      result = args.map(t => {
+        if (!t.val)
+          // this must not be touched
+          return getTransformedTokenStream([t], $baseLink)[0]
+        return t
+      })
+    } else if (typeof args === 'object') {
+      for (const prop in args) {
+        const t = args[prop]
+        if (!t.val)
+          // this must not be touched
+          result[prop] = getTransformedTokenStream([t], $baseLink)[0]
+        else result[prop] = t
+      }
+    }
+    return result
+  }
 }
 
 module.exports = Object.assign(cqn4sql, {
@@ -2247,6 +2246,7 @@ function setElementOnColumns(col, element) {
     writable: true,
   })
 }
+
 const getName = col => col.as || col.ref?.at(-1)
 const idOnly = ref => ref.id || ref
 const is_regexp = x => x?.constructor?.name === 'RegExp' // NOTE: x instanceof RegExp doesn't work in repl

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -506,8 +506,10 @@ function cqn4sql(originalQuery, model) {
         ret ??= {}
         ret.xpr = getTransformedTokenStream(col.xpr)
       }
-      if (col.cast) ret.cast = col.cast
-      if (ret) return ret
+      if (ret) {
+        if (col.cast) ret.cast = col.cast
+        return ret
+      }
       return copy(col)
     }
 

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -2143,7 +2143,7 @@ function cqn4sql(originalQuery, model) {
     }
   }
   function getTransformedFunctionArgs(args, $baseLink = null) {
-    let result = args
+    let result = null
     if (Array.isArray(args)) {
       result = args.map(t => {
         if (!t.val)
@@ -2152,6 +2152,7 @@ function cqn4sql(originalQuery, model) {
         return t
       })
     } else if (typeof args === 'object') {
+      result = {}
       for (const prop in args) {
         const t = args[prop]
         if (!t.val)

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -893,7 +893,7 @@ function infer(originalQuery, model) {
       const calcElement = column.$refLinks?.[column.$refLinks.length - 1].definition || column
       if (alreadySeenCalcElements.has(calcElement)) return
       else alreadySeenCalcElements.add(calcElement)
-      const { ref, xpr, func } = calcElement.value
+      const { ref, xpr } = calcElement.value
       if (ref || xpr) {
         baseLink = baseLink || { definition: calcElement.parent, target: calcElement.parent }
         attachRefLinksToArg(calcElement.value, baseLink, true)
@@ -909,7 +909,7 @@ function infer(originalQuery, model) {
       }
 
       if (calcElement.value.args) {
-        function processArgument(arg, calcElement, column) {
+        const processArgument = (arg, calcElement, column) => {
           inferQueryElement(
             arg,
             false,

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -125,7 +125,8 @@ function infer(originalQuery, model) {
     } else if (from.SELECT) {
       const subqueryInFrom = infer(from, model) // we need the .elements in the sources
       // if no explicit alias is provided, we make up one
-      const subqueryAlias = from.as || subqueryInFrom.joinTree.addNextAvailableTableAlias('__select__', subqueryInFrom.outerQueries)
+      const subqueryAlias =
+        from.as || subqueryInFrom.joinTree.addNextAvailableTableAlias('__select__', subqueryInFrom.outerQueries)
       querySources[subqueryAlias] = { definition: from }
     } else if (typeof from === 'string') {
       // TODO: Create unique alias, what about duplicates?
@@ -165,7 +166,7 @@ function infer(originalQuery, model) {
   function attachRefLinksToArg(arg, $baseLink = null, expandOrExists = false) {
     const { ref, xpr, args, list } = arg
     if (xpr) xpr.forEach(t => attachRefLinksToArg(t, $baseLink, expandOrExists))
-    if (args) args.forEach(arg => attachRefLinksToArg(arg, $baseLink, expandOrExists))
+    if (args) applyToFunctionArgs(args, attachRefLinksToArg, [$baseLink, expandOrExists])
     if (list) list.forEach(arg => attachRefLinksToArg(arg, $baseLink, expandOrExists))
     if (!ref) return
     init$refLinks(arg)
@@ -307,9 +308,9 @@ function infer(originalQuery, model) {
             queryElements[as] = getElementForXprOrSubquery(col)
           }
           if (col.func) {
-            if (col.args) { // {func}.args are optional
-              if (Array.isArray(col.args)) col.args.forEach(arg => inferQueryElement(arg, false))
-              if (typeof col.args === 'object') Object.keys(col.args).forEach(prop => inferQueryElement(col.args[prop], false))
+            if (col.args) {
+              // {func}.args are optional
+              applyToFunctionArgs(col.args, inferQueryElement, [false])
             }
             queryElements[as] = getElementForCast(col)
           }
@@ -500,8 +501,7 @@ function infer(originalQuery, model) {
       const { inExists, inExpr, inCalcElement, baseColumn, inInfixFilter } = context || {}
       if (column.param || column.SELECT) return // parameter references are only resolved into values on execution e.g. :val, :1 or ?
       if (column.args) {
-        if (Array.isArray(column.args)) column.args.forEach(arg => inferQueryElement(arg, false, $baseLink, context)) // e.g. function in expression
-        else if (typeof column.args === 'object') Object.keys(column.args).forEach(prop => inferQueryElement(column.args[prop], false, $baseLink, context))
+        applyToFunctionArgs(column.args, inferQueryElement, [false, $baseLink, context])
       }
       if (column.list) column.list.forEach(arg => inferQueryElement(arg, false, $baseLink, context))
       if (column.xpr)
@@ -608,12 +608,12 @@ function infer(originalQuery, model) {
           }
           const foreignKeyAlias = Array.isArray(definition.keys)
             ? definition.keys.find(k => {
-              if (k.ref.every((step, j) => column.ref[i + j] === step)) {
-                skipAliasedFkSegmentsOfNameStack.push(...k.ref.slice(1))
-                return true
-              }
-              return false
-            })?.as
+                if (k.ref.every((step, j) => column.ref[i + j] === step)) {
+                  skipAliasedFkSegmentsOfNameStack.push(...k.ref.slice(1))
+                  return true
+                }
+                return false
+              })?.as
             : null
           if (foreignKeyAlias) nameSegments.push(foreignKeyAlias)
           else if (skipAliasedFkSegmentsOfNameStack[0] === id) skipAliasedFkSegmentsOfNameStack.shift()
@@ -639,13 +639,13 @@ function infer(originalQuery, model) {
                 inInfixFilter: true,
               })
             } else if (token.func) {
-              token.args?.forEach(arg =>
-                inferQueryElement(arg, false, column.$refLinks[i], {
-                  inExists: skipJoinsForFilter,
-                  inExpr: true,
-                  inInfixFilter: true,
-                }),
-              )
+              if (token.args) {
+                applyToFunctionArgs(token.args, inferQueryElement, [
+                  false,
+                  column.$refLinks[i],
+                  { inExists: skipJoinsForFilter, inExpr: true, inInfixFilter: true },
+                ])
+              }
             }
           })
         }
@@ -907,8 +907,9 @@ function infer(originalQuery, model) {
         }
         mergePathsIntoJoinTree(calcElement.value, basePath)
       }
-      if (func)
-        calcElement.value.args?.forEach(arg => {
+
+      if (calcElement.value.args) {
+        function processArgument(arg, calcElement, column) {
           inferQueryElement(
             arg,
             false,
@@ -920,7 +921,12 @@ function infer(originalQuery, model) {
               ? { $refLinks: column.$refLinks.slice(0, -1), ref: column.ref.slice(0, -1) }
               : { $refLinks: [], ref: [] }
           mergePathsIntoJoinTree(arg, basePath)
-        }) // {func}.args are optional
+        }
+
+        if (calcElement.value.args) {
+          applyToFunctionArgs(calcElement.value.args, processArgument, [calcElement, column])
+        }
+      }
 
       /**
        * Calculates all paths from a given ref and merges them into the join tree.
@@ -1209,5 +1215,10 @@ function isForeignKeyOf(e, assoc) {
   return e in (assoc.elements || assoc.foreignKeys)
 }
 const idOnly = ref => ref.id || ref
+
+function applyToFunctionArgs(funcArgs, cb, cbArgs) {
+  if (Array.isArray(funcArgs)) funcArgs.forEach(arg => cb(arg, ...cbArgs))
+  else if (typeof funcArgs === 'object') Object.keys(funcArgs).forEach(prop => cb(funcArgs[prop], ...cbArgs))
+}
 
 module.exports = infer

--- a/db-service/test/bookshop/db/booksWithExpr.cds
+++ b/db-service/test/bookshop/db/booksWithExpr.cds
@@ -48,6 +48,7 @@ entity Authors {
   dateOfDeath  : Date;
   
   age: Integer = years_between(dateOfBirth, dateOfDeath);
+  ageNamedParams: Integer = years_between(DOB => dateOfBirth, DOD => dateOfDeath);
 
   books : Association to many Books on books.author = $self;
   address : Association to Addresses;

--- a/db-service/test/cqn2sql/function.test.js
+++ b/db-service/test/cqn2sql/function.test.js
@@ -2,7 +2,7 @@ const cds = require('@sap/cds/lib')
 const _cqn2sql = require('../../lib/cqn2sql')
 function cqn2sql(q, m = cds.model) {
   return _cqn2sql(q, m)
-} 
+}
 
 beforeAll(async () => {
   cds.model = await cds.load(__dirname + '/testModel').then(cds.linked)
@@ -210,5 +210,47 @@ describe('function', () => {
     }
     const { sql } = cqn2sql(cqn)
     expect(sql).toEqual('SELECT Foo.ID,Foo.a,Foo.b,Foo.c,Foo.x FROM Foo as Foo WHERE current_date')
+  })
+
+  test('fn with named arguments', () => {
+    const func = {
+      func: 'convert_currency',
+      args: {
+        amount: { ref: ['a'] },
+        source_unit: { ref: ['b'] },
+        target_unit: { val: 'USD' },
+      }
+    }
+    const cqn = {
+      SELECT: {
+        columns: [func],
+        from: { ref: ['Foo'] },
+        where: [func],
+      },
+    }
+
+    const { sql, values } = cqn2sql(cqn)
+    expect({ sql, values }).toEqual({
+      sql: 'SELECT convert_currency(amount => Foo.a,source_unit => Foo.b,target_unit => ?) as convert_currency FROM Foo as Foo WHERE convert_currency(amount => Foo.a,source_unit => Foo.b,target_unit => ?)',
+      values: ['USD', 'USD'],
+    })
+  })
+
+  test('fn with xpr extension', () => {
+    const cqn = {
+      SELECT: {
+        from: { ref: ['Foo'] },
+        columns: [{
+          func: 'row_number',
+          args: [],
+          xpr: ['over', { xpr: ['partition', 'by', { ref: ['a'] }] }]
+        }]
+      },
+    }
+
+    const { sql } = cqn2sql(cqn)
+    expect({ sql }).toEqual({
+      sql: 'SELECT row_number() over (partition by Foo.a) as row_number FROM Foo as Foo',
+    })
   })
 })

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -54,6 +54,14 @@ describe('Unfolding calculated elements in select list', () => {
       }`
     expect(query).to.deep.equal(expected)
   })
+  it('in function with named param', () => {
+    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID, ageNamedParams as f }`, model)
+    const expected = CQL`SELECT from booksCalc.Authors as Authors {
+      Authors.ID,
+      years_between(DOB => Authors.dateOfBirth, DOD => Authors.dateOfDeath) as f
+    }`
+    expect(query).to.deep.equal(expected)
+  })
 
   it('calc elem is function', () => {
     let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, ctitle }`, model)
@@ -510,10 +518,7 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('wildcard select from subquery', () => {
-    let query = cqn4sql(
-      CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } )`,
-      model,
-    )
+    let query = cqn4sql(CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } )`, model)
     const expected = CQL`
     SELECT from (
       SELECT from booksCalc.Simple as Simple


### PR DESCRIPTION
Not all possible defined combination where covered in regards to `func` objects. Mostly that `args` can be an `object` and that `func` and `xpr` can be combined for window functions. [docs](https://pages.github.tools.sap/cap/docs/cds/cxn#function-calls)