### PR TITLE
perf: unify `sql_simple_queries` for HANA queries

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1349,7 +1349,6 @@ const logicOperators = {
   'THEN': 1,
   'AND': 1,
   'OR': 1,
-  'NOT': 1,
 }
 const compareOperators = {
   '=': 1,

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -577,7 +577,6 @@ class HANAService extends SQLService {
         this.blobs.push(...blobColumns.filter(b => !this.blobs.includes(b)))
         if (
           cds.env.features.sql_simple_queries &&
-          (cds.env.features.sql_simple_queries > 1 || !hasBooleans) &&
           structures.length + ObjectKeys(expands).length + ObjectKeys(blobs).length === 0 &&
           !q?.src?.SELECT?.parent &&
           this.temporary.length === 0
@@ -1350,6 +1349,7 @@ const logicOperators = {
   'THEN': 1,
   'AND': 1,
   'OR': 1,
+  'NOT': 1,
 }
 const compareOperators = {
   '=': 1,

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -2,11 +2,22 @@ const { Readable, Stream, promises: { pipeline } } = require('stream')
 const { StringDecoder } = require('string_decoder')
 const { text } = require('stream/consumers')
 
+const cds = require('@sap/cds')
 const hdb = require('hdb')
 const iconv = require('iconv-lite')
 
 const { driver, prom, handleLevel } = require('./base')
 const { isDynatraceEnabled: dt_sdk_is_present, dynatraceClient: wrap_client } = require('./dynatrace')
+
+if (cds.env.features.sql_simple_queries === 1) {
+  // Make hdb return true / false
+  const Reader = require('hdb/lib/protocol/Reader.js')
+  Reader.prototype._readTinyInt = Reader.prototype.readTinyInt
+  Reader.prototype.readTinyInt = function () {
+    const ret = this._readTinyInt()
+    return ret == null ? ret : !!ret
+  }
+}
 
 const credentialMappings = [
   { old: 'certificate', new: 'ca' },


### PR DESCRIPTION
For applications using `sql_simple_queries=2` and `@sap/hana-client` the query results will properly reflect `true` and `false` for `boolean` fields, but when using `hdb` as driver the `boolean` datatype is not returned by the HANA protocol. While `hdb` has the data type defined ([code](https://github.com/SAP/node-hdb/blob/49c69673279655aa6534a9a5f38248ebdcfe36d3/lib/protocol/common/TypeCode.js#L45https://github.com/SAP/node-hdb/blob/49c69673279655aa6534a9a5f38248ebdcfe36d3/lib/protocol/common/TypeCode.js#L45)) for some reason HANA does not recognize `hdb` as a client capable of handling `boolean` column types. Therefor the data type returned is `tinyint` this change adjusts the data converter to output `true` and `false` when using `sql_simple_queries=1`. Allowing the database service to generate the same SQL statements for both `1` and `2`. Saving an additional loop on the application to convert the numeric results to booleans.