### PR TITLE
feat: Query level SQL caching

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -5,6 +5,7 @@ const { Readable } = require('stream')
 const { SQLService } = require('@cap-js/db-service')
 const drivers = require('./drivers')
 const cds = require('@sap/cds')
+const { getTransition } = require('@sap/cds/libx/_runtime/common/utils/resolveView')
 const collations = require('./collations.json')
 const keywords = cds.compiler.to.hdi.keywords
 // keywords come as array
@@ -118,7 +119,7 @@ class HANAService extends SQLService {
   }
 
   async onSELECT(req) {
-    const { query, data } = req
+    const { query, data = query.params } = req
 
     if (!query.target) {
       try { this.infer(query) } catch { /**/ }
@@ -167,7 +168,7 @@ class HANAService extends SQLService {
     return cqn.SELECT.one || query.SELECT.from.ref?.[0].cardinality?.max === 1 ? rows[0] : rows
   }
 
-  async onINSERT({ query, data }) {
+  async onINSERT({ query, data = query.params }) {
     try {
       const { sql, entries, cqn } = this.cqn2sql(query, data)
       if (!sql) return // Do nothing when there is nothing to be done
@@ -708,16 +709,21 @@ class HANAService extends SQLService {
     INSERT_entries(q) {
       this.values = undefined
       const { INSERT } = q
-      // REVISIT: should @cds.persistence.name be considered ?
-      const entity = q.target?.['@cds.persistence.name'] || this.name(q.target?.name || INSERT.into.ref[0], q)
 
       const elements = q.elements || q.target?.elements
       if (!elements) {
         return super.INSERT_entries(q)
       }
 
+      const entity = q.target ? this.table_name(q) : INSERT.into.ref[0]
+      const transitions = getTransition(q.target, this.srv)
       const columns = elements
-        ? ObjectKeys(elements).filter(c => c in elements && !elements[c].virtual && !elements[c].value && !elements[c].isAssociation)
+        ? ObjectKeys(elements).filter(c => (c = transitions.mapping.get(c)?.ref[0] || c)
+          && c in transitions.target.elements
+          && !transitions.target.elements[c].virtual
+          && !transitions.target.elements[c].value
+          && !transitions.target.elements[c].isAssociation
+        )
         : ObjectKeys(INSERT.entries[0])
       this.columns = columns
 
@@ -760,9 +766,8 @@ class HANAService extends SQLService {
       // With the buffer table approach the data is processed in chunks of a configurable size
       // Which allows even smaller HANA systems to process large datasets
       // But the chunk size determines the maximum size of a single row
-      return (this.sql = `INSERT INTO ${this.quote(entity)} (${this.columns.map(c =>
-        this.quote(c),
-      )}) WITH SRC AS (SELECT ? AS JSON FROM DUMMY UNION ALL SELECT TO_NCLOB(NULL) AS JSON FROM DUMMY)
+      return (this.sql = `INSERT INTO ${this.quote(entity)} (${this.columns.map(c => this.quote(transitions.mapping.get(c)?.ref?.[0] || c))
+        }) WITH SRC AS (SELECT ? AS JSON FROM DUMMY UNION ALL SELECT TO_NCLOB(NULL) AS JSON FROM DUMMY)
       SELECT ${converter} FROM JSON_TABLE(SRC.JSON, '$' COLUMNS(${extraction}) ERROR ON ERROR) AS NEW`)
     }
 

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -304,7 +304,7 @@ GROUP BY k
     }
   }
 
-  async onSELECT({ query, data }) {
+  async onSELECT({ query, data = query.params }) {
     // workaround for chunking odata streaming
     if (query.SELECT?.columns?.find(col => col.as === '$mediaContentType')) {
       const columns = query.SELECT.columns
@@ -314,6 +314,7 @@ GROUP BY k
       let res = await super.onSELECT({ query, data })
       if (!res) return res
       // SELECT only binary column
+      query = cds.ql.clone(query)
       query.SELECT.columns = binary
       const { sql: streamSql, values: valuesStream } = this.cqn2sql(query, data)
       const ps = this.prepare(streamSql)
@@ -452,10 +453,9 @@ GROUP BY k
       return `(CASE WHEN json_typeof(value->${this.managed_extract(name).extract.slice(8)}) IS NULL THEN ${managed} ELSE ${src} END)`
     }
 
-    param({ ref }) {
-      this._paramCount = this._paramCount || 1
-      if (ref.length > 1) throw cds.error`Unsupported nested ref parameter: ${ref}`
-      return ref[0] === '?' ? `$${this._paramCount++}` : `:${ref}`
+    param(param) {
+      super.param(param)
+      return '$' + this.params.length
     }
 
     val(val) {

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -114,12 +114,12 @@ class SQLiteService extends SQLService {
     yield ']'
   }
 
-  pragma (pragma, options) {
-    if (!this.dbc) return this.begin('pragma') .then (tx => {
-      try { return tx.pragma (pragma, options) }
+  pragma(pragma, options) {
+    if (!this.dbc) return this.begin('pragma').then(tx => {
+      try { return tx.pragma(pragma, options) }
       finally { tx.release() }
     })
-    return this.dbc.pragma (pragma, options)
+    return this.dbc.pragma(pragma, options)
   }
 
 
@@ -137,7 +137,7 @@ class SQLiteService extends SQLService {
     return any ? Promise.all(values) : values
   }
 
-  async onSIMPLE({ query, data }) {
+  async onSIMPLE({ query, data = query.params }) {
     const { sql, values } = this.cqn2sql(query, data)
     let ps = await this.prepare(sql)
     const vals = await this._prepareStreams(values)

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -391,14 +391,14 @@ describe('SELECT', () => {
     })
 
     // REVISIT: it is not yet fully supported to have named parameters on all databases
-    test.skip('param named', async () => {
+    test('param named', async () => {
       const { string } = cds.entities('basic.projection')
       const cqn = CQL`SELECT string FROM ${string} WHERE string = :param`
       const res = await cds.run(cqn, { param: 'yes' })
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
 
-    test.skip('param number', async () => {
+    test('param number', async () => {
       const { string } = cds.entities('basic.projection')
       const cqn = CQL`SELECT string FROM ${string} WHERE string = :7`
       const res = await cds.run(cqn, { 7: 'yes' })

--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -290,8 +290,9 @@ describe('Bookshop - Read', () => {
       const res3 = await cds.run(q)
       expect(res3[res3.length - 1].title).to.be.eq('dracula')
 
-      q.SELECT.localized = true
-      const res4 = await cds.run(q)
+      const qloc = cds.ql.clone(q)
+      qloc.SELECT.localized = true
+      const res4 = await cds.run(qloc)
       expect(res4[1].title).to.be.eq('dracula')
     } finally {
       await DELETE('/admin/Books(280)', admin)


### PR DESCRIPTION
By attaching a `SQL` cache to executed queries it becomes possible to skip a lot of processing especially for more complex queries. Therefor this PR introduces the initial setup for creating and leveraging re usable `CQN` queries `SQL` caches.

Currently in most writing queries `resolveView` is used to be able to write into entities that cannot be written into directly on the database. The big drawback of the `resolveView` usage is that it does not just modify the query, but also modifies the attached data. Therefor this PR also removes the early `resolveView` and leverages the `getTransitions` and `getDBTable` functions instead to bake the data transformation directly into the SQL statements. This mostly comes down to defining different column names in the `SQL` from the `JSON` properties send to the database service.

```SQL
INSERT INTO Books (ID, title, descr) SELECT value->>'key', value->>'book_name', value->>'description' from json_each(?)
```

Allowing the caching mechanism to simply re-use the `SQL` produced before and serializing the new `entries`. Without having to call `resolveView` on each call even when cached.

There is a clear problem by having the caching mechanism be added on the lowest level. Is that currently many applications will be relying on directly modifying `CQN` without calling `cds.ql.clone` or `q.clone` which is now required to receive the expected results. As `clone` will invalidate any `SQL` cache on the `proto` query.

