### PR TITLE
fix(`expand`): enable expanding from subquery

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -787,7 +787,7 @@ function cqn4sql(originalQuery, model) {
     } else {
       outerAlias = transformedQuery.SELECT.from.as
       subqueryFromRef = [
-        ...transformedQuery.SELECT.from.ref,
+        ...(transformedQuery.SELECT.from.ref || /* subq in from */ [transformedQuery.SELECT.from.target.name]),
         ...(column.$refLinks[0].definition.kind === 'entity' ? column.ref.slice(1) : column.ref),
       ]
     }
@@ -1911,8 +1911,7 @@ function cqn4sql(originalQuery, model) {
                 result[i].ref = [targetSideRefLink.alias, lhs.ref.join('_')]
               }
             }
-          } else if (lhs.ref.length === 1)
-            result[i].ref.unshift(targetSideRefLink.alias)
+          } else if (lhs.ref.length === 1) result[i].ref.unshift(targetSideRefLink.alias)
         }
       }
       return result

--- a/db-service/test/cqn4sql/expand.test.js
+++ b/db-service/test/cqn4sql/expand.test.js
@@ -416,6 +416,20 @@ describe('Unfold expands on associations to special subselects', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.eql(qx)
   })
 
+  it('correctly builds correlated subquery if selecting from subquery', () => {
+    const q = CQL`SELECT from (select author from bookshop.Books) as book {
+      author { name }
+    }`
+    const qx = CQL`SELECT from (select Books.author_ID from bookshop.Books as Books) as book {
+      (SELECT
+          author.name
+        from bookshop.Authors as author
+        where book.author_ID = author.ID) as author
+    }`
+    const res = cqn4sql(q)
+    expect(JSON.parse(JSON.stringify(res))).to.deep.eql(qx)
+  })
+
   it('unfold expand, several fields with alias', () => {
     const q = CQL`SELECT from bookshop.Books {
       author { name, dateOfBirth as dob, placeOfBirth as pob}


### PR DESCRIPTION
if we `select from <subquery>` we do not have a
`SELECT.from.ref` but the `<subquery>` has a `.target` because it has been inferred properly.

Use the name of the `.target` for building the correlated subquery, instead of dumping.

fix #708