### PR TITLE
chore(hana): better error message with missing HANA credentials

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -38,7 +38,7 @@ class HANAService extends SQLService {
   get factory() {
     const driver = drivers[this.options.driver || this.options.credentials?.driver]?.driver || drivers.default.driver
     const service = this
-    const { credentials, kind } = service
+    const { credentials, kind } = service.options
     if (!credentials) {
       throw new Error(`Database kind "${kind}" configured, but no HDI container or Service Manager instance bound to application.`)
     }

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -38,6 +38,10 @@ class HANAService extends SQLService {
   get factory() {
     const driver = drivers[this.options.driver || this.options.credentials?.driver]?.driver || drivers.default.driver
     const service = this
+    const { credentials, kind } = service
+    if (!credentials) {
+      throw new Error(`Database kind "${kind}" configured, but no HDI container or Service Manager instance bound to application.`)
+    }
     const isMultitenant = !!service.options.credentials.sm_url || ('multiTenant' in this.options ? this.options.multiTenant : cds.env.requires.multitenancy)
     const acquireTimeoutMillis = this.options.pool?.acquireTimeoutMillis || cds.env.profiles.includes('production') ? 1000 : 10000
     return {


### PR DESCRIPTION
Currently getting a `TypeError` here when `credentials` is `undefined`.

Adapted version of our error message when the XSUAA credentials are not found.