### PR TITLE
fix(deep-queries): properly return insert result

### DIFF
--- a/db-service/lib/deep-queries.js
+++ b/db-service/lib/deep-queries.js
@@ -61,7 +61,7 @@ async function onDeep(req, next) {
     ...Array.from(queries.inserts.values()).map(query => this.onINSERT({ query })),
   ])
 
-  return beforeData.length ?? rootResult
+  return rootResult ?? beforeData.length
 }
 
 const hasDeep = (q, target) => {

--- a/db-service/test/deep/deep.test.js
+++ b/db-service/test/deep/deep.test.js
@@ -831,8 +831,8 @@ describe('test deep query generation', () => {
 
       const insert = INSERT.into(entity).entries(entry)
 
-      const [...result] = await cds.db.run(insert)
-      expect(result).toMatchObject([{ realm: 'dummy', uniqueName: 'PR1'}])
+      const result = await cds.db.run(insert)
+      expect(result > 0).toBe(true)
 
       const root = { uniqueName: entry.uniqueName, realm: entry.realm }
 

--- a/db-service/test/deep/deep.test.js
+++ b/db-service/test/deep/deep.test.js
@@ -831,7 +831,8 @@ describe('test deep query generation', () => {
 
       const insert = INSERT.into(entity).entries(entry)
 
-      await cds.db.run(insert)
+      const [...result] = await cds.db.run(insert)
+      expect(result).toMatchObject([{ realm: 'dummy', uniqueName: 'PR1'}])
 
       const root = { uniqueName: entry.uniqueName, realm: entry.realm }
 


### PR DESCRIPTION
For `INSERT`s, `beforeData` is always `[]` and

```js
return beforeData.length ?? rootResult
```

would always return `0`.