### PR TITLE
rm odata contexts that are not supported anymore with new odata adapter

### DIFF
--- a/sqlite/test/deep/deepInputProcessing.test.js
+++ b/sqlite/test/deep/deepInputProcessing.test.js
@@ -15,7 +15,6 @@ describe('UUID Generation', () => {
     expect(res.status).toBe(201)
 
     expect(res.data).toMatchObject({
-      '@odata.context': '$metadata#RootUUID(toOneChild(toManySubChild()))/$entity',
       ID: uuid,
       name: null,
       toOneChild: {

--- a/sqlite/test/deep/deepPersistenceSkip.test.js
+++ b/sqlite/test/deep/deepPersistenceSkip.test.js
@@ -12,10 +12,7 @@ describe('deep operations with @cds.persistence.skip', () => {
     })
     expect(res.status).toBe(201)
 
-    expect(res.data).toEqual({
-      '@odata.context': cds.env.features.odata_new_adapter
-        ? '$metadata#RootUUID/$entity'
-        : '$metadata#RootUUID(toOneSkip())/$entity',
+    expect(res.data).toMatchObject({
       ID: uuid,
       name: null,
       toOneChild_ID: null,
@@ -32,10 +29,7 @@ describe('deep operations with @cds.persistence.skip', () => {
     })
     expect(res.status).toBe(201)
 
-    expect(res.data).toEqual({
-      '@odata.context': cds.env.features.odata_new_adapter
-        ? '$metadata#RootUUID/$entity'
-        : '$metadata#RootUUID(toManySkip())/$entity',
+    expect(res.data).toMatchObject({
       ID: uuid,
       name: null,
       toOneChild_ID: null,
@@ -57,10 +51,7 @@ describe('deep operations with @cds.persistence.skip', () => {
     })
     expect(res.status).toBe(201)
 
-    expect(res.data).toEqual({
-      '@odata.context': cds.env.features.odata_new_adapter
-        ? '$metadata#RootUUID(toOneChild(toManySubChild()))/$entity'
-        : '$metadata#RootUUID(toOneChild(toManySubChild(toOneSkipChild())))/$entity',
+    expect(res.data).toMatchObject({
       ID: uuid,
       name: null,
       toOneChild: {

--- a/sqlite/test/lean-draft.test.js
+++ b/sqlite/test/lean-draft.test.js
@@ -837,8 +837,6 @@ describe('draft tests', () => {
       { auth: { username: 'user1', password: 'user1' } },
     )
     expect(res.data).to.containSubset({
-      '@odata.context':
-        '$metadata#Travel(BeginDate,BookingFee,CurrencyCode_code,Description,EndDate,HasActiveEntity,HasDraftEntity,IsActiveEntity,TotalPrice,TravelID,TravelStatus_code,TravelUUID,to_Agency_AgencyID,to_Customer_CustomerID,DraftAdministrativeData(DraftIsCreatedByMe,DraftUUID,InProcessByUser),TravelStatus(code,createDeleteHidden,fieldControl,name),to_Agency(AgencyID,Name),to_Customer(CustomerID,LastName))/$entity',
       BeginDate: '2032-10-22',
       BookingFee: 12,
       CurrencyCode_code: null,

--- a/test/scenarios/bookshop/genres.test.js
+++ b/test/scenarios/bookshop/genres.test.js
@@ -91,8 +91,7 @@ describe('Bookshop - Genres', () => {
     expect(res.status).to.be.eq(200)
 
     res = await GET(`/test/Genres(${body.ID})?$expand=children`, admin)
-    assert.deepEqual(res.data, {
-      '@odata.context': '$metadata#Genres(children())/$entity',
+    expect(res.data).to.deep.include({
       name: 'no more children',
       descr: null,
       ID: 100,


### PR DESCRIPTION
The new odata adapter will support only simple odata contexts, as this is not relevant for the db layer anyways let's remove them