### PR TITLE
fix: SAP HANA functions should also be callable in upper case on SAP HANA

### DIFF
--- a/db-service/lib/cql-functions.js
+++ b/db-service/lib/cql-functions.js
@@ -253,18 +253,18 @@ const StandardFunctions = {
         ) - 0.5
       )
     ) * 86400
-  )`,
+  )`
+}
+
+const HANAFunctions = {
+  // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/f12b86a6284c4aeeb449e57eb5dd3ebd.html
 
   /**
    * Generates SQL statement that calls the session_context function with the given parameter
    * @param {string} x session variable name or SQL expression
    * @returns {string}
    */
-  session_context: x => `session_context('${x.val}')`,
-}
-
-const HANAFunctions = {
-  // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/f12b86a6284c4aeeb449e57eb5dd3ebd.html
+    session_context: x => `session_context('${x.val}')`,
 
   // Time functions
   current_date: p => (p ? `current_date(${p})` : 'current_date'),

--- a/db-service/lib/cql-functions.js
+++ b/db-service/lib/cql-functions.js
@@ -159,10 +159,6 @@ const StandardFunctions = {
 
   // Date and Time Functions
 
-  current_date: p => (p ? `current_date(${p})` : 'current_date'),
-  current_time: p => (p ? `current_time(${p})` : 'current_time'),
-  current_timestamp: p => (p ? `current_timestamp(${p})` : 'current_timestamp'),
-
   /**
    * Generates SQL statement that produces current point in time (date and time with time zone)
    * @returns {string}
@@ -271,6 +267,9 @@ const HANAFunctions = {
   // https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/f12b86a6284c4aeeb449e57eb5dd3ebd.html
 
   // Time functions
+  current_date: p => (p ? `current_date(${p})` : 'current_date'),
+  current_time: p => (p ? `current_time(${p})` : 'current_time'),
+  current_timestamp: p => (p ? `current_timestamp(${p})` : 'current_timestamp'),
   /**
    * Generates SQL statement that calculates the difference in 100nanoseconds between two timestamps
    * @param {string} x left timestamp

--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -104,11 +104,16 @@ const StandardFunctions = {
   maxdatetime: () => "'9999-12-31T23:59:59.999Z'",
   mindatetime: () => "'0001-01-01T00:00:00.000Z'",
   now: () => `session_context('$now')`,
+  fractionalseconds: x => `(TO_DECIMAL(SECOND(${x}),5,3) - TO_INTEGER(SECOND(${x})))`
+}
+
+const HANAFunctions = {
   current_date: () => 'current_utcdate',
   current_time: () => 'current_utctime',
   current_timestamp: () => 'current_utctimestamp',
   current_utctimestamp: x => x ? `current_utctimestamp(${x})` : 'current_utctimestamp',
-  fractionalseconds: x => `(TO_DECIMAL(SECOND(${x}),5,3) - TO_INTEGER(SECOND(${x})))`,
 }
 
-module.exports = StandardFunctions
+for (let each in HANAFunctions) HANAFunctions[each.toUpperCase()] = HANAFunctions[each]
+
+module.exports = { ...StandardFunctions, ...HANAFunctions }

--- a/hana/test/hana-functions.test.js
+++ b/hana/test/hana-functions.test.js
@@ -8,7 +8,7 @@ describe('HANA native functions', () => {
       const cqn = { SELECT: {
         one: true,
         from: {ref: ['DUMMY']}, 
-        columns: [{func: 'current_utctimestamp', as: 'NO'}]
+        columns: [{func: 'CURRENT_UTCTIMESTAMP', as: 'NO'}]
       }}
   
       const res = await cds.run(cqn)

--- a/test/cds.js
+++ b/test/cds.js
@@ -72,7 +72,7 @@ cds.test = Object.setPrototypeOf(function () {
         hash.update(isolateName)
         ret.data.isolation = isolate = {
           // Create one database for each overall test execution
-          database: process.env.TRAVIS_JOB_ID || process.env.GITHUB_RUN_ID || require('os').userInfo().username.repeat(6) || 'test_db',
+          database: process.env.TRAVIS_JOB_ID || process.env.GITHUB_RUN_ID || require('os').userInfo().username || 'test_db',
           // Create one tenant for each test suite
           tenant: 'T' + hash.digest('hex'),
         }

--- a/test/cds.js
+++ b/test/cds.js
@@ -72,7 +72,7 @@ cds.test = Object.setPrototypeOf(function () {
         hash.update(isolateName)
         ret.data.isolation = isolate = {
           // Create one database for each overall test execution
-          database: process.env.TRAVIS_JOB_ID || process.env.GITHUB_RUN_ID || require('os').userInfo().username || 'test_db',
+          database: process.env.TRAVIS_JOB_ID || process.env.GITHUB_RUN_ID || require('os').userInfo().username.repeat(6) || 'test_db',
           // Create one tenant for each test suite
           tenant: 'T' + hash.digest('hex'),
         }


### PR DESCRIPTION
According to https://cap.cloud.sap/docs/guides/databases#functions-mappings-for-runtime-queries

> For the SAP HANA functions, both usages are allowed: all-lowercase as given above, as well as all-uppercase.