### PR TITLE
fix: Enforce `LargeStrings` to be `Strings` for `sql_simple_queries=1`

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1124,6 +1124,7 @@ class HANAService extends SQLService {
 
     static OutputConverters = {
       ...super.OutputConverters,
+      LargeString: cds.env.features.sql_simple_queries === 1 ? e => `TO_NVARCHAR(${e})` : undefined,
       // REVISIT: binaries should use BASE64_ENCODE, but this results in BASE64_ENCODE(BINTONHEX(${e}))
       Binary: e => `BINTONHEX(${e})`,
       Date: e => `to_char(${e}, 'YYYY-MM-DD')`,

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1124,7 +1124,7 @@ class HANAService extends SQLService {
 
     static OutputConverters = {
       ...super.OutputConverters,
-      LargeString: cds.env.features.sql_simple_queries === 1 ? e => `TO_NVARCHAR(${e})` : undefined,
+      LargeString: cds.env.features.sql_simple_queries > 0 ? e => `TO_NVARCHAR(${e})` : undefined,
       // REVISIT: binaries should use BASE64_ENCODE, but this results in BASE64_ENCODE(BINTONHEX(${e}))
       Binary: e => `BINTONHEX(${e})`,
       Date: e => `to_char(${e}, 'YYYY-MM-DD')`,


### PR DESCRIPTION
when using `sql_simple_queries=1` and `hdb` the `NCLOB` columns are returned as `Buffers` not as `Strings`. With this change these columns include an output converters that informs `hdb` to handle them as `Strings`.