### PR TITLE
fix: Remove `orderBy` ref check for `sql_simple_queries`

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -371,7 +371,6 @@ class HANAService extends SQLService {
             columns.push({ ref: [parent.as, '_path_'], as: '_parent_path_' })
         }
 
-        let orderByHasOutputColumnRef = false
         if (orderBy) {
           // Ensure that all columns used in the orderBy clause are exposed
           orderBy = orderBy.map((c, i) => {
@@ -389,7 +388,6 @@ class HANAService extends SQLService {
               }
               return { __proto__: c, ref: [this.column_name(match || c)], sort: c.sort }
             }
-            orderByHasOutputColumnRef = true
             return c
           })
         }
@@ -428,8 +426,7 @@ class HANAService extends SQLService {
           q.as = q.SELECT.from.as
         }
 
-        const outputAliasSimpleQueriesRequired = cds.env.features.sql_simple_queries
-          && (orderByHasOutputColumnRef || having)
+        const outputAliasSimpleQueriesRequired = cds.env.features.sql_simple_queries && (orderBy || having)
         if (outputAliasSimpleQueriesRequired || rowNumberRequired || q.SELECT.columns.length !== aliasedOutputColumns.length) {
           q = cds.ql.SELECT(aliasedOutputColumns).from(q)
           q.as = q.SELECT.from.as


### PR DESCRIPTION
HANA doesn't follow ANSI SQL specified `ORDER BY` column reference resolving in **_some_** queries.

fixes: https://github.com/cap-js/cds-dbs/issues/962