### PR TITLE
perf: Add foreign key indexes to tables

### DIFF
--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -55,10 +55,10 @@ describe('Bookshop - Read', () => {
     expect(res.data.value.length).to.be.eq(4) // As there are two books which have the same author
     expect(
       res.data.value.every(
-      item =>
-        'author' in item &&
-        'ID' in item.author && // foreign key is renamed to element name in target
-        !('author_ID' in item.author),
+        item =>
+          'author' in item &&
+          'ID' in item.author && // foreign key is renamed to element name in target
+          !('author_ID' in item.author),
       ),
     ).to.be.true
   })
@@ -355,18 +355,18 @@ describe('Bookshop - Read', () => {
   })
 
   it('allows filtering with between operator', async () => {
-    const query = SELECT.from('sap.capire.bookshop.Books', ['ID', 'stock']).where ({ stock: { between: 0, and: 100 } })
+    const query = SELECT.from('sap.capire.bookshop.Books', ['ID', 'stock']).where({ stock: { between: 0, and: 100 } })
 
-    return expect((await query).every(row => row.stock >=0 && row.stock <=100)).to.be.true
+    return expect((await query).every(row => row.stock >= 0 && row.stock <= 100)).to.be.true
   })
 
   it('allows various mechanisms for expressing "not in"', async () => {
     const results = await cds.db.run([
-      SELECT.from('sap.capire.bookshop.Books', ['ID']).where({ ID: { 'not in': [201, 251] } }),
-      SELECT.from('sap.capire.bookshop.Books', ['ID']).where({ ID: { not: { in: [201, 251] } } }),
-      SELECT.from('sap.capire.bookshop.Books', ['ID']).where('ID not in', [201, 251])
+      SELECT.from('sap.capire.bookshop.Books', ['ID']).where({ ID: { 'not in': [201, 251] } }).orderBy('ID'),
+      SELECT.from('sap.capire.bookshop.Books', ['ID']).where({ ID: { not: { in: [201, 251] } } }).orderBy('ID'),
+      SELECT.from('sap.capire.bookshop.Books', ['ID']).where('ID not in', [201, 251]).orderBy('ID')
     ])
 
-    for (const row of results) expect(row).to.deep.eq([{ID: 207},{ID: 252},{ID: 271}])
+    for (const result of results) expect(result).to.deep.eq([{ ID: 207 }, { ID: 252 }, { ID: 271 }])
   })
 })


### PR DESCRIPTION
With the latest release of `better-sqlite3@11.5` the `SQLite3` version was bumped to `3.47.0` ([changes](https://sqlite.org/releaselog/3_47_0.html)).

> No attempt is made to create [automatic indexes](https://sqlite.org/optoverview.html#autoindex) on a column that is known to be non-selective because of its use in other indexes that have been analyzed.

this seems to be the most important change for CAP applications as we create many `join` conditions using `associations` and `compositions` which `SQLite3` tries to process to the best of its ability by creating temporary automatic indexes, but with this optimization the likeliness of these indexes being created is greatly reduced. Causing some of the more complex join queries to take `5000x` longer then when using `better-sqlite@11.4`. This PR tries to mitigate the effect of the reduced number of automatically generated indexes by using the model definition to provide explicit indexes for these modeled join condition sources / targets.

An example of the impact that providing explicit indexes has on complex SFlight requests:

```
analytics/Bookings?$expand=to_Travel($expand=CurrencyCode,TravelStatus,to_Agency,to_Customer,to_Booking),to_Carrier,to_Flight&$top=30
```

|   | sqlite | postgres | hana |
| --- | --- | --- | --- |
| before | ~50 req/s | ~50 req/s | ~140 req/s |
| after | ~130 req/s | ~110 req/s | ~140 req/s |

So while it doesn't have an impact on the HANA performance it provides additional optimization information for `SQLite` and `Postgres`. Closing the gap that `SQLite` and `Postgres` always have had when being compared with `HANA` for complex join heavy queries.