### PR TITLE
fix: prepend aliases to refs within function args in on conditions

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1852,6 +1852,11 @@ function cqn4sql(originalQuery, model) {
           result[i] = asXpr(xpr)
           continue
         }
+        if(lhs.args) {
+          const args = calculateOnCondition(lhs.args)
+          result[i] = { ...lhs, args }
+          continue
+        }
         const rhs = result[i + 2]
         if (rhs?.ref || lhs.ref) {
           // if we have refs on each side of the comparison, we might need to perform tuple expansion

--- a/db-service/test/bookshop/db/schema.cds
+++ b/db-service/test/bookshop/db/schema.cds
@@ -422,3 +422,10 @@ entity Item {
   key ID: Integer;
   item: Association to Item;
 }
+
+entity Posts {
+  key ID: Integer;
+  name: String;
+  iSimilar: Association to many Posts on UPPER(name) = UPPER(iSimilar.name);
+  iSimilarNested: Association to many Posts on UPPER(iSimilarNested.name) = UPPER(LOWER(UPPER(name)), name); 
+}


### PR DESCRIPTION
 we need to drill recursively into the function arguments found in
on-conditions and prepend aliases of the outer query in case of scoped queries / expands

fixes #779