### PR TITLE
deps: `@sap/hana-client` optional peer dependency

### DIFF
--- a/hana/package.json
+++ b/hana/package.json
@@ -34,6 +34,11 @@
     "@sap/hana-client": ">=2",
     "@sap/cds": ">=7.6"
   },
+  "peerDependenciesMeta": {
+    "@sap/hana-client": {
+      "optional": true
+    }
+  },
   "cds": {
     "requires": {
       "kinds": {


### PR DESCRIPTION
Currently noticing the huge package is still coming in `@sap/cds-dk` with `@sap/hdi-deploy` version 5 because`@cap-js/hana` defines it as a non-optional peer dependency.