### PR TITLE
fix: Improve `sql_simple_queries` flag

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -287,8 +287,6 @@ class CQN2SQLRenderer {
         return col
       }).flat()
 
-    if (isSimple) return `SELECT ${cols} FROM (${sql})`
-
     // Prevent SQLite from hitting function argument limit of 100
     let obj = "'{}'"
     for (let i = 0; i < cols.length; i += 48) {

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -1,8 +1,6 @@
 const cds = require('@sap/cds')
 const cds_infer = require('./infer')
 const cqn4sql = require('./cqn4sql')
-const _simple_queries = cds.env.features.sql_simple_queries
-const _strict_booleans = _simple_queries < 2
 
 const { Readable } = require('stream')
 
@@ -277,29 +275,7 @@ class CQN2SQLRenderer {
     const SELECT = q.SELECT
     if (!SELECT.columns) return sql
 
-    const isRoot = SELECT.expand === 'root'
-    const isSimple = _simple_queries &&
-      isRoot && // Simple queries are only allowed to have a root
-      !ObjectKeys(q.elements).some(e =>
-        _strict_booleans && q.elements[e].type === 'cds.Boolean' || // REVISIT: Booleans require json for sqlite
-        q.elements[e].isAssociation || // Indicates columns contains an expand
-        q.elements[e].$assocExpand || // REVISIT: sometimes associations are structs
-        q.elements[e].items // Array types require to be inlined with a json result
-      )
-
-    let cols = SELECT.columns.map(isSimple
-      ? x => {
-        const name = this.column_name(x)
-        const escaped = `${name.replace(/"/g, '""')}`
-        let col = `${this.output_converter4(x.element, this.quote(name))} AS "${escaped}"`
-        if (x.SELECT?.count) {
-          // Return both the sub select and the count for @odata.count
-          const qc = cds.ql.clone(x, { columns: [{ func: 'count' }], one: 1, limit: 0, orderBy: 0 })
-          return [col, `${this.expr(qc)} AS "${escaped}@odata.count"`]
-        }
-        return col
-      }
-      : x => {
+    let cols = SELECT.columns.map(x => {
         const name = this.column_name(x)
         const escaped = `${name.replace(/"/g, '""')}`
         let col = `'$."${escaped}"',${this.output_converter4(x.element, this.quote(name))}`
@@ -318,7 +294,7 @@ class CQN2SQLRenderer {
     for (let i = 0; i < cols.length; i += 48) {
       obj = `jsonb_insert(${obj},${cols.slice(i, i + 48)})`
     }
-    return `SELECT ${isRoot || SELECT.one ? obj.replace('jsonb', 'json') : `jsonb_group_array(${obj})`} as _json_ FROM (${sql})`
+    return `SELECT ${SELECT.expand === 'root' || SELECT.one ? obj.replace('jsonb', 'json') : `jsonb_group_array(${obj})`} as _json_ FROM (${sql})`
   }
 
   /**

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -9,7 +9,7 @@ const iconv = require('iconv-lite')
 const { driver, prom, handleLevel } = require('./base')
 const { isDynatraceEnabled: dt_sdk_is_present, dynatraceClient: wrap_client } = require('./dynatrace')
 
-if (cds.env.features.sql_simple_queries === 3) {
+if (cds.env.features.sql_simple_queries) {
   // Make hdb return true / false
   const Reader = require('hdb/lib/protocol/Reader.js')
   Reader.prototype._readTinyInt = Reader.prototype.readTinyInt

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -397,22 +397,11 @@ GROUP BY k
         }
         return col
       })
-      const isRoot = SELECT.expand === 'root'
-      const isSimple = cds.env.features.sql_simple_queries &&
-        isRoot && // Simple queries are only allowed to have a root
-        !Object.keys(q.elements).some(e =>
-          q.elements[e].isAssociation || // Indicates columns contains an expand
-          q.elements[e].$assocExpand || // REVISIT: sometimes associations are structs
-          q.elements[e].items // Array types require to be inlined with a json result
-        )
-
-      const subQuery = `SELECT ${cols} FROM (${sql}) as ${queryAlias}`
-      if (isSimple) return subQuery
 
       // REVISIT: Remove SELECT ${cols} by adjusting SELECT_columns
       let obj = `to_jsonb(${queryAlias}.*)`
-      return `SELECT ${SELECT.one || isRoot ? obj : `coalesce(jsonb_agg (${obj}),'[]'::jsonb)`
-        } as _json_ FROM (${subQuery}) as ${queryAlias}`
+      return `SELECT ${SELECT.one || SELECT.expand === 'root' ? obj : `coalesce(jsonb_agg (${obj}),'[]'::jsonb)`
+        } as _json_ FROM (SELECT ${cols} FROM (${sql}) as ${queryAlias}) as ${queryAlias}`
     }
 
     doubleQuote(name) {

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -213,10 +213,7 @@ class SQLiteService extends SQLService {
       struct: expr => `${expr}->'$'`,
       array: expr => `${expr}->'$'`,
       // SQLite has no booleans so we need to convert 0 and 1
-      boolean:
-        cds.env.features.sql_simple_queries === 2
-          ? undefined
-          : expr => `CASE ${expr} when 1 then 'true' when 0 then 'false' END ->'$'`,
+      boolean: expr => `CASE ${expr} when 1 then 'true' when 0 then 'false' END ->'$'`,
       // DateTimes are returned without ms added by InputConverters
       DateTime: e => `substr(${e},0,20)||'Z'`,
       // Timestamps are returned with ms, as written by InputConverters.


### PR DESCRIPTION
`sql_simple_queries` shouldn't exist.

This change makes it so that only `HANA` knows about the `sql_simple_queries` flag and it is no longer numeric. It now is either `truthy` or `falsy`. There is a gap in `hdb` which uses an older protocol version which uses `TINYINT` as a fallback for the lack of `BOOLEAN` support when using `@sap/hana-client` this limitation is no longer there. 

Which means that if applications have columns modeled as `cds.uint8` they are not allowed to use `sql_simple_queries` and `hdb` as driver. Either do the default behavior of not using `sql_simple_queries` or use `@sap/hana-client` as driver.