### PR TITLE
fix: boolean for sql_simple_queries 

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -289,7 +289,7 @@ class CQN2SQLRenderer {
       ? x => {
         const name = this.column_name(x)
         const escaped = `${name.replace(/"/g, '""')}`
-        let col = `${this.quote(name)} AS "${escaped}"`
+        let col = `${this.output_converter4(x.element, this.quote(name))} AS "${escaped}"`
         if (x.SELECT?.count) {
           // Return both the sub select and the count for @odata.count
           const qc = cds.ql.clone(x, { columns: [{ func: 'count' }], one: 1, limit: 0, orderBy: 0 })

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -289,7 +289,7 @@ class CQN2SQLRenderer {
       ? x => {
         const name = this.column_name(x)
         const escaped = `${name.replace(/"/g, '""')}`
-        let col = `${this.output_converter4(x.element, this.quote(name))} AS "${escaped}"`
+        let col = `${this.quote(name)} AS "${escaped}"`
         if (x.SELECT?.count) {
           // Return both the sub select and the count for @odata.count
           const qc = cds.ql.clone(x, { columns: [{ func: 'count' }], one: 1, limit: 0, orderBy: 0 })

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -208,10 +208,10 @@ class SQLiteService extends SQLService {
       struct: expr => `${expr}->'$'`,
       array: expr => `${expr}->'$'`,
       // SQLite has no booleans so we need to convert 0 and 1
-      boolean: expr =>
+      boolean:
         cds.env.features.sql_simple_queries === 2
           ? undefined
-          : `CASE ${expr} when 1 then 'true' when 0 then 'false' END ->'$'`,
+          : expr => `CASE ${expr} when 1 then 'true' when 0 then 'false' END ->'$'`,
       // DateTimes are returned without ms added by InputConverters
       DateTime: e => `substr(${e},0,20)||'Z'`,
       // Timestamps are returned with ms, as written by InputConverters.

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -208,7 +208,10 @@ class SQLiteService extends SQLService {
       struct: expr => `${expr}->'$'`,
       array: expr => `${expr}->'$'`,
       // SQLite has no booleans so we need to convert 0 and 1
-      boolean: expr => `CASE ${expr} when 1 then 'true' when 0 then 'false' END ->'$'`,
+      boolean: expr =>
+        cds.env.features.sql_simple_queries === 2
+          ? undefined
+          : `CASE ${expr} when 1 then 'true' when 0 then 'false' END ->'$'`,
       // DateTimes are returned without ms added by InputConverters
       DateTime: e => `substr(${e},0,20)||'Z'`,
       // Timestamps are returned with ms, as written by InputConverters.


### PR DESCRIPTION
For sql_simple_queries=2 elements of Boolean type are returned as strings due to the output converter. To correct this, we disable the boolean output converter for this feature flag.