### PR TITLE
fix: enable `cesu8` by default for `hdb` driver and encode entries streams 

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -236,7 +236,7 @@ class HANAService extends SQLService {
       const row = rows[i]
       const expands = JSON.parse(row._expands_)
       const blobs = JSON.parse(row._blobs_)
-      const data = Object.assign(JSON.parse(row._json_), expands, blobs)
+      const data = Object.assign(JSON.parse(row._json_ || '{}'), expands, blobs)
       Object.keys(blobs).forEach(k => (data[k] = row[k] || data[k]))
 
       // REVISIT: try to unify with handleLevel from base driver used for streaming
@@ -661,6 +661,7 @@ class HANAService extends SQLService {
 
       const _stream = entries => {
         const stream = Readable.from(this.INSERT_entries_stream(entries, 'hex'), { objectMode: false })
+        stream.setEncoding('utf-8')
         stream.type = 'json'
         stream._raw = entries
         return stream

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -661,6 +661,7 @@ class HANAService extends SQLService {
 
       const _stream = entries => {
         const stream = Readable.from(this.INSERT_entries_stream(entries, 'hex'), { objectMode: false })
+        stream.type = 'json'
         stream._raw = entries
         return stream
       }

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -1,4 +1,4 @@
-const { Readable, Stream } = require('stream')
+const { Readable, Stream, promises: { pipeline } } = require('stream')
 const { StringDecoder } = require('string_decoder')
 const { text } = require('stream/consumers')
 
@@ -160,7 +160,8 @@ class HDBDriver extends driver {
         if (this._creds.useCesu8 !== false && v.type === 'json') {
           const encode = iconv.encodeStream('cesu8')
           v.setEncoding('utf-8')
-          v.pipe(encode)
+          // hdb will react to the stream error no need to handle it twice
+          pipeline(v, encode).catch(() => { })
           return encode
         }
 

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -22,7 +22,6 @@ class HDBDriver extends driver {
    */
   constructor(creds) {
     creds = {
-      useCesu8: false,
       fetchSize: 1 << 16, // V8 default memory page size
       ...creds,
     }
@@ -138,7 +137,7 @@ class HDBDriver extends driver {
   _getResultForProcedure(rows, outParameters) {
     // on hdb, rows already contains results for scalar params
     const isArray = Array.isArray(rows)
-    const result = isArray ? {...rows[0]} : {...rows}
+    const result = isArray ? { ...rows[0] } : { ...rows }
 
     // merge table output params into scalar params
     const args = isArray ? rows.slice(1) : []
@@ -158,6 +157,13 @@ class HDBDriver extends driver {
     const streams = []
     values = values.map((v, i) => {
       if (v instanceof Stream) {
+        if (this._creds.useCesu8 !== false && v.type === 'json') {
+          const encode = iconv.encodeStream('cesu8')
+          v.setEncoding('utf-8')
+          v.pipe(encode)
+          return encode
+        }
+
         streams[i] = v
         const iterator = v[Symbol.asyncIterator]()
         return Readable.from(iterator, { objectMode: false })


### PR DESCRIPTION
fixes: https://github.com/cap-js/cds-dbs/blob/da629d98192cf1b196cceb172cb01f4a39acd887/test/compliance/resources/db/basic/literals/basic.literals.string.js#L41

The tests run with `hana-client` inside the pipelines. Tested locally works as expected.