### PR TITLE
fix: Adjust Decimal formatter to always render a whole number

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1169,7 +1169,7 @@ class HANAService extends SQLService {
       Int64: expr => `TO_NVARCHAR(${expr})`,
       // Reading decimal as string to not loose precision
       Decimal: (expr, elem) => elem?.scale
-        ? `TO_NVARCHAR(${expr}, '9.${''.padEnd(elem.scale, '0')}')`
+        ? `TO_NVARCHAR(${expr}, '0.${''.padEnd(elem.scale, '0')}')`
         : `TO_NVARCHAR(${expr})`,
 
       // HANA types

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -1,5 +1,4 @@
 const assert = require('assert')
-const os = require('os')
 const cds = require('../cds.js')
 
 describe('SELECT', () => {
@@ -827,7 +826,7 @@ describe('SELECT', () => {
       })
       .filter(a => a)
 
-    const noUUIDRefs = ref => cds.builtin.types[ref.element?.type] !== cds.builtin.types.UUID
+    // const noUUIDRefs = ref => cds.builtin.types[ref.element?.type] !== cds.builtin.types.UUID
     const noBooleanRefs = ref => !(cds.builtin.types[ref.element?.type] instanceof cds.builtin.types.boolean.constructor)
     const noBinaryRefs = ref => !(cds.builtin.types[ref.element?.type] === cds.builtin.types.Binary || cds.builtin.types[ref.element?.type] === cds.builtin.types.LargeBinary)
     const noBlobRefs = ref => noBinaryRefs(ref) && cds.builtin.types[ref.element?.type] !== cds.builtin.types.LargeString

--- a/test/compliance/resources/db/basic/literals/basic.literals.number.js
+++ b/test/compliance/resources/db/basic/literals/basic.literals.number.js
@@ -56,6 +56,17 @@ module.exports = [
     integer64: '-9223372036854775808',
   },
   {
+    decimal: null
+  },
+  {
+    decimal: 0,
+    '=decimal': '0.0000'
+  },
+  {
+    decimal: 1,
+    '=decimal': '1.0000'
+  },
+  {
     decimal: '3.14153',
     '=decimal': '3.1415'
   },


### PR DESCRIPTION
closes https://github.com/cap-js/cds-dbs/issues/851

replaces https://github.com/cap-js/cds-dbs/pull/852