### PR TITLE
fix: prevent $search queries from throwing

### DIFF
--- a/db-service/lib/cql-functions.js
+++ b/db-service/lib/cql-functions.js
@@ -23,10 +23,16 @@ const StandardFunctions = {
   search: function (ref, arg) {
     if (!('val' in arg)) throw new Error(`Only single value arguments are allowed for $search`)
     // only apply first search term, rest is ignored
-    const sub= /("")|("(?:[^"]|\\")*(?:[^\\]|\\\\)")|(\S*)/.exec(arg.val)
-    arg.val = arg.__proto__.val = (sub[2] ? JSON.parse(sub[2]) : sub[3]) || ''    
-    const refs = ref.list || [ref],
-      { toString } = ref
+    const sub = /("")|("(?:[^"]|\\")*(?:[^\\]|\\\\)")|(\S*)/.exec(arg.val)
+    let val
+    try {
+      val = (sub[2] ? JSON.parse(sub[2]) : sub[3]) || ''
+    } catch {
+      val = sub[2] || sub[3] || ''
+    }
+    arg.val = arg.__proto__.val = val
+    const refs = ref.list || [ref]
+    const { toString } = ref
     return '(' + refs.map(ref2 => this.contains(this.tolower(toString(ref2)), this.tolower(arg))).join(' or ') + ')'
   },
   /**
@@ -159,8 +165,8 @@ const StandardFunctions = {
    * Generates SQL statement that produces current point in time (date and time with time zone)
    * @returns {string}
    */
-   now: function() {
-    return this.session_context({val: '$now'})
+  now: function () {
+    return this.session_context({ val: '$now' })
   },
   /**
    * Generates SQL statement that produces the year of a given timestamp

--- a/test/scenarios/bookshop/search.test.js
+++ b/test/scenarios/bookshop/search.test.js
@@ -79,7 +79,7 @@ describe.skip('Bookshop - Search', () => {
       // ad-hoc search expression
       Books['@cds.search.authorsAddress'] = true
 
-      let res = await SELECT.from(Books).columns('author.name as author', 'title').search('1 Main Street, Bradford')
+      let res = await SELECT.from(Books).columns('author.name as author', 'title').search('"1 Main Street, Bradford"')
       // author name in res[0] must match "Emily Brontë"
       expect(res.length).to.be.eq(1)
       expect(res[0].author).to.be.eq('Emily Brontë')
@@ -91,10 +91,32 @@ describe.skip('Bookshop - Search', () => {
       Books['@cds.search.author'] = true
       Authors['@cds.search.address'] = true // address is a calculated element
 
-      let res = await SELECT.from(Books).columns('author.name as author', 'title').search('1 Main Street, Bradford')
+      let res = await SELECT.from(Books).columns('author.name as author', 'title').search('"1 Main Street, Bradford"')
       // author name in res[0] must match "Emily Brontë"
       expect(res.length).to.be.eq(1)
       expect(res[0].author).to.be.eq('Emily Brontë')
+    })
+
+    test('Search escaped character in search literal', async () => {
+      const { Books } = cds.entities
+      const { Authors } = cds.entities
+      // ad-hoc search expression
+      Books['@cds.search.author'] = true
+      Authors['@cds.search.address'] = true // address is a calculated element
+
+      let res = await SELECT.from(Books).columns('author.name as author', 'title').search('"\\"\\\\"')
+      expect(res.length).to.be.eq(0)
+    })
+
+    test('Search improperly escaped character in search literal', async () => {
+      const { Books } = cds.entities
+      const { Authors } = cds.entities
+      // ad-hoc search expression
+      Books['@cds.search.author'] = true
+      Authors['@cds.search.address'] = true // address is a calculated element
+
+      let res = await SELECT.from(Books).columns('author.name as author', 'title').search('"\\q"')
+      expect(res.length).to.be.eq(0)
     })
 
     test('search on result of subselect', async () => {


### PR DESCRIPTION
Currently it is possible for `@cap-js/sqlite` and `@cap-js/postgres` to send invalid `$search` queries that make the request fail with `500` which should be succeeding with empty results.