### PR TITLE
ci: use new `release-please` action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,12 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{secrets.CDS_DBS_TOKEN}}
-          command: manifest
-          monorepo-tags: true
       # The logic below handles the npm publication:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
the other one is deprecated, as can be seen
in the annotations of [this workflow run](https://github.com/cap-js/cds-dbs/actions/runs/10001079480/attempts/1)

also got rid of unexpected inputs for github actions, we dont need them.