### PR TITLE
fix: enforce db file to be existent before server start

### DIFF
--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -22,7 +22,7 @@ class SQLiteService extends SQLService {
       options: { max: 1, ...this.options.pool },
       create: tenant => {
         const database = this.url4(tenant)
-        const dbc = new sqlite(database)
+        const dbc = new sqlite(database, {fileMustExist: true})
 
         const deterministic = { deterministic: true }
         dbc.function('session_context', key => dbc[$session][key])


### PR DESCRIPTION
docs: https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#new-databasepath-options

`options.fileMustExist`: if the database does not exist, an `Error` will be thrown instead of creating a new file. This option is ignored for in-memory, temporary, or readonly database connections (default: `false`).

With this any CRUD request does not create empty db files. It's obviously an error by developer but does not pollute the environment.