### PR TITLE
fix(sqlite): default `[development]` URL to `:memory:`

### DIFF
--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -37,7 +37,10 @@
       "kinds": {
         "sql": {
           "[development]": {
-            "kind": "sqlite"
+            "kind": "sqlite",
+            "credentials": {
+              "url": ":memory:"
+            }
           }
         },
         "sqlite": {


### PR DESCRIPTION
```sh
cds init bookshop && cd bookshop
cds env get requires.db
```
currently gives you
```js
{
  impl: '@cap-js/sqlite',
  credentials: { url: 'db.sqlite', database: ':memory:' }, 💣 "url" and "database" don't match
  kind: 'sqlite'
}
```

There are a few ways to solve this but I think `@cap-js/sqlite` should determine itself that the default URL for `[development]` is `:memory:`, and not rely on the default defined in `@sap/cds` (see the `_databases` section in `cds-requires.js`), which it currently does.

This is a non-breaking change, as today the `cds`-provided `database: 'memory'` wins, so even before we deployed to an in-memory DB by default.

We might then also be able to remove the redundant and outdated `credentials.database` from our `cds` defaults in the next major.