### PR TITLE
test(`cds 8`): explicitly set `fewerLocalizedViews = false`

### DIFF
--- a/db-service/test/cqn4sql/expand.test.js
+++ b/db-service/test/cqn4sql/expand.test.js
@@ -282,36 +282,6 @@ describe('Unfold expands on associations to special subselects', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
-  it('nested expand with unmanaged backlink', () => {
-    let expandQuery = SELECT.localized `from bookshop.DataRestrictions {
-      *,
-      dataRestrictionAccessGroups {
-        dataRestrictionID,
-        accessGroupID,
-        accessGroup {
-          ID
-        }
-      }
-    }`
-    let expected = CQL(`
-      SELECT from ${transitive_?'localized.':''}bookshop.DataRestrictions as DataRestrictions {
-        DataRestrictions.ID,
-        (
-          SELECT from ${transitive_?'localized.':''}bookshop.DataRestrictionAccessGroups as dataRestrictionAccessGroups {
-            dataRestrictionAccessGroups.dataRestrictionID,
-            dataRestrictionAccessGroups.accessGroupID,
-            (
-              SELECT from localized.bookshop.AccessGroups as accessGroup {
-                accessGroup.ID
-              } where accessGroup.ID = dataRestrictionAccessGroups.accessGroupID
-            ) as accessGroup
-          } where DataRestrictions.ID = dataRestrictionAccessGroups.dataRestrictionID
-        ) as dataRestrictionAccessGroups
-      }
-    `)
-    // seems to only happen with the `for.nodejs(…)` compiled model
-    expect(cds.clone(cqn4sql(expandQuery, cds.compile.for.nodejs(JSON.parse(JSON.stringify(model)))))).to.deep.equal(expected)
-  })
 
   it('add where exists <assoc> shortcut to expand subquery where condition', () => {
     const q = {

--- a/db-service/test/cqn4sql/localized.test.js
+++ b/db-service/test/cqn4sql/localized.test.js
@@ -5,11 +5,12 @@ const cqn4sql = require('../../lib/cqn4sql')
 const cds = require('@sap/cds')
 const { expect } = cds.test
 const transitive_ = !cds.unfold || 'transitive_localized_views' in cds.env.sql && cds.env.sql.transitive_localized_views !== false
+const options = { fewerLocalizedViews: false }
 
 describe('localized', () => {
   let model
   beforeAll(async () => {
-    model = await cds.load(__dirname + '/../bookshop/db/schema').then(cds.compile.for.nodejs)
+    model = await cds.load(__dirname + '/../bookshop/db/schema').then( m => cds.compile.for.nodejs(m, options))
   })
   it('performs no replacement if not requested', () => {
     const q = CQL`SELECT from bookshop.Books {ID, title}`
@@ -77,6 +78,38 @@ describe('localized', () => {
                       ) as currency
                     }`)
   })
+
+  it('nested expand with unmanaged backlink', () => {
+    let expandQuery = SELECT.localized `from bookshop.DataRestrictions {
+      *,
+      dataRestrictionAccessGroups {
+        dataRestrictionID,
+        accessGroupID,
+        accessGroup {
+          ID
+        }
+      }
+    }`
+    let expected = CQL(`
+      SELECT from ${transitive_?'localized.':''}bookshop.DataRestrictions as DataRestrictions {
+        DataRestrictions.ID,
+        (
+          SELECT from ${transitive_?'localized.':''}bookshop.DataRestrictionAccessGroups as dataRestrictionAccessGroups {
+            dataRestrictionAccessGroups.dataRestrictionID,
+            dataRestrictionAccessGroups.accessGroupID,
+            (
+              SELECT from localized.bookshop.AccessGroups as accessGroup {
+                accessGroup.ID
+              } where accessGroup.ID = dataRestrictionAccessGroups.accessGroupID
+            ) as accessGroup
+          } where DataRestrictions.ID = dataRestrictionAccessGroups.dataRestrictionID
+        ) as dataRestrictionAccessGroups
+      }
+    `)
+    // seems to only happen with the `for.nodejs(…)` compiled model
+    expect(cds.clone(cqn4sql(expandQuery, cds.compile.for.nodejs(JSON.parse(JSON.stringify(model)))))).to.deep.equal(expected)
+  })
+
   it('performs replacement of ref if ”@cds.localized: true” and localized is set', () => {
     const q = SELECT.localized `from bookshop.BPLocalized {ID, title}`
     let query = cqn4sql(q, model)
@@ -185,5 +218,48 @@ describe('localized', () => {
     )`)
     const res = cqn4sql(q, model)
     expect(cds.clone(res)).to.deep.equal(qx)
+  })
+
+  it('should handle localized associations in on-conditions properly', async () => {
+    let stakeholderModel = cds.model = await cds.load(__dirname + '/model/cap_issue').then(cds.linked)
+    stakeholderModel = cds.compile.for.nodejs(JSON.parse(JSON.stringify(stakeholderModel)), options)
+    // make sure that in a localized scenario, all aliases
+    // are properly replaced in the on-conditions.
+
+    // the issue here was that we had a where condition like
+    // `where exists foo[id=1] or exists foo[id=2]`
+    // with `foo` being an association `foo : Association to one Foo on foo.ID = foo_ID;`.
+    // While building up the where exists subqueries, we calculate unique table aliases for `foo`,
+    // which results in a table alias `foo2` for the second condition of the initial where clause.
+    // Now, if we incorporate the on-condition into the where clause of the second where exists subquery,
+    // we must replace the table alias `foo` from the on-condition with `foo2`.
+
+    // the described scenario didn't work because in a localized scenario, the localized `foo`
+    // association (pointing to `localized.Foo`) was compared to the non-localized version
+    // of the association (pointing to `Foo`) and hence, the alias was not properly replaced
+    let q = SELECT.localized `from Foo:boos { ID }
+      where exists foo.specialOwners[owner2_userID = $user.id]
+      or exists foo.activeOwners[owner_userID = $user.id]
+    `
+    let q2 = cqn4sql(q, stakeholderModel)
+    expect(cds.clone(q2)).to.deep.equal(CQL(`
+      SELECT from localized.Boo as boos { boos.ID } WHERE EXISTS (
+        SELECT 1 from localized.Foo as Foo3 WHERE Foo3.ID = boos.foo_ID
+      ) AND (
+        EXISTS (
+          SELECT 1 from localized.Foo as foo WHERE foo.ID = boos.foo_ID AND EXISTS (
+            SELECT 1 from ${transitive_?'localized.':''}SpecialOwner2 as specialOwners
+            WHERE specialOwners.foo_ID = foo.ID and specialOwners.owner2_userID = $user.id
+          )
+        )
+        OR
+        EXISTS (
+          SELECT 1 from localized.Foo as foo2 WHERE foo2.ID = boos.foo_ID AND EXISTS (
+            SELECT 1 from ${transitive_?'localized.':''}ActiveOwner as activeOwners
+            WHERE activeOwners.foo_ID = foo2.ID and activeOwners.owner_userID = $user.id
+          )
+        )
+      )
+    `))
   })
 })

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -1300,54 +1300,6 @@ describe('Path expressions in from combined with `exists` predicate', () => {
   })
 })
 
-
-describe('cap issue', () => {
-  let model
-  beforeAll(async () => {
-    model = cds.model = await cds.load(__dirname + '/model/cap_issue').then(cds.linked)
-    model = cds.compile.for.nodejs(JSON.parse(JSON.stringify(model)))
-  })
-  it('MUST ... two EXISTS both on same path in where with real life example', () => {
-    // make sure that in a localized scenario, all aliases
-    // are properly replaced in the on-conditions.
-
-    // the issue here was that we had a where condition like
-    // `where exists foo[id=1] or exists foo[id=2]`
-    // with `foo` being an association `foo : Association to one Foo on foo.ID = foo_ID;`.
-    // While building up the where exists subqueries, we calculate unique table aliases for `foo`,
-    // which results in a table alias `foo2` for the second condition of the initial where clause.
-    // Now, if we incorporate the on-condition into the where clause of the second where exists subquery,
-    // we must replace the table alias `foo` from the on-condition with `foo2`.
-
-    // the described scenario didn't work because in a localized scenario, the localized `foo`
-    // association (pointing to `localized.Foo`) was compared to the non-localized version
-    // of the association (pointing to `Foo`) and hence, the alias was not properly replaced
-    let q = SELECT.localized `from Foo:boos { ID }
-      where exists foo.specialOwners[owner2_userID = $user.id]
-      or exists foo.activeOwners[owner_userID = $user.id]
-    `
-    let q2 = cqn4sql(q, model)
-    expect(cds.clone(q2)).to.deep.equal(CQL(`
-      SELECT from localized.Boo as boos { boos.ID } WHERE EXISTS (
-        SELECT 1 from localized.Foo as Foo3 WHERE Foo3.ID = boos.foo_ID
-      ) AND (
-        EXISTS (
-          SELECT 1 from localized.Foo as foo WHERE foo.ID = boos.foo_ID AND EXISTS (
-            SELECT 1 from ${transitive_?'localized.':''}SpecialOwner2 as specialOwners
-            WHERE specialOwners.foo_ID = foo.ID and specialOwners.owner2_userID = $user.id
-          )
-        )
-        OR
-        EXISTS (
-          SELECT 1 from localized.Foo as foo2 WHERE foo2.ID = boos.foo_ID AND EXISTS (
-            SELECT 1 from ${transitive_?'localized.':''}ActiveOwner as activeOwners
-            WHERE activeOwners.foo_ID = foo2.ID and activeOwners.owner_userID = $user.id
-          )
-        )
-      )
-    `))
-  })
-})
 describe('comparisons of associations in on condition of elements needs to be expanded', () => {
   let model
   beforeAll(async () => {


### PR DESCRIPTION
the `cds-compiler` will not produce `localized` views for transitive dependencies of `localized` artifacts.

That means an `Author` will not get a `localized.Authors` view just because there is an `author` association in the `localized` entity `Books`.

at some point those tests can be rewritten, but to test the deep replacement mechanism for `localized` artifacts it is fine for now to just explicitly set the `fewerLocalizedViews` option.