### PR TITLE
chore: demystify cds.test and cds.env

### DIFF
--- a/sqlite/test/lean-draft.test.js
+++ b/sqlite/test/lean-draft.test.js
@@ -5,9 +5,11 @@ const cds = require('../../test/cds.js')
 describe('draft tests', () => {
 
   const { GET, POST, PATCH, DELETE, expect } = cds.test('@capire/sflight')
-
-  process.env.cds_requires_db_kind = 'better-sqlite'
-  process.env.cds_requires_auth_kind = 'mocked-auth'
+  // NOTE: all access to cds.env has to go after the call to cds.test() or cds.test.in()
+  // (see https://cap.cloud.sap/docs/node.js/cds-test#cds-test-env-check)
+  cds.env.requires.db.kind = 'better-sqlite'
+  cds.env.requires.auth.kind = 'mocked-auth'
+  cds.env.features.ieee754compatible = true
 
   if (cds.env.fiori) cds.env.fiori.lean_draft = cds.env.fiori.draft_compat = true
   else cds.env.features.lean_draft = cds.env.features.lean_draft_compatibility = true
@@ -16,10 +18,6 @@ describe('draft tests', () => {
     user1: { password: 'user1', roles: ['processor'] },
     user2: { password: 'user2', roles: ['processor'] },
   }
-
-  beforeAll(() => {
-    cds.env.features.ieee754compatible = true
-  })
 
   beforeEach(async () => {
     await Promise.allSettled([


### PR DESCRIPTION
The fix in https://github.com/cap-js/cds-dbs/pull/751 shows that we're still confused about when and how to access `cds.env` in combination with using `cds.test`. Long story short: 

- Ensure to call `cds.test()` or `cds.test.in()` before accessing `cds.env` anywhere
- see also: https://cap.cloud.sap/docs/node.js/cds-test#cds-test-env-check

Note that the `beforeAll` in https://github.com/cap-js/cds-dbs/pull/751 is actually _not_ required.