### PR TITLE
test: Skip start script for users with remote HANA configured

### DIFF
--- a/hana/package.json
+++ b/hana/package.json
@@ -16,7 +16,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "npm start && cds-test $(../test/find)",
+    "test": "(([ -z \"${HANA_HOST}\" ] && npm start) || true) && cds-test $(../test/find)",
     "test:remote": "cds-test",
     "start": "npm run start:hce || npm run start:hxe",
     "start:hce": "cd ./tools/docker/hce/ && ./start.sh",


### PR DESCRIPTION
This allows mac users with the `HANA_HOST` environment variable set to use the normal `npm t -w hana` command