### PR TITLE
test: Remove find workaround

### DIFF
--- a/hana/package.json
+++ b/hana/package.json
@@ -16,7 +16,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "(([ -z \"${HANA_HOST}\" ] && npm start) || true) && cds-test $(../test/find)",
+    "test": "(([ -z \"${HANA_HOST}\" ] && npm start) || true) && cds-test",
     "test:remote": "cds-test",
     "start": "npm run start:hce || npm run start:hxe",
     "start:hce": "cd ./tools/docker/hce/ && ./start.sh",

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -23,7 +23,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "npm start && cds-test $(../test/find)",
+    "test": "npm start && cds-test",
     "start": "docker compose -f pg-stack.yml up -d"
   },
   "dependencies": {
@@ -59,6 +59,7 @@
         },
         "postgres": {
           "impl": "@cap-js/postgres",
+          "kind": "sqlite",
           "dialect": "postgres",
           "vcap": {
             "label": "postgresql-db"

--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -23,7 +23,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "cds-test $(../test/find)"
+    "test": "cds-test"
   },
   "dependencies": {
     "@cap-js/db-service": "^1.14.1",

--- a/test/find
+++ b/test/find
@@ -1,2 +1,0 @@
-# /bin/bash
-find -L test -type f -regex .*$npm_config_file$npm_config_test\\.test\\.js


### PR DESCRIPTION
Now that `cds-test` walks symbolic links it is no longer needed to have the `find` workaround. This allows now for simpler test file selection.

```
npm t -w sqlite SELECT.test.js           // runs /cds-dbs/sqlite/test/compliance/compliance/SELECT.test.js
npm t -w postgres bookshop/read.test.js  // runs /cds-dbs/postgres/test/compliance/scenarios/bookshop/read.test.js
npm t -w hana sflight                    // runs /cds-dbs/hana/test/compliance/scenarios/sflight/*.test.js
```