### PR TITLE
fix: cross joins w/o on-condition

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -363,8 +363,10 @@ class CQN2SQLRenderer {
       return _aliased(this.quote(this.name(z)))
     }
     if (from.SELECT) return _aliased(`(${this.SELECT(from)})`)
-    if (from.join)
-      return `${this.from(from.args[0])} ${from.join} JOIN ${this.from(from.args[1])} ON ${this.where(from.on)}`
+    if (from.join) {
+      const joinCondition = from.on ? ` ON ${this.where(from.on)}` : '';
+      return `${this.from(from.args[0])} ${from.join} JOIN ${this.from(from.args[1])}${joinCondition}`;
+    }
   }
 
   /**

--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -400,13 +400,13 @@ describe('Bookshop - Read', () => {
     }
   })
 
-  it('cross joins w/o on condition', async () => {
+  it('cross joins without on condition', async () => {
     const query = SELECT.from('sap.capire.bookshop.Books as Books, sap.capire.bookshop.Authors as Authors')
       .columns('Books.title', 'Authors.name as author')
       .where('Books.author_ID = Authors.ID')
-    const queryWithPaths = SELECT.from('sap.capire.bookshop.Books').columns('title', 'author.name as author')
-    const res = await cds.db.run(query)
-    const resWithPaths = await cds.db.run(queryWithPaths)
-    expect(res).to.deep.eq(resWithPaths)
+    const pathExpressionQuery = SELECT.from('sap.capire.bookshop.Books').columns('title', 'author.name as author')
+    const crossJoinResult = await cds.db.run(query)
+    const pathExpressionResult = await cds.db.run(pathExpressionQuery)
+    expect(crossJoinResult).to.deep.eq(pathExpressionResult)
   })
 })

--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -399,4 +399,14 @@ describe('Bookshop - Read', () => {
       ]))
     }
   })
+
+  it('cross joins w/o on condition', async () => {
+    const query = SELECT.from('sap.capire.bookshop.Books as Books, sap.capire.bookshop.Authors as Authors')
+      .columns('Books.title', 'Authors.name as author')
+      .where('Books.author_ID = Authors.ID')
+    const queryWithPaths = SELECT.from('sap.capire.bookshop.Books').columns('title', 'author.name as author')
+    const res = await cds.db.run(query)
+    const resWithPaths = await cds.db.run(queryWithPaths)
+    expect(res).to.deep.eq(resWithPaths)
+  })
 })


### PR DESCRIPTION
do not try to render an on-condition if none is provided

fix #897
fix #891

---

reproduced dump reported in the issues can be found [here](https://github.com/cap-js/cds-dbs/actions/runs/11891517718/job/33132429878?pr=899#step:7:264) fixed with 2e439b1dec9dac0d0a941f4717e2011e2fbde04c 