### PR TITLE
chore: Use new `latest` tag for hxe image

### DIFF
--- a/.github/workflows/hana.yml
+++ b/.github/workflows/hana.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: HANA Node.js ${{ matrix.node }}
+    permissions:
+      packages: write
 
     strategy:
       fail-fast: true

--- a/hana/tools/docker/hxe/Dockerfile
+++ b/hana/tools/docker/hxe/Dockerfile
@@ -1,4 +1,4 @@
-FROM saplabs/hanaexpress:2.00.061.00.20220519.1
+FROM saplabs/hanaexpress:latest
 
 COPY ./start-hdi.sql /usr/sap/HXE/start-hdi.sql
 COPY ./setup.sh /setup


### PR DESCRIPTION
Update the HANA express image from `2.00.061.00.20220519.1` to `latest` (`2.00.072.00.20231123.1`)