### PR TITLE
chore: Migrate to docker compose v2

### DIFF
--- a/hana/tools/docker/hce/ready.sh
+++ b/hana/tools/docker/hce/ready.sh
@@ -1,5 +1,5 @@
-docker exec hce_hana_1 /bin/bash -c "while ! ./check_hana_health ; do sleep 10 ; done;"
-docker exec -it hce_hana_1 /bin/bash -c "\
+docker exec hce-hana-1 /bin/bash -c "while ! ./check_hana_health ; do sleep 10 ; done;"
+docker exec -it hce-hana-1 /bin/bash -c "\
 cd /usr/sap/H00/HDB00;\
 . ./hdbenv.sh;\
 hdbuserstore -i SET SYSDBKEY localhost:30013@SYSTEMDB SYSTEM Manager1;\

--- a/hana/tools/docker/hce/start.sh
+++ b/hana/tools/docker/hce/start.sh
@@ -1,6 +1,6 @@
 exists=$(docker images hana-master:current -q);
 if [ $exists ]; then
-    docker-compose -f hana.yml up -d;
+    docker compose -f hana.yml up -d;
     ./ready.sh;
 else
     ./update.sh;

--- a/hana/tools/docker/hxe/ready.sh
+++ b/hana/tools/docker/hxe/ready.sh
@@ -1,9 +1,9 @@
-until docker cp ./start-hdi.sql hxe_hana_1:/usr/sap/HXE/start-hdi.sql
+until docker cp ./start-hdi.sql hxe-hana-1:/usr/sap/HXE/start-hdi.sql
 do
   sleep 1
 done
 
-docker exec hxe_hana_1 bash -c "until /check_hana_health -n -e ready-status > /dev/null; do sleep 1; done;"
+docker exec hxe-hana-1 bash -c "until /check_hana_health -n -e ready-status > /dev/null; do sleep 1; done;"
 echo "HANA has started"
-docker exec hxe_hana_1 bash -c "/usr/sap/HXE/HDB90/exe/hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p Manager1 -I /usr/sap/HXE/start-hdi.sql > /dev/null && sleep 10"
+docker exec hxe-hana-1 bash -c "/usr/sap/HXE/HDB90/exe/hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p Manager1 -I /usr/sap/HXE/start-hdi.sql > /dev/null && sleep 10"
 echo "HDI has been enabled"

--- a/hana/tools/docker/hxe/start.sh
+++ b/hana/tools/docker/hxe/start.sh
@@ -1,8 +1,8 @@
 if [ $IMAGE_ID ] && [ $TAG ]; then
     echo "Using prepared HXE image"
-    docker-compose -f ci.yml up -d;
+    docker compose -f ci.yml up -d;
 else
     export VERSION=$(node ./latest.js);
-    docker-compose -f hana.yml up -d;
+    docker compose -f hana.yml up -d;
 fi
 ./ready.sh;

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "test": "npm start && jest --silent",
-    "start": "docker-compose -f pg-stack.yml up -d"
+    "start": "docker compose -f pg-stack.yml up -d"
   },
   "dependencies": {
     "@cap-js/db-service": "^1.9.0",


### PR DESCRIPTION
`docker-compose` (v1) has been replaced for a little while now with `docker compose` (v2), but for `Docker Desktop` there is an alias `docker-compose` which actually is (v2) which created a miss match between the GitHub Action and the local development setup as the container name changed from `hana_1` to `hana-1`. 

This PR aligns the two by switching to `docker compose` (v2) for the GitHub Actions as well. As the GitHub Action default runner seems to have removed the `docker-compose` (v1) command.