### PR TITLE
feat: Add simple queries feature flag

### DIFF
--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -370,7 +370,8 @@ GROUP BY k
       return super.column_alias4(x, q)
     }
 
-    SELECT_expand({ SELECT }, sql) {
+    SELECT_expand(q, sql) {
+      const { SELECT } = q
       if (!SELECT.columns) return sql
       const queryAlias = this.quote(SELECT.from?.as || (SELECT.expand === 'root' && 'root'))
       const cols = SELECT.columns.map(x => {
@@ -385,10 +386,22 @@ GROUP BY k
         }
         return col
       })
+      const isRoot = SELECT.expand === 'root'
+      const isSimple = cds.env.features.sql_simple_queries &&
+        isRoot && // Simple queries are only allowed to have a root
+        !Object.keys(q.elements).some(e =>
+          q.elements[e].isAssociation || // Indicates columns contains an expand
+          q.elements[e].$assocExpand || // REVISIT: sometimes associations are structs
+          q.elements[e].items // Array types require to be inlined with a json result
+        )
+
+      const subQuery = `SELECT ${cols} FROM (${sql}) as ${queryAlias}`
+      if (isSimple) return subQuery
+
       // REVISIT: Remove SELECT ${cols} by adjusting SELECT_columns
       let obj = `to_jsonb(${queryAlias}.*)`
-      return `SELECT ${SELECT.one || SELECT.expand === 'root' ? obj : `coalesce(jsonb_agg (${obj}),'[]'::jsonb)`
-        } as _json_ FROM (SELECT ${cols} FROM (${sql}) as ${queryAlias}) as ${queryAlias}`
+      return `SELECT ${SELECT.one || isRoot ? obj : `coalesce(jsonb_agg (${obj}),'[]'::jsonb)`
+        } as _json_ FROM (${subQuery}) as ${queryAlias}`
     }
 
     doubleQuote(name) {


### PR DESCRIPTION
In the case of SQLite the simple queries are mostly compatible. When a `boolean` column is selected it is not considered a simple query as the result would be `"true" | "false"` which are both truthy.

In the case of Postgres a lot of number results are numbers where strings are expected and strings where numbers are expected.