### PR TITLE
Refactor: import of compareJSON

### DIFF
--- a/db-service/lib/deep-queries.js
+++ b/db-service/lib/deep-queries.js
@@ -3,20 +3,7 @@ const { _target_name4 } = require('./SQLService')
 
 const ROOT = Symbol('root')
 
-// REVISIT: remove old path with cds^8
-let _compareJson
-const compareJson = (...args) => {
-  if (!_compareJson) {
-    try {
-      // new path
-      _compareJson = require('@sap/cds/libx/_runtime/common/utils/compareJson').compareJson
-    } catch {
-      // old path
-      _compareJson = require('@sap/cds/libx/_runtime/cds-services/services/utils/compareJson').compareJson
-    }
-  }
-  return _compareJson(...args)
-}
+const { compareJson } = require('@sap/cds/libx/_runtime/common/utils/compareJson')
 
 const handledDeep = Symbol('handledDeep')
 


### PR DESCRIPTION
Simplified the import of compareJSON by removing the old path

forgot the tag `refactor:` in the commit message