### PR TITLE
test(nested-projections): Adapt CDL syntax for upcoming major

### DIFF
--- a/db-service/test/cds-infer/nested-projections.test.js
+++ b/db-service/test/cds-infer/nested-projections.test.js
@@ -162,7 +162,7 @@ describe('nested projections', () => {
           {
             title,
             descr,
-            author. { name }
+            author.{ name }
           } as bookInfos
         }`
         let { Books } = model.entities


### PR DESCRIPTION
The next cds-compiler version may be more restrictive on the "nested projections" syntax.  There should not be any space between `.` and `{`. Whether this restriction will actually make it into the next major is yet to decide.