### PR TITLE
revert: "fix: enforce db file to be existent before server start (#742)"

### DIFF
--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -22,7 +22,7 @@ class SQLiteService extends SQLService {
       options: { max: 1, ...this.options.pool },
       create: tenant => {
         const database = this.url4(tenant)
-        const dbc = new sqlite(database, {fileMustExist: true})
+        const dbc = new sqlite(database)
 
         const deterministic = { deterministic: true }
         dbc.function('session_context', key => dbc[$session][key])


### PR DESCRIPTION
This reverts commit 64a90186aaf44b3426df2e9adbf9a1b4cf2f92b7.

causes failures in stakeholder tests, reverting and double checking after major