### PR TITLE
fix: dont mistake non-key access with foreign key

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -2175,10 +2175,10 @@ module.exports = Object.assign(cqn4sql, {
 function calculateElementName(token) {
   const nonJoinRelevantAssoc = [...token.$refLinks].findIndex(l => l.definition.isAssociation && l.onlyForeignKeyAccess)
   let name
-  if (nonJoinRelevantAssoc)
+  if (nonJoinRelevantAssoc !== -1)
     // calculate fk name
     name = token.ref.slice(nonJoinRelevantAssoc).join('_')
-  else name = token.$refLinks[token.$refLinks.length - 1].definition.name
+  else name = getFullName(token.$refLinks[token.$refLinks.length - 1].definition)
   return name
 }
 

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -199,7 +199,7 @@ class JoinTree {
         }
         const child = new Node($refLink, node, where, args)
         if (child.$refLink.definition.isAssociation) {
-          if (child.where || col.inline) {
+          if (child.where || child.$refLink.definition.on || col.inline) {
             // filter is always join relevant
             // if the column ends up in an `inline` -> each assoc step is join relevant
             child.$refLink.onlyForeignKeyAccess = false
@@ -212,9 +212,11 @@ class JoinTree {
         const elements =
           node.$refLink?.definition.isAssociation &&
           (node.$refLink.definition.elements || node.$refLink.definition.foreignKeys)
-        if (node.$refLink && (!elements || !(child.$refLink.definition.name in elements)))
-          // foreign key access
+        if (node.$refLink && (!elements || !(child.$refLink.definition.name in elements))) {
+          // no foreign key access
           node.$refLink.onlyForeignKeyAccess = false
+          col.$refLinks[i - 1] = node.$refLink
+        }
 
         node.children.set(id, child)
         node = child

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -1233,6 +1233,21 @@ describe('optimize fk access', () => {
 
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
+  it('association as key leads to non-key field', () => {
+    const query = CQL`SELECT from Pupils {
+      ID
+    } group by classrooms.classroom.ID, classrooms.classroom.name`
+    const expected = CQL`SELECT from Pupils as Pupils
+                        left join ClassroomsPupils as classrooms
+                          on classrooms.pupil_ID = Pupils.ID
+                        left join Classrooms as classroom
+                          on classroom.ID = classrooms.classroom_ID
+                        {
+                          Pupils.ID
+                        } group by classroom.ID, classroom.name`
+
+    expect(cqn4sql(query, model)).to.deep.equal(expected)
+  })
   it('two step path ends in foreign key simple ref', () => {
     const query = CQL`SELECT from Classrooms {
       pupils.pupil.ID as studentCount,

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -1248,6 +1248,21 @@ describe('optimize fk access', () => {
 
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
+  it('association as key leads to nested non-key field', () => {
+    const query = CQL`SELECT from Pupils {
+      ID
+    } group by classrooms.classroom.ID, classrooms.classroom.info.capacity`
+    const expected = CQL`SELECT from Pupils as Pupils
+                        left join ClassroomsPupils as classrooms
+                          on classrooms.pupil_ID = Pupils.ID
+                        left join Classrooms as classroom
+                          on classroom.ID = classrooms.classroom_ID
+                        {
+                          Pupils.ID
+                        } group by classroom.ID, classroom.info_capacity`
+
+    expect(cqn4sql(query, model)).to.deep.equal(expected)
+  })
   it('two step path ends in foreign key simple ref', () => {
     const query = CQL`SELECT from Classrooms {
       pupils.pupil.ID as studentCount,


### PR DESCRIPTION
Consider this two path expressions:
`classrooms.classroom.ID, classrooms.classroom.name`

While the first path could be optimized to `classrooms.classroom_ID`, the second path is _not_ a key access and hence must be transformed to `classroom.name`, where `classroom` is the nested join node, refer to this example:

<details>

```js
    const query = CQL`SELECT from Pupils {
      ID
    } group by classrooms.classroom.ID, classrooms.classroom.name`
    const expected = CQL`SELECT from Pupils as Pupils
                        left join ClassroomsPupils as classrooms
                          on classrooms.pupil_ID = Pupils.ID
                        left join Classrooms as classroom
                          on classroom.ID = classrooms.classroom_ID
                        {
                          Pupils.ID
                        } group by classroom.ID, classroom.name`
```

</details>

As both paths navigate through the same join nodes, we do not (yet?) optimize the first path to the foreign key, but access the `ID` in the target of `classroom`. This is also the behavior of the `cds-compiler` and should not matter too much as the join node is produced through the second path anyway:

```md
Pupils
  └── classrooms
        └── classroom
              ├── ID
              └── name
```
The problem was, that when we found the second path, we have already seen this path up to the `n - 1` step before, and only the _reference_ for the first path was adjusted to not be a foreign key access anymore.

fixes cap/issue#16001