### PR TITLE
fix: allocate a new Buffer for each chunk of a Blob stream when using hana-client

### DIFF
--- a/hana/lib/drivers/hana-client.js
+++ b/hana/lib/drivers/hana-client.js
@@ -325,7 +325,7 @@ async function* rsIterator(rs, one) {
   yield buffer
 }
 
-async function* streamBlob(rs, rowIndex = -1, columnIndex, binaryBuffer = Buffer.allocUnsafe(1 << 16)) {
+async function* streamBlob(rs, rowIndex = -1, columnIndex, binaryBuffer) {
   const promChain = {
     resolve: () => { },
     reject: () => { }
@@ -369,11 +369,11 @@ async function* streamBlob(rs, rowIndex = -1, columnIndex, binaryBuffer = Buffer
     let blobPosition = 0
 
     while (true) {
-      // REVISIT: Ensure that the data read is divisible by 3 as that allows for base64 encoding
-      const read = await getData(columnIndex, blobPosition, binaryBuffer, 0, binaryBuffer.byteLength)
+      const buffer = binaryBuffer || Buffer.allocUnsafe(1 << 16)
+      const read = await getData(columnIndex, blobPosition, binaryBuffer, 0, buffer.byteLength)
       blobPosition += read
-      if (read < binaryBuffer.byteLength) {
-        yield binaryBuffer.subarray(0, read)
+      if (read < buffer.byteLength) {
+        yield buffer.subarray(0, read)
         break
       }
       yield binaryBuffer

--- a/hana/lib/drivers/hana-client.js
+++ b/hana/lib/drivers/hana-client.js
@@ -370,13 +370,13 @@ async function* streamBlob(rs, rowIndex = -1, columnIndex, binaryBuffer) {
 
     while (true) {
       const buffer = binaryBuffer || Buffer.allocUnsafe(1 << 16)
-      const read = await getData(columnIndex, blobPosition, binaryBuffer, 0, buffer.byteLength)
+      const read = await getData(columnIndex, blobPosition, buffer, 0, buffer.byteLength)
       blobPosition += read
       if (read < buffer.byteLength) {
         yield buffer.subarray(0, read)
         break
       }
-      yield binaryBuffer
+      yield buffer
     }
   } catch (e) {
     promChain.reject(e)


### PR DESCRIPTION
The original optimization was put into place to prevent allocating to much memory when streaming large data from HANA. This change relies on the memory management capabilities of `nodejs` to detect when a `Buffer` is no longer being referenced. Making this code identical in all scenarios where the optimization was working as intended, but will allow scenarios where the `Buffer` is kept for an extended period of time to not be changed with following reads.

fixes: https://github.com/cap-js/cds-dbs/issues/788