### PR TITLE
fix: Ensure that `Iterator` and `Readable` work correctly for `INSERT`

### DIFF
--- a/test/compliance/INSERT.test.js
+++ b/test/compliance/INSERT.test.js
@@ -1,6 +1,12 @@
-require('../cds')
+const cds = require('../cds')
+
+const { Readable } = require('stream')
 
 describe('INSERT', () => {
+  const { data, expect } = cds.test(__dirname + '/resources')
+  data.autoIsolation(true)
+  data.autoReset()
+
   describe('into', () => {
     test.skip('missing', () => {
       throw new Error('not supported')
@@ -8,8 +14,57 @@ describe('INSERT', () => {
   })
 
   describe('entries', () => {
-    test.skip('missing', () => {
-      throw new Error('not supported')
+    const genCount = 100
+    const gen = function* () {
+      for (let i = 0; i < genCount; i++)
+        yield { uuid: cds.utils.uuid() }
+    }
+
+    test('array', async () => {
+      const { uuid } = cds.entities('basic.literals')
+
+      await INSERT([...gen()]).into(uuid)
+
+      const result = await SELECT.from(uuid)
+      expect(result.length).to.eq(genCount)
+    })
+
+    test('iterator', async () => {
+      const { uuid } = cds.entities('basic.literals')
+
+      await INSERT(gen()).into(uuid)
+
+      const result = await SELECT.from(uuid)
+      expect(result.length).to.eq(genCount)
+    })
+
+    test('Readable (Object Mode)', async () => {
+      const { uuid } = cds.entities('basic.literals')
+
+      await INSERT(Readable.from(gen())).into(uuid)
+
+      const result = await SELECT.from(uuid)
+      expect(result.length).to.eq(genCount)
+    })
+
+    test('Readable (Raw Mode)', async () => {
+      const { uuid } = cds.entities('basic.literals')
+
+      const raw = function* (src) {
+        yield '['
+        let sep = ''
+        for (const obj of src) {
+          yield sep
+          yield JSON.stringify(obj)
+          sep = ','
+        }
+        yield ']'
+      }
+
+      await INSERT(Readable.from(raw(gen()), { objectMode: false })).into(uuid)
+
+      const result = await SELECT.from(uuid)
+      expect(result.length).to.eq(genCount)
     })
   })
 


### PR DESCRIPTION
Currently a lot of the `cds-dbs` logic relies on non consuming `Arrays` which are required to be kept fully in memory. It should be allowed to `INSERT` any kind of `Iterator` for scenarios where it is possible to not load the whole dataset into the application.

Examples:

```js
const { Books } = cds.entities

// Generator
const gen = function*(amount) {
  for(let i = 0; i < amount; i++) {
    yield { ID: cds.utils.uuid() }
  }
}
await INSERT(gen(100)).into(Books)

// Generator (async)
const genAsync = async function*(amount) {
  for(let i = 0; i < amount; i++) {
    yield { ID: await fetchKey() }
  }
}
await INSERT(genAsync(100)).into(Books)

// Readable (raw)
express.post('/upload', async (req,res) => {
  await INSERT(req).into(Books)
  res.end('done')
})

// Readable (object)
await INSERT(Readble.from(genAsync(100))).into(Books)

```