### PR TITLE
chore: fix db.run('...',1,2,3,4)

### DIFF
--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -154,10 +154,7 @@ class DatabaseService extends cds.Service {
    */
   run(query, data, ...etc) {
     // Allow db.run('...',1,2,3,4)
-    if (data !== undefined && typeof query === 'string' && typeof data !== 'object') {
-      data = [data, ...etc]
-      return super.run(query, data)
-    }
+    if (data !== undefined && typeof query === 'string' && typeof data !== 'object') arguments[1] = [data, ...etc]
     return super.run(...arguments) //> important to call like that for tagged template literal args
   }
 

--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -154,7 +154,10 @@ class DatabaseService extends cds.Service {
    */
   run(query, data, ...etc) {
     // Allow db.run('...',1,2,3,4)
-    if (data !== undefined && typeof query === 'string' && typeof data !== 'object') data = [data, ...etc]
+    if (data !== undefined && typeof query === 'string' && typeof data !== 'object') {
+      data = [data, ...etc]
+      return super.run(query, data)
+    }
     return super.run(...arguments) //> important to call like that for tagged template literal args
   }
 


### PR DESCRIPTION
otherwise, the transformed `data` is not considered.

introduced in #943 