### PR TITLE
fix: pseudo paths in expands

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1868,13 +1868,18 @@ function cqn4sql(originalQuery, model) {
               value: [],
               writable: true,
             })
+            let pseudoPath = false
             ref.reduce((prev, res, i) => {
               if (res === '$self')
                 // next is resolvable in entity
                 return prev
               if (res in pseudos.elements) {
+                pseudoPath = true
                 thing.$refLinks.push({ definition: pseudos.elements[res], target: pseudos })
                 return pseudos.elements[res]
+              } else if (pseudoPath) {
+                thing.$refLinks.push({ definition: {}, target: pseudos })
+                return prev?.elements[res]
               }
               const definition =
                 prev?.elements?.[res] || getDefinition(prev?.target)?.elements[res] || pseudos.elements[res]

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -172,12 +172,17 @@ function infer(originalQuery, model) {
     if (!ref) return
     init$refLinks(arg)
     let i = 0
+    let pseudoPath = false
     for (const step of ref) {
       const id = step.id || step
       if (i === 0) {
-        // infix filter never have table alias
-        // we need to search for first step in ´model.definitions[infixAlias]`
-        if ($baseLink) {
+        if (id in pseudos.elements) {
+          // pseudo path
+          arg.$refLinks.push({ definition: pseudos.elements[id], target: pseudos })
+          pseudoPath = true // only first path step must be well defined
+        } else if ($baseLink) {
+          // infix filter never have table alias
+          // we need to search for first step in ´model.definitions[infixAlias]`
           const { definition } = $baseLink
           const elements = getDefinition(definition.target)?.elements || definition.elements
           const e = elements?.[id] || cds.error`"${id}" not found in the elements of "${definition.name}"`
@@ -201,11 +206,15 @@ function infer(originalQuery, model) {
           const definition = getDefinition(id) || cds.error`"${id}" not found in the definitions of your model`
           arg.$refLinks[0] = { definition, target: definition }
         }
+      } else if (arg.ref[0] === '$user' && pseudoPath) {
+        // `$user.some.unknown.element` -> no error
+        arg.$refLinks.push({ definition: {}, target: pseudos })
       } else {
         const recent = arg.$refLinks[i - 1]
         const { elements } = getDefinition(recent.definition.target) || recent.definition
         const e = elements[id]
-        if (!e) throw new Error(`"${id}" not found in the elements of "${arg.$refLinks[i - 1].definition.name}"`)
+        const notFoundIn = pseudoPath ? arg.ref[i - 1] : getFullPathForLinkedArg(arg)
+        if (!e) throw new Error(`"${id}" not found in the elements of "${notFoundIn}"`)
         arg.$refLinks.push({ definition: e, target: getDefinition(e.target) || e })
       }
       arg.$refLinks[i].alias = !ref[i + 1] && arg.as ? arg.as : id.split('.').pop()

--- a/db-service/test/bookshop/db/booksWithExpr.cds
+++ b/db-service/test/bookshop/db/booksWithExpr.cds
@@ -97,5 +97,5 @@ entity VariableReplacements {
   key ID: Integer;
   author: Association to Authors;
   // with variable replacements
-  authorAlive = author[dateOfBirth <= $now and dateOfDeath >= $now];
+  authorAlive = author[dateOfBirth <= $now and dateOfDeath >= $now and $user.unknown.foo.bar = 'Bob'];
 }

--- a/db-service/test/cqn4sql/model/collaborations.cds
+++ b/db-service/test/cqn4sql/model/collaborations.cds
@@ -10,6 +10,10 @@ entity Collaborations : cuid {
   leads           : Association to many CollaborationLeads on leads.collaboration = $self and leads.isLead = true;
   collaborationLogs: Association to many CollaborationLogs on collaborationLogs.collaboration = $self;
   activeOwners: Association to ActiveOwners on activeOwners.collaboration = $self;
+  participant: Association to CollaborationParticipants;
+  leads2              = participant[validFrom <= $now
+  and                               validTo   >= $now
+  and                               isLead    =  true];
 }
 entity ActiveOwners : cuid {
   collaboration: Association to Collaborations;
@@ -34,6 +38,9 @@ entity SubCollaborationAssignments : cuid {
 }
 entity CollaborationParticipants : cuid {
   scholar_userID: Int16;
+  isLead           : Boolean default false;
+  validFrom        : DateTime;
+  validTo          : DateTime;
 }
 entity CollaborationApplications : cuid {
     subCollaborations: Composition of many SubCollaborationApplications on subCollaborations.application = $self;


### PR DESCRIPTION
pseudo paths were leading to a dump if they were
used in an expand on an association which follows them in its filter expression.

We need to revisit #617, as there is a lot of duplicate logic in two main functions of `infer` --> get rid of
`attachRefLinksToArg`!