### PR TITLE
chore: remove latest sha from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "last-release-sha": "0b8ecb614a3f1257896507d36edb989cab003bb7",
   "packages": {
     "db-service": {},
     "sqlite": {},


### PR DESCRIPTION
Only merge after [#288](https://github.com/cap-js/cds-dbs/pull/761) got merged ‼️