### PR TITLE
refactor(infer): consolidate two main functions

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1404,7 +1404,8 @@ function cqn4sql(originalQuery, model) {
           if (list.every(e => e.val))
             // no need for transformation
             transformedTokenStream.push({ list })
-          else transformedTokenStream.push({ list: getTransformedTokenStream(list, $baseLink) })
+          else 
+            transformedTokenStream.push({ list: getTransformedTokenStream(list, $baseLink) })
         }
       } else if (tokenStream.length === 1 && token.val && $baseLink) {
         // infix filter - OData variant w/o mentioning key --> flatten out and compare each leaf to token.val
@@ -1726,7 +1727,8 @@ function cqn4sql(originalQuery, model) {
       transformedFrom.$refLinks.splice(0, transformedFrom.$refLinks.length - 1)
 
       let args = from.ref.at(-1).args
-      const subquerySource = transformedFrom.$refLinks[0].target
+      const subquerySource =
+        getDefinition(transformedFrom.$refLinks[0].definition.target) || transformedFrom.$refLinks[0].target
       if (subquerySource.params && !args) args = {}
       const id = localized(subquerySource)
       transformedFrom.ref = [args ? { id, args } : id]

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -5,6 +5,7 @@ const cds = require('@sap/cds')
 const JoinTree = require('./join-tree')
 const { pseudos } = require('./pseudos')
 const { isCalculatedOnRead } = require('../utils')
+const { t } = require('@sap/cds/lib/utils/tar')
 const cdsTypes = cds.linked({
   definitions: {
     Timestamp: { type: 'cds.Timestamp' },
@@ -42,6 +43,8 @@ function infer(originalQuery, model) {
   // cache for already processed calculated elements
   const alreadySeenCalcElements = new Set()
 
+  let $combinedElements
+
   const sources = inferTarget(_.from || _.into || _.entity, {})
   const joinTree = new JoinTree(sources)
   const aliases = Object.keys(sources)
@@ -62,21 +65,21 @@ function infer(originalQuery, model) {
     },
   })
   if (originalQuery.SELECT || originalQuery.DELETE || originalQuery.UPDATE) {
-    const $combinedElements = inferCombinedElements()
+    $combinedElements = inferCombinedElements()
     /**
      * TODO: this function is currently only called on DELETE's
      *       because it correctly set's up the $refLink's in the
      *       where clause: This functionality should be pulled out
      *       of ´inferQueryElement()` as this is a subtle side effect
      */
-    const elements = inferQueryElements($combinedElements)
+    const elements = inferQueryElements()
     Object.defineProperties(inferred, {
-      $combinedElements: { value: $combinedElements, writable: true },
-      elements: { value: elements, writable: true },
-      joinTree: { value: joinTree, writable: true }, // REVISIT: eliminate
+      $combinedElements: { value: $combinedElements, writable: true, configurable: true },
+      elements: { value: elements, writable: true, configurable: true },
+      joinTree: { value: joinTree, writable: true, configurable: true }, // REVISIT: eliminate
     })
     // also enrich original query -> writable because it may be inferred again
-    Object.defineProperty(originalQuery, 'elements', { value: elements, writable: true })
+    Object.defineProperty(originalQuery, 'elements', { value: elements, writable: true, configurable: true })
   }
   return inferred
 
@@ -299,11 +302,11 @@ function infer(originalQuery, model) {
    *                                   to an array of objects containing the index and table alias where the element can be found.
    * @returns {object} The inferred `elements` dictionary of the query, which maps element names to their corresponding definitions.
    */
-  function inferQueryElements($combinedElements) {
+  function inferQueryElements() {
     let queryElements = {}
     const { columns, where, groupBy, having, orderBy } = _
     if (!columns) {
-      inferElementsFromWildCard(aliases)
+      inferElementsFromWildCard(queryElements)
     } else {
       let wildcardSelect = false
       const dollarSelfRefs = []
@@ -338,9 +341,9 @@ function infer(originalQuery, model) {
             !firstStepIsTableAlias && col.ref.length > 1 && ['$self', '$projection'].includes(col.ref[0])
           // we must handle $self references after the query elements have been calculated
           if (firstStepIsSelf) dollarSelfRefs.push(col)
-          else handleRef(col)
+          else handleRef(col, )
         } else if (col.expand) {
-          inferQueryElement(col)
+          inferQueryElement(col, queryElements, null)
         } else {
           cds.error`Not supported: ${JSON.stringify(col)}`
         }
@@ -348,7 +351,7 @@ function infer(originalQuery, model) {
 
       if (dollarSelfRefs.length) inferDollarSelfRefs(dollarSelfRefs)
 
-      if (wildcardSelect) inferElementsFromWildCard(aliases)
+      if (wildcardSelect) inferElementsFromWildCard(queryElements)
     }
     if (orderBy) {
       // link $refLinks -> special name resolution rules for orderBy
@@ -376,7 +379,7 @@ function infer(originalQuery, model) {
           $baseLink = null
         }
 
-        inferQueryElement(token, false, $baseLink)
+        inferQueryElement(token, queryElements, $baseLink, { inQueryModifier: true })
         if (token.isJoinRelevant && rejectJoinRelevantPath) {
           // reverse the array, find the last association and calculate the index of the association in non-reversed order
           const assocIndex =
@@ -390,7 +393,7 @@ function infer(originalQuery, model) {
     }
 
     // walk over all paths in other query properties
-    if (where) walkTokenStream(where)
+    if (where) walkTokenStream(where, true)
     if (groupBy) groupBy.forEach(token => inferQueryElement(token, false))
     if (having) walkTokenStream(having)
     if (_.with)
@@ -407,7 +410,7 @@ function infer(originalQuery, model) {
      *
      * @param {array} tokenStream
      */
-    function walkTokenStream(tokenStream) {
+    function walkTokenStream(tokenStream, inExpr = false) {
       let skipJoins
       const processToken = t => {
         if (t === 'exists') {
@@ -417,7 +420,7 @@ function infer(originalQuery, model) {
           // don't miss an exists within an expression
           t.xpr.forEach(processToken)
         } else {
-          inferQueryElement(t, false, null, { inExists: skipJoins, inExpr: true })
+          inferQueryElement(t, queryElements, null, { inExists: skipJoins, inExpr, inQueryModifier: true })
           skipJoins = false
         }
       }
@@ -460,7 +463,7 @@ function infer(originalQuery, model) {
     }
 
     function handleRef(col) {
-      inferQueryElement(col)
+      inferQueryElement(col, queryElements)
       const { definition } = col.$refLinks[col.$refLinks.length - 1]
       if (col.cast)
         // final type overwritten -> element not visible anymore
@@ -470,148 +473,89 @@ function infer(originalQuery, model) {
         setElementOnColumns(col, queryElements[col.as || '$user'])
       else setElementOnColumns(col, definition)
     }
+  }
 
-    /**
-     * This function is responsible for inferring a query element based on a provided column.
-     * It initializes and attaches a non-enumerable `$refLinks` property to the column,
-     * which stores an array of objects that represent the corresponding artifact of the ref step.
-     * Each object in the `$refLinks` array corresponds to the same index position in the `column.ref` array.
-     * Based on the leaf artifact (last object in the `$refLinks` array), the query element is inferred.
-     *
-     * @param {object} column - The column object that contains the properties to infer a query element.
-     * @param {boolean} [insertIntoQueryElements=true] - Determines whether the inferred element should be inserted into the queries elements.
-     * For instance, it's set to false when walking over the where clause.
-     * @param {object} [$baseLink=null] - A base reference link, usually it's an object with a definition and a target.
-     * Used for infix filters, exists <assoc> and nested projections.
-     * @param {object} [context={}] - Contextual information for element inference.
-     * @param {boolean} [context.inExists=false] - Flag to control the creation of joins for non-association path traversals.
-     * for `exists <assoc>` paths we do not need to create joins for path expressions as they are part of the semi-joined subquery.
-     * @param {boolean} [context.inExpr=false] - Flag to signal whether the element is part of an expression.
-     * Used to ignore non-persisted elements.
-     * @param {boolean} [context.inNestedProjection=false] - Flag to signal whether the element is part of a nested projection.
-     *
-     * Note:
-     * - `inExists` is used to specify cases where no joins should be created for non-association path traversals.
-     *   It is primarily used for infix filters in `exists assoc[parent.foo='bar']`, where it becomes part of a semi-join.
-     * - Columns with a `param` property are parameter references resolved into values only at execution time.
-     * - Columns with an `args` property are function calls in expressions.
-     * - Columns with a `list` property represent a list of values (e.g., for the IN operator).
-     * - Columns with a `SELECT` property represent subqueries.
-     *
-     * @throws {Error} If an unmanaged association is found in an infix filter path, an error is thrown.
-     * @throws {Error} If a non-foreign key traversal is found in an infix filter, an error is thrown.
-     * @throws {Error} If a first step is not found in the combined elements, an error is thrown.
-     * @throws {Error} If a filter is provided while navigating along non-associations, an error is thrown.
-     * @throws {Error} If the same element name is inferred more than once, an error is thrown.
-     *
-     * @returns {void}
-     */
+  /**
+   * This function is responsible for inferring a query element based on a provided column.
+   * It initializes and attaches a non-enumerable `$refLinks` property to the column,
+   * which stores an array of objects that represent the corresponding artifact of the ref step.
+   * Each object in the `$refLinks` array corresponds to the same index position in the `column.ref` array.
+   * Based on the leaf artifact (last object in the `$refLinks` array), the query element is inferred.
+   *
+   * @param {object} arg - The column object that contains the properties to infer a query element.
+   * @param {boolean} [queryElements=true] - Determines whether the inferred element should be inserted into the queries elements.
+   * For instance, it's set to false when walking over the where clause.
+   * @param {object} [$baseLink=null] - A base reference link, usually it's an object with a definition and a target.
+   * Used for infix filters, exists <assoc> and nested projections.
+   * @param {object} [context={}] - Contextual information for element inference.
+   * @param {boolean} [context.inExists=false] - Flag to control the creation of joins for non-association path traversals.
+   * for `exists <assoc>` paths we do not need to create joins for path expressions as they are part of the semi-joined subquery.
+   * @param {boolean} [context.inExpr=false] - Flag to signal whether the element is part of an expression.
+   * Used to ignore non-persisted elements.
+   * @param {boolean} [context.inNestedProjection=false] - Flag to signal whether the element is part of a nested projection.
+   *
+   * Note:
+   * - `inExists` is used to specify cases where no joins should be created for non-association path traversals.
+   *   It is primarily used for infix filters in `exists assoc[parent.foo='bar']`, where it becomes part of a semi-join.
+   * - Columns with a `param` property are parameter references resolved into values only at execution time.
+   * - Columns with an `args` property are function calls in expressions.
+   * - Columns with a `list` property represent a list of values (e.g., for the IN operator).
+   * - Columns with a `SELECT` property represent subqueries.
+   *
+   * @throws {Error} If an unmanaged association is found in an infix filter path, an error is thrown.
+   * @throws {Error} If a non-foreign key traversal is found in an infix filter, an error is thrown.
+   * @throws {Error} If a first step is not found in the combined elements, an error is thrown.
+   * @throws {Error} If a filter is provided while navigating along non-associations, an error is thrown.
+   * @throws {Error} If the same element name is inferred more than once, an error is thrown.
+   *
+   * @returns {void}
+   */
 
-    function inferQueryElement(column, insertIntoQueryElements = true, $baseLink = null, context) {
-      const { inExists, inExpr, inCalcElement, baseColumn, inInfixFilter } = context || {}
-      if (column.param || column.SELECT) return // parameter references are only resolved into values on execution e.g. :val, :1 or ?
-      if (column.args) {
-        applyToFunctionArgs(column.args, inferQueryElement, [false, $baseLink, context])
-      }
-      if (column.list) column.list.forEach(arg => inferQueryElement(arg, false, $baseLink, context))
-      if (column.xpr)
-        column.xpr.forEach(token => inferQueryElement(token, false, $baseLink, { ...context, inExpr: true })) // e.g. function in expression
+  function inferQueryElement(arg, queryElements = null, $baseLink = null, context = {}) {
+    const { inExists, inExpr, inCalcElement, baseColumn, inInfixFilter, inQueryModifier } = context
+    if (arg.param || arg.SELECT) return // parameter references are only resolved into values on execution e.g. :val, :1 or ?
+    if (arg.args) applyToFunctionArgs(arg.args, inferQueryElement, [null, $baseLink, context])
+    if (arg.list) arg.list.forEach(arg => inferQueryElement(arg, null, $baseLink, context))
+    if (arg.xpr) arg.xpr.forEach(token => inferQueryElement(token, queryElements, $baseLink, { ...context, inExpr: true })) // e.g. function in expression
 
-      if (!column.ref) {
-        if (column.expand) queryElements[column.as] = resolveExpand(column)
-        return
-      }
+    if (!arg.ref) {
+      if (arg.expand && queryElements) queryElements[arg.as] = resolveExpand(arg)
+      return
+    }
 
-      init$refLinks(column)
-      // if any path step points to an artifact with `@cds.persistence.skip`
-      // we must ignore the element from the queries elements
-      let isPersisted = true
-      const firstStepIsTableAlias = column.ref.length > 1 && column.ref[0] in sources
-      const firstStepIsSelf =
-        !firstStepIsTableAlias && column.ref.length > 1 && ['$self', '$projection'].includes(column.ref[0])
-      const expandOnTableAlias = column.ref.length === 1 && column.ref[0] in sources && (column.expand || column.inline)
-      const nameSegments = []
-      // if a (segment) of a (structured) foreign key is renamed, we must not include
-      // the aliased ref segments into the name of the final foreign key which is e.g. used in
-      // on conditions of joins
-      const skipAliasedFkSegmentsOfNameStack = []
-      let pseudoPath = false
-      column.ref.forEach((step, i) => {
-        const id = step.id || step
-        if (i === 0) {
-          if (id in pseudos.elements) {
-            // pseudo path
-            column.$refLinks.push({ definition: pseudos.elements[id], target: pseudos })
-            pseudoPath = true // only first path step must be well defined
-            nameSegments.push(id)
-          } else if ($baseLink) {
-            const { definition, target } = $baseLink
-            const elements = getDefinition(definition.target)?.elements || definition.elements
-            if (elements && id in elements) {
-              const element = elements[id]
-              if (inInfixFilter) {
-                const nextStep = column.ref[1]?.id || column.ref[1]
-                if (isNonForeignKeyNavigation(element, nextStep)) {
-                  if (inExists) {
-                    Object.defineProperty($baseLink, 'pathExpressionInsideFilter', { value: true })
-                  } else {
-                    rejectNonFkNavigation(element, element.on ? $baseLink.definition.name : nextStep)
-                  }
-                }
-              }
-              const resolvableIn = getDefinition(definition.target) || target
-              const $refLink = { definition: elements[id], target: resolvableIn }
-              column.$refLinks.push($refLink)
-            } else {
-              stepNotFoundInPredecessor(id, definition.name)
-            }
-            nameSegments.push(id)
-          } else if (firstStepIsTableAlias) {
-            column.$refLinks.push({
-              definition: getDefinitionFromSources(sources, id),
-              target: getDefinitionFromSources(sources, id),
-            })
-          } else if (firstStepIsSelf) {
-            column.$refLinks.push({ definition: { elements: queryElements }, target: { elements: queryElements } })
-          } else if (column.ref.length > 1 && inferred.outerQueries?.find(outer => id in outer.sources)) {
-            // outer query accessed via alias
-            const outerAlias = inferred.outerQueries.find(outer => id in outer.sources)
-            column.$refLinks.push({
-              definition: getDefinitionFromSources(outerAlias.sources, id),
-              target: getDefinitionFromSources(outerAlias.sources, id),
-            })
-          } else if (id in $combinedElements) {
-            if ($combinedElements[id].length > 1) stepIsAmbiguous(id) // exit
-            const definition = $combinedElements[id][0].tableAlias.elements[id]
-            const $refLink = { definition, target: $combinedElements[id][0].tableAlias }
-            column.$refLinks.push($refLink)
-            nameSegments.push(id)
-          } else if (expandOnTableAlias) {
-            // expand on table alias
-            column.$refLinks.push({
-              definition: getDefinitionFromSources(sources, id),
-              target: getDefinitionFromSources(sources, id),
-            })
-          } else {
-            stepNotFoundInCombinedElements(id) // REVISIT: fails with {__proto__:elements)
-          }
-        } else {
-          const { definition } = column.$refLinks[i - 1]
-          const elements = getDefinition(definition.target)?.elements || definition.elements //> go for assoc._target first, instead of assoc as struct
-          const element = elements?.[id]
-
-          if (firstStepIsSelf && element?.isAssociation) {
-            throw new Error(
-              `Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ ${column.ref
-                .map(idOnly)
-                .join(', ')} ]`,
-            )
-          }
-
-          const target = getDefinition(definition.target) || column.$refLinks[i - 1].target
-          if (element) {
-            if ($baseLink && inInfixFilter) {
-              const nextStep = column.ref[i + 1]?.id || column.ref[i + 1]
+    // initialize $refLinks
+    Object.defineProperty(arg, '$refLinks', {
+      value: [],
+      writable: true,
+    })
+    // if any path step points to an artifact with `@cds.persistence.skip`
+    // we must ignore the element from the queries elements
+    let isPersisted = true
+    const firstStepIsTableAlias = arg.ref.length > 1 && arg.ref[0] in sources
+    const firstStepIsSelf =
+      !firstStepIsTableAlias && arg.ref.length > 1 && ['$self', '$projection'].includes(arg.ref[0])
+    const expandOnTableAlias = arg.ref.length === 1 && arg.ref[0] in sources && (arg.expand || arg.inline)
+    const nameSegments = []
+    // if a (segment) of a (structured) foreign key is renamed, we must not include
+    // the aliased ref segments into the name of the final foreign key which is e.g. used in
+    // on conditions of joins
+    const skipAliasedFkSegmentsOfNameStack = []
+    let pseudoPath = false
+    arg.ref.forEach((step, i) => {
+      const id = step.id || step
+      if (i === 0) {
+        if (id in pseudos.elements) {
+          // pseudo path
+          arg.$refLinks.push({ definition: pseudos.elements[id], target: pseudos })
+          pseudoPath = true // only first path step must be well defined
+          nameSegments.push(id)
+        } else if ($baseLink) {
+          const { definition, target } = $baseLink
+          const elements = getDefinition(definition.target)?.elements || definition.elements
+          if (elements && id in elements) {
+            const element = elements[id]
+            if (inInfixFilter) {
+              const nextStep = arg.ref[1]?.id || arg.ref[1]
               if (isNonForeignKeyNavigation(element, nextStep)) {
                 if (inExists) {
                   Object.defineProperty($baseLink, 'pathExpressionInsideFilter', { value: true })
@@ -620,527 +564,588 @@ function infer(originalQuery, model) {
                 }
               }
             }
-            const $refLink = { definition: elements[id], target }
-            column.$refLinks.push($refLink)
-          } else if (firstStepIsSelf) {
-            stepNotFoundInColumnList(id)
-          } else if (column.ref[0] === '$user' && pseudoPath) {
-            // `$user.some.unknown.element` -> no error
-            column.$refLinks.push({ definition: {}, target })
-          } else if (id === '$dummy') {
-            // `some.known.element.$dummy` -> no error; used by cds.ql to simulate joins
-            column.$refLinks.push({ definition: { name: '$dummy', parent: column.$refLinks[i - 1].target } })
-            Object.defineProperty(column, 'isJoinRelevant', { value: true })
+            const resolvableIn = getDefinition(definition.target) || target
+            const $refLink = { definition: elements[id], target: resolvableIn }
+            arg.$refLinks.push($refLink)
           } else {
-            const notFoundIn = pseudoPath ? column.ref[i - 1] : getFullPathForLinkedArg(column)
-            stepNotFoundInPredecessor(id, notFoundIn)
+            stepNotFoundInPredecessor(id, definition.name)
           }
-          const foreignKeyAlias = Array.isArray(definition.keys)
-            ? definition.keys.find(k => {
-                if (k.ref.every((step, j) => column.ref[i + j] === step)) {
-                  skipAliasedFkSegmentsOfNameStack.push(...k.ref.slice(1))
-                  return true
-                }
-                return false
-              })?.as
-            : null
-          if (foreignKeyAlias) nameSegments.push(foreignKeyAlias)
-          else if (skipAliasedFkSegmentsOfNameStack[0] === id) skipAliasedFkSegmentsOfNameStack.shift()
-          else {
-            nameSegments.push(firstStepIsSelf && i === 1 ? element.__proto__.name : id)
-          }
-        }
-
-        if (step.where) {
-          const danglingFilter = !(column.ref[i + 1] || column.expand || column.inline || inExists)
-          if (!column.$refLinks[i].definition.target || danglingFilter)
-            throw new Error('A filter can only be provided when navigating along associations')
-          if (!column.expand) Object.defineProperty(column, 'isJoinRelevant', { value: true })
-          let skipJoinsForFilter = false
-          step.where.forEach(token => {
-            if (token === 'exists') {
-              // books[exists genre[code='A']].title --> column is join relevant but inner exists filter is not
-              skipJoinsForFilter = true
-            } else if (token.ref || token.xpr) {
-              inferQueryElement(token, false, column.$refLinks[i], {
-                inExists: skipJoinsForFilter || inExists,
-                inExpr: !!token.xpr,
-                inInfixFilter: true,
-              })
-            } else if (token.func) {
-              if (token.args) {
-                applyToFunctionArgs(token.args, inferQueryElement, [
-                  false,
-                  column.$refLinks[i],
-                  { inExists: skipJoinsForFilter || inExists, inExpr: true, inInfixFilter: true },
-                ])
-              }
-            }
+          nameSegments.push(id)
+        } else if (firstStepIsTableAlias) {
+          arg.$refLinks.push({
+            definition: getDefinitionFromSources(sources, id),
+            target: getDefinitionFromSources(sources, id),
           })
+        } else if (firstStepIsSelf) {
+          arg.$refLinks.push({ definition: { elements: queryElements }, target: { elements: queryElements } })
+        } else if (arg.ref.length > 1 && inferred.outerQueries?.find(outer => id in outer.sources)) {
+          // outer query accessed via alias
+          const outerAlias = inferred.outerQueries.find(outer => id in outer.sources)
+          arg.$refLinks.push({
+            definition: getDefinitionFromSources(outerAlias.sources, id),
+            target: getDefinitionFromSources(outerAlias.sources, id),
+          })
+        } else if (id in $combinedElements) {
+          if ($combinedElements[id].length > 1) stepIsAmbiguous(id) // exit
+          const definition = $combinedElements[id][0].tableAlias.elements[id]
+          const $refLink = { definition, target: $combinedElements[id][0].tableAlias }
+          arg.$refLinks.push($refLink)
+          nameSegments.push(id)
+        } else if (expandOnTableAlias) {
+          // expand on table alias
+          arg.$refLinks.push({
+            definition: getDefinitionFromSources(sources, id),
+            target: getDefinitionFromSources(sources, id),
+          })
+        } else {
+          stepNotFoundInCombinedElements(id) // REVISIT: fails with {__proto__:elements)
         }
+      } else {
+        const { definition } = arg.$refLinks[i - 1]
+        const elements = getDefinition(definition.target)?.elements || definition.elements //> go for assoc._target first, instead of assoc as struct
+        const element = elements?.[id]
 
-        column.$refLinks[i].alias = !column.ref[i + 1] && column.as ? column.as : id.split('.').pop()
-        if (getDefinition(column.$refLinks[i].definition.target)?.['@cds.persistence.skip'] === true)
-          isPersisted = false
-        if (!column.ref[i + 1]) {
-          const flatName = nameSegments.join('_')
-          Object.defineProperty(column, 'flatName', { value: flatName, writable: true })
-          // if column is casted, we overwrite it's origin with the new type
-          if (column.cast) {
-            const base = getElementForCast(column)
-            if (insertIntoQueryElements) queryElements[column.as || flatName] = getCopyWithAnnos(column, base)
-          } else if (column.expand) {
-            const elements = resolveExpand(column)
-            let elementName
-            // expand on table alias
-            if (column.$refLinks.length === 1 && column.$refLinks[0].definition.kind === 'entity')
-              elementName = column.$refLinks[0].alias
-            else elementName = column.as || flatName
-            if (insertIntoQueryElements) queryElements[elementName] = elements
-          } else if (column.inline && insertIntoQueryElements) {
-            const elements = resolveInline(column)
-            queryElements = { ...queryElements, ...elements }
-          } else {
-            // shortcut for `ref: ['$user']` -> `ref: ['$user', 'id']`
-            const leafArt =
-              i === 0 && id === '$user' ? column.$refLinks[i].definition.elements.id : column.$refLinks[i].definition
-            // infer element based on leaf artifact of path
-            if (insertIntoQueryElements) {
-              let elementName
-              if (column.as) {
-                elementName = column.as
-              } else {
-                // if the navigation the user has written differs from the final flat ref - e.g. for renamed foreign keys -
-                // the inferred name of the element equals the flat version of the user-written ref.
-                const refNavigation = column.ref
-                  .slice(firstStepIsSelf || firstStepIsTableAlias ? 1 : 0)
-                  .map(idOnly)
-                  .join('_')
-                if (refNavigation !== flatName) elementName = refNavigation
-                else elementName = flatName
-              }
-              if (queryElements[elementName] !== undefined)
-                throw new Error(`Duplicate definition of element “${elementName}”`)
-              const element = getCopyWithAnnos(column, leafArt)
-              queryElements[elementName] = element
-            }
-          }
-        }
-      })
-
-      // we need inner joins for the path expressions inside filter expressions after exists predicate
-      if ($baseLink?.pathExpressionInsideFilter) Object.defineProperty(column, 'join', { value: 'inner' })
-
-      // ignore whole expand if target of assoc along path has ”@cds.persistence.skip”
-      if (column.expand) {
-        const { $refLinks } = column
-        const skip = $refLinks.some(link => getDefinition(link.definition.target)?.['@cds.persistence.skip'] === true)
-        if (skip) {
-          $refLinks[$refLinks.length - 1].skipExpand = true
-          return
-        }
-      }
-      const leafArt = column.$refLinks[column.$refLinks.length - 1].definition
-      const virtual = (leafArt.virtual || !isPersisted) && !inExpr
-      // check if we need to merge the column `ref` into the join tree of the query
-      if (!inExists && !virtual && !inCalcElement) {
-        // for a ref inside an `inline` we need to consider the column `ref` which has the `inline` prop
-        const colWithBase = baseColumn
-          ? { ref: [...baseColumn.ref, ...column.ref], $refLinks: [...baseColumn.$refLinks, ...column.$refLinks] }
-          : column
-        if (isColumnJoinRelevant(colWithBase)) {
-          Object.defineProperty(column, 'isJoinRelevant', { value: true })
-          joinTree.mergeColumn(colWithBase, originalQuery.outerQueries)
-        }
-      }
-      if (isCalculatedOnRead(leafArt)) {
-        linkCalculatedElement(column, $baseLink, baseColumn)
-      }
-
-      /**
-       * Resolves and processes the inline attribute of a column in a database query.
-       *
-       * @param {object} col - The column object with properties: `inline` and `$refLinks`.
-       * @param {string} [namePrefix=col.as || col.flatName] - Prefix for naming new columns. Defaults to `col.as` or `col.flatName`.
-       * @returns {object} - An object with resolved and processed inline column definitions.
-       *
-       * Procedure:
-       * 1. Iterate through `inline` array. For each `inlineCol`:
-       *    a. If `inlineCol` equals '*', wildcard elements are processed and added to the `elements` object.
-       *    b. If `inlineCol` has inline or expand attributes, corresponding functions are called recursively and the resulting elements are added to the `elements` object.
-       *    c. If `inlineCol` has val or func attributes, new elements are created and added to the `elements` object.
-       *    d. Otherwise, the corresponding `$refLinks` definition is added to the `elements` object.
-       * 2. Returns the `elements` object.
-       */
-      function resolveInline(col, namePrefix = col.as || col.flatName) {
-        const { inline, $refLinks } = col
-        const $leafLink = $refLinks[$refLinks.length - 1]
-        if (!$leafLink.definition.target && !$leafLink.definition.elements) {
+        if (firstStepIsSelf && element?.isAssociation) {
           throw new Error(
-            `Unexpected “inline” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`,
+            `Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ ${arg.ref
+              .map(idOnly)
+              .join(', ')} ]`,
           )
         }
-        let elements = {}
-        inline.forEach(inlineCol => {
-          inferQueryElement(inlineCol, false, $leafLink, { inExpr: true, baseColumn: col })
-          if (inlineCol === '*') {
-            const wildCardElements = {}
-            // either the `.elements´ of the struct or the `.elements` of the assoc target
-            const leafLinkElements =
-              getDefinition($leafLink.definition.target)?.elements || $leafLink.definition.elements
-            Object.entries(leafLinkElements).forEach(([k, v]) => {
-              const name = namePrefix ? `${namePrefix}_${k}` : k
-              // if overwritten/excluded omit from wildcard elements
-              // in elements the names are already flat so consider the prefix
-              // in excluding, the elements are addressed without the prefix
-              if (!(name in elements || col.excluding?.includes(k))) wildCardElements[name] = v
+
+        const target = getDefinition(definition.target) || arg.$refLinks[i - 1].target
+        if (element) {
+          if ($baseLink && inInfixFilter) {
+            const nextStep = arg.ref[i + 1]?.id || arg.ref[i + 1]
+            if (isNonForeignKeyNavigation(element, nextStep)) {
+              if (inExists) {
+                Object.defineProperty($baseLink, 'pathExpressionInsideFilter', { value: true })
+              } else {
+                rejectNonFkNavigation(element, element.on ? $baseLink.definition.name : nextStep)
+              }
+            }
+          }
+          const $refLink = { definition: elements[id], target }
+          arg.$refLinks.push($refLink)
+        } else if (firstStepIsSelf) {
+          stepNotFoundInColumnList(id)
+        } else if (arg.ref[0] === '$user' && pseudoPath) {
+          // `$user.some.unknown.element` -> no error
+          arg.$refLinks.push({ definition: {}, target })
+        } else if (id === '$dummy') {
+          // `some.known.element.$dummy` -> no error; used by cds.ql to simulate joins
+          arg.$refLinks.push({ definition: { name: '$dummy', parent: arg.$refLinks[i - 1].target } })
+          Object.defineProperty(arg, 'isJoinRelevant', { value: true })
+        } else {
+          const notFoundIn = pseudoPath ? arg.ref[i - 1] : getFullPathForLinkedArg(arg)
+          stepNotFoundInPredecessor(id, notFoundIn)
+        }
+        const foreignKeyAlias = Array.isArray(definition.keys)
+          ? definition.keys.find(k => {
+              if (k.ref.every((step, j) => arg.ref[i + j] === step)) {
+                skipAliasedFkSegmentsOfNameStack.push(...k.ref.slice(1))
+                return true
+              }
+              return false
+            })?.as
+          : null
+        if (foreignKeyAlias) nameSegments.push(foreignKeyAlias)
+        else if (skipAliasedFkSegmentsOfNameStack[0] === id) skipAliasedFkSegmentsOfNameStack.shift()
+        else {
+          nameSegments.push(firstStepIsSelf && i === 1 ? element.__proto__.name : id)
+        }
+      }
+
+      if (step.where) {
+        const danglingFilter = !(arg.ref[i + 1] || arg.expand || arg.inline || inExists)
+        if (!arg.$refLinks[i].definition.target || danglingFilter)
+          throw new Error('A filter can only be provided when navigating along associations')
+        if (!arg.expand) Object.defineProperty(arg, 'isJoinRelevant', { value: true })
+        let skipJoinsForFilter = false
+        step.where.forEach(token => {
+          if (token === 'exists') {
+            // books[exists genre[code='A']].title --> column is join relevant but inner exists filter is not
+            skipJoinsForFilter = true
+          } else if (token.ref || token.xpr) {
+            inferQueryElement(token, false, arg.$refLinks[i], {
+              inExists: skipJoinsForFilter || inExists,
+              inExpr: !!token.xpr,
+              inInfixFilter: true,
             })
-            elements = { ...elements, ...wildCardElements }
-          } else {
-            const nameParts = namePrefix ? [namePrefix] : []
-            if (inlineCol.as) nameParts.push(inlineCol.as)
-            else nameParts.push(...inlineCol.ref.map(idOnly))
-            const name = nameParts.join('_')
-            if (inlineCol.inline) {
-              const inlineElements = resolveInline(inlineCol, name)
-              elements = { ...elements, ...inlineElements }
-            } else if (inlineCol.expand) {
-              const expandElements = resolveExpand(inlineCol)
-              elements = { ...elements, [name]: expandElements }
-            } else if (inlineCol.val) {
-              elements[name] = { ...getCdsTypeForVal(inlineCol.val) }
-            } else if (inlineCol.func) {
-              elements[name] = {}
-            } else {
-              elements[name] = inlineCol.$refLinks[inlineCol.$refLinks.length - 1].definition
+          } else if (token.func) {
+            if (token.args) {
+              applyToFunctionArgs(token.args, inferQueryElement, [
+                false,
+                arg.$refLinks[i],
+                { inExists: skipJoinsForFilter || inExists, inExpr: true, inInfixFilter: true },
+              ])
             }
           }
         })
-        return elements
       }
 
-      /**
-       * Resolves a query column which has an `expand` property.
-       *
-       * @param {object} col - The column object with properties: `expand` and `$refLinks`.
-       * @returns {object} - A `cds.struct` object with expanded column definitions.
-       *
-       * Procedure:
-       * - if `$leafLink` is an association, constructs an `expandSubquery` and infers a new query structure.
-       *   Returns a new `cds.struct` if the association has a target cardinality === 1 or a `cds.array` for to many relations.
-       * - else constructs an `elements` object based on the refs `expand` found in the expand and returns a new `cds.struct` with these `elements`.
-       */
-      function resolveExpand(col) {
-        const { expand, $refLinks } = col
-        const $leafLink = $refLinks?.[$refLinks.length - 1] || inferred.SELECT.from.$refLinks.at(-1) // fallback to anonymous expand
-        if (!$leafLink.definition.target && !$leafLink.definition.elements) {
-          throw new Error(
-            `Unexpected “expand” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`,
-          )
-        }
-        const target = getDefinition($leafLink.definition.target)
-        if (target) {
-          const expandSubquery = {
-            SELECT: {
-              from: target.name,
-              columns: expand.filter(c => !c.inline),
-            },
-          }
-          if (col.excluding) expandSubquery.SELECT.excluding = col.excluding
-          if (col.as) expandSubquery.SELECT.as = col.as
-          const inferredExpandSubquery = infer(expandSubquery, model)
-          const res = $leafLink.definition.is2one
-            ? new cds.struct({ elements: inferredExpandSubquery.elements })
-            : new cds.array({ items: new cds.struct({ elements: inferredExpandSubquery.elements }) })
-          return Object.defineProperty(res, '$assocExpand', { value: true })
-        } else if ($leafLink.definition.elements) {
-          let elements = {}
-          expand.forEach(e => {
-            if (e === '*') {
-              elements = { ...elements, ...$leafLink.definition.elements }
+      arg.$refLinks[i].alias = !arg.ref[i + 1] && arg.as ? arg.as : id.split('.').pop()
+      if (getDefinition(arg.$refLinks[i].definition.target)?.['@cds.persistence.skip'] === true) isPersisted = false
+      if (!arg.ref[i + 1]) {
+        const flatName = nameSegments.join('_')
+        Object.defineProperty(arg, 'flatName', { value: flatName, writable: true })
+        // if column is casted, we overwrite it's origin with the new type
+        if (arg.cast) {
+          const base = getElementForCast(arg)
+          if (insertIntoQueryElements) queryElements[arg.as || flatName] = getCopyWithAnnos(arg, base)
+        } else if (arg.expand) {
+          const elements = resolveExpand(arg)
+          let elementName
+          // expand on table alias
+          if (arg.$refLinks.length === 1 && arg.$refLinks[0].definition.kind === 'entity')
+            elementName = arg.$refLinks[0].alias
+          else elementName = arg.as || flatName
+          if (queryElements) queryElements[elementName] = elements
+        } else if (arg.inline && queryElements) {
+          const elements = resolveInline(arg)
+          queryElements = { ...queryElements, ...elements }
+        } else {
+          // shortcut for `ref: ['$user']` -> `ref: ['$user', 'id']`
+          const leafArt =
+            i === 0 && id === '$user' ? arg.$refLinks[i].definition.elements.id : arg.$refLinks[i].definition
+          // infer element based on leaf artifact of path
+          if (insertIntoQueryElements()) {
+            let elementName
+            if (arg.as) {
+              elementName = arg.as
             } else {
-              inferQueryElement(e, false, $leafLink, { inExpr: true })
-              if (e.expand) elements[e.as || e.flatName] = resolveExpand(e)
-              if (e.inline) elements = { ...elements, ...resolveInline(e) }
-              else elements[e.as || e.flatName] = e.$refLinks ? e.$refLinks[e.$refLinks.length - 1].definition : e
+              // if the navigation the user has written differs from the final flat ref - e.g. for renamed foreign keys -
+              // the inferred name of the element equals the flat version of the user-written ref.
+              const refNavigation = arg.ref
+                .slice(firstStepIsSelf || firstStepIsTableAlias ? 1 : 0)
+                .map(idOnly)
+                .join('_')
+              if (refNavigation !== flatName) elementName = refNavigation
+              else elementName = flatName
             }
-          })
-          return new cds.struct({ elements })
+            if (queryElements[elementName] !== undefined)
+              throw new Error(`Duplicate definition of element “${elementName}”`)
+            const element = getCopyWithAnnos(arg, leafArt)
+            queryElements[elementName] = element
+          }
         }
       }
+    })
 
-      function stepNotFoundInPredecessor(step, def) {
-        throw new Error(`"${step}" not found in "${def}"`)
-      }
+    // we need inner joins for the path expressions inside filter expressions after exists predicate
+    if ($baseLink?.pathExpressionInsideFilter) Object.defineProperty(arg, 'join', { value: 'inner' })
 
-      function stepIsAmbiguous(step) {
-        throw new Error(
-          `ambiguous reference to "${step}", write ${Object.values($combinedElements[step])
-            .map(ta => `"${ta.index}.${step}"`)
-            .join(', ')} instead`,
-        )
-      }
-
-      function stepNotFoundInCombinedElements(step) {
-        throw new Error(
-          `"${step}" not found in the elements of ${Object.values(sources)
-            .map(s => s.definition)
-            .map(def => `"${def.name || /* subquery */ def.as}"`)
-            .join(', ')}`,
-        )
-      }
-
-      function stepNotFoundInColumnList(step) {
-        const err = [`"${step}" not found in the columns list of query`]
-        // if the `elt` from a `$self.elt` path is found in the `$combinedElements` -> hint to remove `$self`
-        if (step in $combinedElements)
-          err.push(` did you mean ${$combinedElements[step].map(ta => `"${ta.index || ta.as}.${step}"`).join(',')}?`)
-        throw new Error(err.join(','))
+    // ignore whole expand if target of assoc along path has ”@cds.persistence.skip”
+    if (arg.expand) {
+      const { $refLinks } = arg
+      const skip = $refLinks.some(link => getDefinition(link.definition.target)?.['@cds.persistence.skip'] === true)
+      if (skip) {
+        $refLinks[$refLinks.length - 1].skipExpand = true
+        return
       }
     }
-    function linkCalculatedElement(column, baseLink, baseColumn) {
-      const calcElement = column.$refLinks?.[column.$refLinks.length - 1].definition || column
-      if (alreadySeenCalcElements.has(calcElement)) return
-      else alreadySeenCalcElements.add(calcElement)
-      const { ref, xpr } = calcElement.value
-      if (ref || xpr) {
-        baseLink = baseLink || { definition: calcElement.parent, target: calcElement.parent }
-        attachRefLinksToArg(calcElement.value, baseLink, true)
+    const leafArt = arg.$refLinks[arg.$refLinks.length - 1].definition
+    const virtual = (leafArt.virtual || !isPersisted) && !inExpr
+    // check if we need to merge the column `ref` into the join tree of the query
+    if (!inExists && !virtual && !inCalcElement) {
+      // for a ref inside an `inline` we need to consider the column `ref` which has the `inline` prop
+      const colWithBase = baseColumn
+        ? { ref: [...baseColumn.ref, ...arg.ref], $refLinks: [...baseColumn.$refLinks, ...arg.$refLinks] }
+        : arg
+      if (isColumnJoinRelevant(colWithBase)) {
+        Object.defineProperty(arg, 'isJoinRelevant', { value: true })
+        joinTree.mergeColumn(colWithBase, originalQuery.outerQueries)
+      }
+    }
+    if (isCalculatedOnRead(leafArt)) {
+      linkCalculatedElement(arg, $baseLink, baseColumn)
+    }
+
+
+    function insertIntoQueryElements() {
+      return queryElements && !inExpr && !inInfixFilter && !inQueryModifier
+    }
+
+    /**
+     * Resolves and processes the inline attribute of a column in a database query.
+     *
+     * @param {object} col - The column object with properties: `inline` and `$refLinks`.
+     * @param {string} [namePrefix=col.as || col.flatName] - Prefix for naming new columns. Defaults to `col.as` or `col.flatName`.
+     * @returns {object} - An object with resolved and processed inline column definitions.
+     *
+     * Procedure:
+     * 1. Iterate through `inline` array. For each `inlineCol`:
+     *    a. If `inlineCol` equals '*', wildcard elements are processed and added to the `elements` object.
+     *    b. If `inlineCol` has inline or expand attributes, corresponding functions are called recursively and the resulting elements are added to the `elements` object.
+     *    c. If `inlineCol` has val or func attributes, new elements are created and added to the `elements` object.
+     *    d. Otherwise, the corresponding `$refLinks` definition is added to the `elements` object.
+     * 2. Returns the `elements` object.
+     */
+    function resolveInline(col, namePrefix = col.as || col.flatName) {
+      const { inline, $refLinks } = col
+      const $leafLink = $refLinks[$refLinks.length - 1]
+      if (!$leafLink.definition.target && !$leafLink.definition.elements) {
+        throw new Error(
+          `Unexpected “inline” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`,
+        )
+      }
+      let elements = {}
+      inline.forEach(inlineCol => {
+        inferQueryElement(inlineCol, false, $leafLink, { inExpr: true, baseColumn: col })
+        if (inlineCol === '*') {
+          const wildCardElements = {}
+          // either the `.elements´ of the struct or the `.elements` of the assoc target
+          const leafLinkElements = getDefinition($leafLink.definition.target)?.elements || $leafLink.definition.elements
+          Object.entries(leafLinkElements).forEach(([k, v]) => {
+            const name = namePrefix ? `${namePrefix}_${k}` : k
+            // if overwritten/excluded omit from wildcard elements
+            // in elements the names are already flat so consider the prefix
+            // in excluding, the elements are addressed without the prefix
+            if (!(name in elements || col.excluding?.includes(k))) wildCardElements[name] = v
+          })
+          elements = { ...elements, ...wildCardElements }
+        } else {
+          const nameParts = namePrefix ? [namePrefix] : []
+          if (inlineCol.as) nameParts.push(inlineCol.as)
+          else nameParts.push(...inlineCol.ref.map(idOnly))
+          const name = nameParts.join('_')
+          if (inlineCol.inline) {
+            const inlineElements = resolveInline(inlineCol, name)
+            elements = { ...elements, ...inlineElements }
+          } else if (inlineCol.expand) {
+            const expandElements = resolveExpand(inlineCol)
+            elements = { ...elements, [name]: expandElements }
+          } else if (inlineCol.val) {
+            elements[name] = { ...getCdsTypeForVal(inlineCol.val) }
+          } else if (inlineCol.func) {
+            elements[name] = {}
+          } else {
+            elements[name] = inlineCol.$refLinks[inlineCol.$refLinks.length - 1].definition
+          }
+        }
+      })
+      return elements
+    }
+
+    /**
+     * Resolves a query column which has an `expand` property.
+     *
+     * @param {object} col - The column object with properties: `expand` and `$refLinks`.
+     * @returns {object} - A `cds.struct` object with expanded column definitions.
+     *
+     * Procedure:
+     * - if `$leafLink` is an association, constructs an `expandSubquery` and infers a new query structure.
+     *   Returns a new `cds.struct` if the association has a target cardinality === 1 or a `cds.array` for to many relations.
+     * - else constructs an `elements` object based on the refs `expand` found in the expand and returns a new `cds.struct` with these `elements`.
+     */
+    function resolveExpand(col) {
+      const { expand, $refLinks } = col
+      const $leafLink = $refLinks?.[$refLinks.length - 1] || inferred.SELECT.from.$refLinks.at(-1) // fallback to anonymous expand
+      if (!$leafLink.definition.target && !$leafLink.definition.elements) {
+        throw new Error(
+          `Unexpected “expand” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`,
+        )
+      }
+      const target = getDefinition($leafLink.definition.target)
+      if (target) {
+        const expandSubquery = {
+          SELECT: {
+            from: target.name,
+            columns: expand.filter(c => !c.inline),
+          },
+        }
+        if (col.excluding) expandSubquery.SELECT.excluding = col.excluding
+        if (col.as) expandSubquery.SELECT.as = col.as
+        const inferredExpandSubquery = infer(expandSubquery, model)
+        const res = $leafLink.definition.is2one
+          ? new cds.struct({ elements: inferredExpandSubquery.elements })
+          : new cds.array({ items: new cds.struct({ elements: inferredExpandSubquery.elements }) })
+        return Object.defineProperty(res, '$assocExpand', { value: true })
+      } else if ($leafLink.definition.elements) {
+        let elements = {}
+        expand.forEach(e => {
+          if (e === '*') {
+            elements = { ...elements, ...$leafLink.definition.elements }
+          } else {
+            inferQueryElement(e, false, $leafLink, { inExpr: true })
+            if (e.expand) elements[e.as || e.flatName] = resolveExpand(e)
+            if (e.inline) elements = { ...elements, ...resolveInline(e) }
+            else elements[e.as || e.flatName] = e.$refLinks ? e.$refLinks[e.$refLinks.length - 1].definition : e
+          }
+        })
+        return new cds.struct({ elements })
+      }
+    }
+
+    function stepNotFoundInPredecessor(step, def) {
+      throw new Error(`"${step}" not found in "${def}"`)
+    }
+
+    function stepIsAmbiguous(step) {
+      throw new Error(
+        `ambiguous reference to "${step}", write ${Object.values($combinedElements[step])
+          .map(ta => `"${ta.index}.${step}"`)
+          .join(', ')} instead`,
+      )
+    }
+
+    function stepNotFoundInCombinedElements(step) {
+      throw new Error(
+        `"${step}" not found in the elements of ${Object.values(sources)
+          .map(s => s.definition)
+          .map(def => `"${def.name || /* subquery */ def.as}"`)
+          .join(', ')}`,
+      )
+    }
+
+    function stepNotFoundInColumnList(step) {
+      const err = [`"${step}" not found in the columns list of query`]
+      // if the `elt` from a `$self.elt` path is found in the `$combinedElements` -> hint to remove `$self`
+      if (step in $combinedElements)
+        err.push(` did you mean ${$combinedElements[step].map(ta => `"${ta.index || ta.as}.${step}"`).join(',')}?`)
+      throw new Error(err.join(','))
+    }
+  }
+  function linkCalculatedElement(column, baseLink, baseColumn) {
+    const calcElement = column.$refLinks?.[column.$refLinks.length - 1].definition || column
+    if (alreadySeenCalcElements.has(calcElement)) return
+    else alreadySeenCalcElements.add(calcElement)
+    const { ref, xpr } = calcElement.value
+    if (ref || xpr) {
+      baseLink = baseLink || { definition: calcElement.parent, target: calcElement.parent }
+      attachRefLinksToArg(calcElement.value, baseLink, true)
+      const basePath =
+        column.$refLinks?.length > 1
+          ? { $refLinks: column.$refLinks.slice(0, -1), ref: column.ref.slice(0, -1) }
+          : { $refLinks: [], ref: [] }
+      if (baseColumn) {
+        basePath.$refLinks.push(...baseColumn.$refLinks)
+        basePath.ref.push(...baseColumn.ref)
+      }
+      mergePathsIntoJoinTree(calcElement.value, basePath)
+    }
+
+    if (calcElement.value.args) {
+      const processArgument = (arg, calcElement, column) => {
+        inferQueryElement(
+          arg,
+          false,
+          { definition: calcElement.parent, target: calcElement.parent },
+          { inCalcElement: true },
+        )
         const basePath =
           column.$refLinks?.length > 1
             ? { $refLinks: column.$refLinks.slice(0, -1), ref: column.ref.slice(0, -1) }
             : { $refLinks: [], ref: [] }
-        if (baseColumn) {
-          basePath.$refLinks.push(...baseColumn.$refLinks)
-          basePath.ref.push(...baseColumn.ref)
-        }
-        mergePathsIntoJoinTree(calcElement.value, basePath)
+        mergePathsIntoJoinTree(arg, basePath)
       }
 
       if (calcElement.value.args) {
-        const processArgument = (arg, calcElement, column) => {
-          inferQueryElement(
-            arg,
-            false,
-            { definition: calcElement.parent, target: calcElement.parent },
-            { inCalcElement: true },
-          )
-          const basePath =
-            column.$refLinks?.length > 1
-              ? { $refLinks: column.$refLinks.slice(0, -1), ref: column.ref.slice(0, -1) }
-              : { $refLinks: [], ref: [] }
-          mergePathsIntoJoinTree(arg, basePath)
-        }
-
-        if (calcElement.value.args) {
-          applyToFunctionArgs(calcElement.value.args, processArgument, [calcElement, column])
-        }
-      }
-
-      /**
-       * Calculates all paths from a given ref and merges them into the join tree.
-       * Recursively walks into refs of calculated elements.
-       *
-       * @param {object} arg with a ref and sibling $refLinks
-       * @param {object} basePath with a ref and sibling $refLinks, used for recursion
-       */
-      function mergePathsIntoJoinTree(arg, basePath = null) {
-        basePath = basePath || { $refLinks: [], ref: [] }
-        if (arg.ref) {
-          arg.$refLinks.forEach((link, i) => {
-            const { definition } = link
-            if (!definition.value) {
-              basePath.$refLinks.push(link)
-              basePath.ref.push(arg.ref[i])
-            }
-          })
-          const leafOfCalculatedElementRef = arg.$refLinks[arg.$refLinks.length - 1].definition
-          if (leafOfCalculatedElementRef.value) mergePathsIntoJoinTree(leafOfCalculatedElementRef.value, basePath)
-
-          mergePathIfNecessary(basePath, arg)
-        } else if (arg.xpr || arg.args) {
-          const prop = arg.xpr ? 'xpr' : 'args'
-          arg[prop].forEach(step => {
-            const subPath = { $refLinks: [...basePath.$refLinks], ref: [...basePath.ref] }
-            if (step.ref) {
-              step.$refLinks.forEach((link, i) => {
-                const { definition } = link
-                if (definition.value) {
-                  mergePathsIntoJoinTree(definition.value, subPath)
-                } else {
-                  subPath.$refLinks.push(link)
-                  subPath.ref.push(step.ref[i])
-                }
-              })
-              mergePathIfNecessary(subPath, step)
-            } else if (step.args || step.xpr) {
-              const nestedProp = step.xpr ? 'xpr' : 'args'
-              step[nestedProp].forEach(a => {
-                mergePathsIntoJoinTree(a, subPath)
-              })
-            }
-          })
-        }
-
-        function mergePathIfNecessary(p, step) {
-          const calcElementIsJoinRelevant = isColumnJoinRelevant(p)
-          if (calcElementIsJoinRelevant) {
-            if (!calcElement.value.isColumnJoinRelevant)
-              Object.defineProperty(step, 'isJoinRelevant', { value: true, writable: true })
-            joinTree.mergeColumn(p, originalQuery.outerQueries)
-          } else {
-            // we need to explicitly set the value to false in this case,
-            // e.g. `SELECT from booksCalc.Books { ID, author.{name }, author {name } }`
-            // --> for the inline column, the name is join relevant, while for the expand, it is not
-            Object.defineProperty(step, 'isJoinRelevant', { value: false, writable: true })
-          }
-        }
+        applyToFunctionArgs(calcElement.value.args, processArgument, [calcElement, column])
       }
     }
 
     /**
-     * Checks whether or not the `ref` of the given column is join relevant.
-     * A `ref` is considered join relevant if it includes an association traversal and:
-     *    - the association is unmanaged
-     *    - a non-foreign key access is performed
-     *    - an infix filter is applied at the association
+     * Calculates all paths from a given ref and merges them into the join tree.
+     * Recursively walks into refs of calculated elements.
      *
-     * @param {object} column the column with the `ref` to check for join relevance
-     * @returns {boolean} true if the column ref needs to be merged into a join tree
+     * @param {object} arg with a ref and sibling $refLinks
+     * @param {object} basePath with a ref and sibling $refLinks, used for recursion
      */
-    function isColumnJoinRelevant(column) {
-      let fkAccess = false
-      let assoc = null
-      for (let i = 0; i < column.ref.length; i++) {
-        const ref = column.ref[i]
-        const link = column.$refLinks[i]
-        if (link.definition.on && link.definition.isAssociation) {
-          if (!column.ref[i + 1]) {
-            if (column.expand && assoc) return true
-            // if unmanaged assoc is exposed, ignore it
-            return false
+    function mergePathsIntoJoinTree(arg, basePath = null) {
+      basePath = basePath || { $refLinks: [], ref: [] }
+      if (arg.ref) {
+        arg.$refLinks.forEach((link, i) => {
+          const { definition } = link
+          if (!definition.value) {
+            basePath.$refLinks.push(link)
+            basePath.ref.push(arg.ref[i])
           }
-          return true
-        }
-        if (assoc) {
-          // foreign key access without filters never join relevant
-          if (assoc.keys?.some(key => key.ref.every((step, j) => column.ref[i + j] === step))) return false
-          // <assoc>.<anotherAssoc>.<…> is join relevant as <anotherAssoc> is not fk of <assoc>
-          return true
-        }
-        if (link.definition.target && link.definition.keys) {
-          if (column.ref[i + 1] || assoc) fkAccess = false
-          else fkAccess = true
-          assoc = link.definition
-          if (ref.where) {
-            // always join relevant except for expand assoc
-            if (column.expand && !column.ref[i + 1]) return false
-            return true
-          }
-        }
-      }
-
-      if (!assoc) return false
-      if (fkAccess) return false
-      return true
-    }
-
-    /**
-     * Iterates over all `$combinedElements` of the `query` and puts them into the `query`s `elements`,
-     * if there is not already an element with the same name present.
-     */
-    function inferElementsFromWildCard() {
-      const exclude = _.excluding ? x => _.excluding.includes(x) : () => false
-
-      if (Object.keys(queryElements).length === 0 && aliases.length === 1) {
-        const { elements } = getDefinitionFromSources(sources, aliases[0])
-        // only one query source and no overwritten columns
-        for (const k of Object.keys(elements)) {
-          if (!exclude(k)) {
-            const element = elements[k]
-            if (element.type !== 'cds.LargeBinary') {
-              queryElements[k] = element
-            }
-            if (isCalculatedOnRead(element)) {
-              linkCalculatedElement(element)
-            }
-          }
-        }
-        return
-      }
-
-      const ambiguousElements = {}
-      Object.entries($combinedElements).forEach(([name, tableAliases]) => {
-        if (Object.keys(tableAliases).length > 1) {
-          ambiguousElements[name] = tableAliases
-          return ambiguousElements[name]
-        }
-        if (exclude(name) || name in queryElements) return true
-        const element = tableAliases[0].tableAlias.elements[name]
-        if (element.type !== 'cds.LargeBinary') queryElements[name] = element
-        if (isCalculatedOnRead(element)) {
-          linkCalculatedElement(element)
-        }
-      })
-
-      if (Object.keys(ambiguousElements).length > 0) throwAmbiguousWildcardError()
-
-      function throwAmbiguousWildcardError() {
-        const err = []
-        err.push('Ambiguous wildcard elements:')
-        Object.keys(ambiguousElements).forEach(name => {
-          const tableAliasNames = Object.values(ambiguousElements[name]).map(v => v.index)
-          err.push(
-            `       select "${name}" explicitly with ${tableAliasNames
-              .map(taName => `"${taName}.${name}"`)
-              .join(', ')}`,
-          )
         })
-        throw new Error(err.join('\n'))
+        const leafOfCalculatedElementRef = arg.$refLinks[arg.$refLinks.length - 1].definition
+        if (leafOfCalculatedElementRef.value) mergePathsIntoJoinTree(leafOfCalculatedElementRef.value, basePath)
+
+        mergePathIfNecessary(basePath, arg)
+      } else if (arg.xpr || arg.args) {
+        const prop = arg.xpr ? 'xpr' : 'args'
+        arg[prop].forEach(step => {
+          const subPath = { $refLinks: [...basePath.$refLinks], ref: [...basePath.ref] }
+          if (step.ref) {
+            step.$refLinks.forEach((link, i) => {
+              const { definition } = link
+              if (definition.value) {
+                mergePathsIntoJoinTree(definition.value, subPath)
+              } else {
+                subPath.$refLinks.push(link)
+                subPath.ref.push(step.ref[i])
+              }
+            })
+            mergePathIfNecessary(subPath, step)
+          } else if (step.args || step.xpr) {
+            const nestedProp = step.xpr ? 'xpr' : 'args'
+            step[nestedProp].forEach(a => {
+              mergePathsIntoJoinTree(a, subPath)
+            })
+          }
+        })
+      }
+
+      function mergePathIfNecessary(p, step) {
+        const calcElementIsJoinRelevant = isColumnJoinRelevant(p)
+        if (calcElementIsJoinRelevant) {
+          if (!calcElement.value.isColumnJoinRelevant)
+            Object.defineProperty(step, 'isJoinRelevant', { value: true, writable: true })
+          joinTree.mergeColumn(p, originalQuery.outerQueries)
+        } else {
+          // we need to explicitly set the value to false in this case,
+          // e.g. `SELECT from booksCalc.Books { ID, author.{name }, author {name } }`
+          // --> for the inline column, the name is join relevant, while for the expand, it is not
+          Object.defineProperty(step, 'isJoinRelevant', { value: false, writable: true })
+        }
+      }
+    }
+  }
+
+  /**
+   * Checks whether or not the `ref` of the given column is join relevant.
+   * A `ref` is considered join relevant if it includes an association traversal and:
+   *    - the association is unmanaged
+   *    - a non-foreign key access is performed
+   *    - an infix filter is applied at the association
+   *
+   * @param {object} column the column with the `ref` to check for join relevance
+   * @returns {boolean} true if the column ref needs to be merged into a join tree
+   */
+  function isColumnJoinRelevant(column) {
+    let fkAccess = false
+    let assoc = null
+    for (let i = 0; i < column.ref.length; i++) {
+      const ref = column.ref[i]
+      const link = column.$refLinks[i]
+      if (link.definition.on && link.definition.isAssociation) {
+        if (!column.ref[i + 1]) {
+          if (column.expand && assoc) return true
+          // if unmanaged assoc is exposed, ignore it
+          return false
+        }
+        return true
+      }
+      if (assoc) {
+        // foreign key access without filters never join relevant
+        if (assoc.keys?.some(key => key.ref.every((step, j) => column.ref[i + j] === step))) return false
+        // <assoc>.<anotherAssoc>.<…> is join relevant as <anotherAssoc> is not fk of <assoc>
+        return true
+      }
+      if (link.definition.target && link.definition.keys) {
+        if (column.ref[i + 1] || assoc) fkAccess = false
+        else fkAccess = true
+        assoc = link.definition
+        if (ref.where) {
+          // always join relevant except for expand assoc
+          if (column.expand && !column.ref[i + 1]) return false
+          return true
+        }
       }
     }
 
-    /**
-     * Returns a new object which is the inferred element for the given `col`.
-     * A cast type (via cast function) on the column gets preserved.
-     *
-     * @param {object} col
-     * @returns object
-     */
-    function getElementForXprOrSubquery(col) {
-      const { xpr } = col
-      let skipJoins = false
-      xpr?.forEach(token => {
-        if (token === 'exists') {
-          // no joins for infix filters along `exists <path>`
-          skipJoins = true
-        } else {
-          inferQueryElement(token, false, null, { inExists: skipJoins, inExpr: true })
-          skipJoins = false
+    if (!assoc) return false
+    if (fkAccess) return false
+    return true
+  }
+
+  /**
+   * Iterates over all `$combinedElements` of the `query` and puts them into the `query`s `elements`,
+   * if there is not already an element with the same name present.
+   */
+  function inferElementsFromWildCard(queryElements) {
+    const exclude = _.excluding ? x => _.excluding.includes(x) : () => false
+
+    if (Object.keys(queryElements).length === 0 && aliases.length === 1) {
+      const { elements } = getDefinitionFromSources(sources, aliases[0])
+      // only one query source and no overwritten columns
+      for (const k of Object.keys(elements)) {
+        if (!exclude(k)) {
+          const element = elements[k]
+          if (element.type !== 'cds.LargeBinary') {
+            queryElements[k] = element
+          }
+          if (isCalculatedOnRead(element)) {
+            linkCalculatedElement(element)
+          }
         }
-      })
-      const base = getElementForCast(col.cast ? col : xpr?.[0] || col)
-      if (col.key) base.key = col.key // > preserve key on column
-      return getCopyWithAnnos(col, base)
+      }
+      return
     }
 
-    /**
-     * Returns an object with the cast-type defined in the cast of the `thing`.
-     * If no cast property is present, it just returns an empty object.
-     * The type of the cast is mapped to the `cds` type if possible.
-     *
-     * @param {object} thing with the cast property
-     * @returns {object}
-     */
-    function getElementForCast(thing) {
-      const { cast, $refLinks } = thing
-      if (!cast) return {}
-      if ($refLinks?.[$refLinks.length - 1].definition.elements)
-        // no cast on structure
-        cds.error`Structured elements can't be cast to a different type`
-      thing.cast = cdsTypes[cast.type] || cast
-      return thing.cast
+    const ambiguousElements = {}
+    Object.entries($combinedElements).forEach(([name, tableAliases]) => {
+      if (Object.keys(tableAliases).length > 1) {
+        ambiguousElements[name] = tableAliases
+        return ambiguousElements[name]
+      }
+      if (exclude(name) || name in queryElements) return true
+      const element = tableAliases[0].tableAlias.elements[name]
+      if (element.type !== 'cds.LargeBinary') queryElements[name] = element
+      if (isCalculatedOnRead(element)) {
+        linkCalculatedElement(element)
+      }
+    })
+
+    if (Object.keys(ambiguousElements).length > 0) throwAmbiguousWildcardError()
+
+    function throwAmbiguousWildcardError() {
+      const err = []
+      err.push('Ambiguous wildcard elements:')
+      Object.keys(ambiguousElements).forEach(name => {
+        const tableAliasNames = Object.values(ambiguousElements[name]).map(v => v.index)
+        err.push(
+          `       select "${name}" explicitly with ${tableAliasNames.map(taName => `"${taName}.${name}"`).join(', ')}`,
+        )
+      })
+      throw new Error(err.join('\n'))
     }
+  }
+
+  /**
+   * Returns a new object which is the inferred element for the given `col`.
+   * A cast type (via cast function) on the column gets preserved.
+   *
+   * @param {object} col
+   * @returns object
+   */
+  function getElementForXprOrSubquery(col) {
+    const { xpr } = col
+    let skipJoins = false
+    xpr?.forEach(token => {
+      if (token === 'exists') {
+        // no joins for infix filters along `exists <path>`
+        skipJoins = true
+      } else {
+        inferQueryElement(token, false, null, { inExists: skipJoins, inExpr: true })
+        skipJoins = false
+      }
+    })
+    const base = getElementForCast(col.cast ? col : xpr?.[0] || col)
+    if (col.key) base.key = col.key // > preserve key on column
+    return getCopyWithAnnos(col, base)
+  }
+
+  /**
+   * Returns an object with the cast-type defined in the cast of the `thing`.
+   * If no cast property is present, it just returns an empty object.
+   * The type of the cast is mapped to the `cds` type if possible.
+   *
+   * @param {object} thing with the cast property
+   * @returns {object}
+   */
+  function getElementForCast(thing) {
+    const { cast, $refLinks } = thing
+    if (!cast) return {}
+    if ($refLinks?.[$refLinks.length - 1].definition.elements)
+      // no cast on structure
+      cds.error`Structured elements can't be cast to a different type`
+    thing.cast = cdsTypes[cast.type] || cast
+    return thing.cast
   }
 
   /**

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -808,7 +808,7 @@ function infer(originalQuery, model) {
     else alreadySeenCalcElements.add(calcElement)
     const { ref, xpr } = calcElement.value
     if (ref || xpr) {
-      baseLink = baseLink || { definition: calcElement.parent, target: calcElement.parent }
+      baseLink = { definition: calcElement.parent, target: calcElement.parent }
       inferArg(calcElement.value, null, baseLink, { inCalcElement: true, ...context })
       const basePath =
         column.$refLinks?.length > 1
@@ -884,8 +884,8 @@ function infer(originalQuery, model) {
       function mergePathIfNecessary(p, step) {
         const calcElementIsJoinRelevant = isColumnJoinRelevant(p)
         if (calcElementIsJoinRelevant) {
-          if (!calcElement.value.isColumnJoinRelevant)
-            Object.defineProperty(step, 'isJoinRelevant', { value: true, writable: true })
+          if (!calcElement.value.isJoinRelevant)
+            Object.defineProperty(step, 'isJoinRelevant', { value: true, writable: true,  })
           joinTree.mergeColumn(p, originalQuery.outerQueries)
         } else {
           // we need to explicitly set the value to false in this case,

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -394,7 +394,7 @@ function infer(originalQuery, model) {
 
     // walk over all paths in other query properties
     if (where) walkTokenStream(where, true)
-    if (groupBy) groupBy.forEach(token => inferQueryElement(token, false))
+    if (groupBy) walkTokenStream(groupBy)
     if (having) walkTokenStream(having)
     if (_.with)
       // consider UPDATE.with

--- a/db-service/test/cqn4sql/path-in-from.test.js
+++ b/db-service/test/cqn4sql/path-in-from.test.js
@@ -29,7 +29,7 @@ describe('infix filter on entities', () => {
 
   it('fails when using table alias in infix filter at entity', () => {
     expect(() => cqn4sql(CQL`SELECT from bookshop.Books[Books.price < 12.13] {ID}`, model)).to.throw(
-      /"Books" not found in the elements of "bookshop.Books"/,
+      /"Books" not found in "bookshop.Books"/,
     )
   })
 


### PR DESCRIPTION
Rework #617

when the `infer` function was developed, it grew quite fast and some functions were tailor made for very specific use cases. While separation of concerns is a good practice w.r.t. maintainability, the wheel must not be re-invented for each minor deviation in behavior.

That being said, the two function `inferQueryElement` and `attachRefLinksToArg` are doing essentially the same. They both walk an `arg` which is - generally spoken - an expression. That might be a simple `ref`, `func`, `val` or a (nested) `xpr`.

- `inferQueryElement` was used for the `columns` of a query. Each column was resolved to a query element. All elements together formed the set of query elements. The other main part of the function is the attachment of the infamous `$refLinks` next to each `ref` array. Moreover, there was a flag `insertIntoQueryElements` which could be set to `false`, if the `arg` must _not_ be inserted into the queries elements. This is the case for nested `xpr`, the `where`, `having`, `with`, `groupBy` and `orderBy` clause of the query.
- `attachRefLinksToArg` does exactly what the name implies, it attaches `$refLinks` to an `arg` but does not resolve the `arg` to a query element. This function was used for the `from` clause of the query.

It is obvious that both functions have significant shared logic. This change removes the usage of the `attachRefLinksToArg` function.

- [x] stakeholder tests are all green with this branch → cap/stakeholder-tests/actions/runs/9482613
- [x] cds tests are all green with this branch → /cap/cds/actions/runs/9483245