### PR TITLE
fix: insertion of large decimals

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1054,6 +1054,7 @@ class HANAService extends SQLService {
       Binary: () => `NVARCHAR(2147483647)`,
       array: () => `NVARCHAR(2147483647) FORMAT JSON`,
       Vector: () => `NVARCHAR(2147483647)`,
+      Decimal: () => `DECIMAL`,
 
       // JavaScript types
       string: () => `NVARCHAR(2147483647)`,

--- a/test/bookshop/package.json
+++ b/test/bookshop/package.json
@@ -24,7 +24,8 @@
       "db": "sql"
     },
     "features": {
-      "odata_new_adapter": true
+      "odata_new_adapter": true,
+      "string_decimals": true
     }
   }
 }

--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -48,7 +48,7 @@ describe('Bookshop - Insert', () => {
     await cds.run(INSERT(entry).into(Books))
     // intentionally comparing with plain SQL to avoid output converters
     const written = await cds.run(`SELECT price as "price" FROM ${Books.name.replace(/\./g, '_')} WHERE ID = 2348`)
-    if (typeof written.price !== 'string') return // do not compare on sqlite because of rounding
+    if (typeof written[0].price !== 'string') return // do not compare on sqlite because of rounding
     expect(written[0].price).to.be.eq(entry.price)
   })
     

--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -41,5 +41,15 @@ describe('Bookshop - Insert', () => {
     const resp = await cds.run(INSERT({ footnotes: ['first', 'second'], ID: 121, title: 'Guiness Book of World Records' }).into(Books))
     expect(resp | 0).to.be.eq(1)
   })
+
+  test('big decimals', async () => {
+    const { Books } = cds.entities('sap.capire.bookshop')
+    const entry = { ID: 2348, title: 'Moby Dick', price: '12345678901234567890.12345'}
+    await cds.run(INSERT(entry).into(Books))
+    // intentionally comparing with plain SQL to avoid output converters
+    const written = await cds.run(`SELECT price as "price" FROM ${Books.name.replace(/\./g, '_')} WHERE ID = 2348`)
+    if (typeof written.price !== 'string') return // do not compare on sqlite because of rounding
+    expect(written[0].price).to.be.eq(entry.price)
+  })
     
 })

--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -31,7 +31,7 @@ describe('Bookshop - Insert', () => {
         createdAt: (new Date()).toISOString(),
       }])
     expect(affectedRows | 0).to.be.eq(2)
-    
+
     const res = await SELECT.from('sap.capire.bookshop.Books').where('ID in', [4711, 4712])
     expect(res).to.have.length(2)
   })
@@ -42,14 +42,18 @@ describe('Bookshop - Insert', () => {
     expect(resp | 0).to.be.eq(1)
   })
 
-  test('big decimals', async () => {
+  test.only('big decimals', async () => {
     const { Books } = cds.entities('sap.capire.bookshop')
-    const entry = { ID: 2348, title: 'Moby Dick', price: '12345678901234567890.12345'}
-    await cds.run(INSERT(entry).into(Books))
-    // intentionally comparing with plain SQL to avoid output converters
-    const written = await cds.run(`SELECT price as "price" FROM ${Books.name.replace(/\./g, '_')} WHERE ID = 2348`)
-    if (typeof written[0].price !== 'string') return // do not compare on sqlite because of rounding
-    expect(written[0].price).to.be.eq(entry.price)
+
+    const entry = { ID: 2348, title: 'Moby Dick', price: '12345678901234567890.12345' }
+    await INSERT(entry).into(Books)
+
+    const written = await SELECT('price').from(Books, { ID: 2348 })
+    if (written.price.indexOf('e+') > -1) {
+      expect(written.price).to.be.eq('1.23456789012346e+19')
+    } else {
+      expect(written.price).to.be.eq(entry.price)
+    }
   })
-    
+
 })


### PR DESCRIPTION
hana-client:
`cds.Decimal` → `12345678901234567168`
`cds.Decimal(25,5)` → `12345678901234568244.75648`

hdb:
`cds.Decimal` → `1.2345678901234567168e+19`
`cds.Decimal(25,5)` → `12345678901234568244.75648`

It seems our INSERT erroneously manipulates the values on HANA.
Plain SQL insert ends in the expected result.