### PR TITLE
chore: revert "refactor: import of compareJSON (#814)"

### DIFF
--- a/db-service/lib/deep-queries.js
+++ b/db-service/lib/deep-queries.js
@@ -3,7 +3,20 @@ const { _target_name4 } = require('./SQLService')
 
 const ROOT = Symbol('root')
 
-const { compareJson } = require('@sap/cds/libx/_runtime/common/utils/compareJson')
+// REVISIT: remove old path with cds^8
+let _compareJson
+const compareJson = (...args) => {
+  if (!_compareJson) {
+    try {
+      // new path
+      _compareJson = require('@sap/cds/libx/_runtime/common/utils/compareJson').compareJson
+    } catch {
+      // old path
+      _compareJson = require('@sap/cds/libx/_runtime/cds-services/services/utils/compareJson').compareJson
+    }
+  }
+  return _compareJson(...args)
+}
 
 const handledDeep = Symbol('handledDeep')
 


### PR DESCRIPTION
This reverts commit 3535a4e3ee4dd742931798d8e51381b1283f0e81.
the next hotfix should still be consumable in cds7 due to customer ticket.