### PR TITLE
fix: add cds schema for postgres build plugin

### DIFF
--- a/postgres/package.json
+++ b/postgres/package.json
@@ -67,6 +67,12 @@
         }
       },
       "db": "sql"
+    },
+    "schema": {
+      "buildTaskType": {
+        "name": "postgres",
+        "description": "Postgres database build plugin"
+      }
     }
   },
   "license": "SEE LICENSE"


### PR DESCRIPTION
This fix ensures that `postgres` build tasks do no longer get a warning marker and adds cds env code completion support. 