### PR TITLE
feat!: natively support unknown functions without args

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -990,7 +990,7 @@ class CQN2SQLRenderer {
     } else {
       cds.error`Invalid arguments provided for function '${func}' (${args})`
     }
-    const fn = this.class.Functions[func]?.apply(this.class.Functions, args) || `${func}(${args})`
+    const fn = this.class.Functions[func]?.apply(this.class.Functions, args) || `${func}${args ? `(${args})`: ''}`
     if (xpr) return `${fn} ${this.xpr({ xpr })}`
     return fn
   }


### PR DESCRIPTION
certain HANA functions like `current_timestamp` have to be called without brackets. We do consider this for known functions but not for unknown.

Downside is that for common functions like COUNT, the args always have to be provided.