### PR TITLE
fix: allow hdb to have default type placeholders

### DIFF
--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -7,6 +7,19 @@ const iconv = require('iconv-lite')
 
 const { driver, prom, handleLevel } = require('./base')
 
+try {
+  // When HANA does not know the data type of a place holder
+  // It falls back to expecting strings hdb enforces the type
+  // This validation overwrite converts any value into a string
+  const hdbWriter = require('hdb/lib/protocol/Writer.js')
+
+  const laxStrings = function laxStrings(value) {
+    this.writeCharacters(30, `${value}`);
+  };
+
+  hdbWriter.prototype[30] = laxStrings
+} catch (err) {/* prevent internal changes from breakinge everything */ }
+
 const credentialMappings = [
   { old: 'certificate', new: 'ca' },
   { old: 'encrypt', new: 'useTLS' },


### PR DESCRIPTION
When a resulting SQL statement has place holders of unknown type it causes trouble with `hdb`. As it enforces the data type that HANA provides. So in certain cases a place holder will default to `nvarchar`, but the actual value for the place holder will be a number. Which will be rejected as `hdb` only allows strings to be provided to these placeholders. There for this change converts all the values into a string before sending them to the prepared statement.