### PR TITLE
chore: set last release in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "last-release-sha": "0b8ecb614a3f1257896507d36edb989cab003bb7",
   "packages": {
     "db-service": {},
     "sqlite": {},


### PR DESCRIPTION
It looks like `release-please` has hickups currently. By setting the `last-release-sha` we can force the tool to only search from our last release 0b8ecb614a3f1257896507d36edb989cab003bb7 → We need to change this after the next release ❗️