### PR TITLE
fix: contains not evaluting to bool

### DIFF
--- a/db-service/lib/cql-functions.js
+++ b/db-service/lib/cql-functions.js
@@ -49,7 +49,7 @@ const StandardFunctions = {
    * @param  {...string} args
    * @returns {string}
    */
-  contains: (...args) => `ifnull(instr(${args}),0)`,
+  contains: (...args) => `(ifnull(instr(${args}),0) > 0)`,
   /**
    * Generates SQL statement that produces the number of elements in a given collection
    * @param {string} x

--- a/test/scenarios/bookshop/funcs.test.js
+++ b/test/scenarios/bookshop/funcs.test.js
@@ -23,6 +23,24 @@ describe('Bookshop - Functions', () => {
       expect(res.data.value.length).to.be.eq(2)
     })
 
+    test('contains with explicit equals boolean value', async () => {
+      const res = await GET("/browse/Books?$filter=contains(author,'Allen') eq true")
+      expect(res.status).to.be.eq(200)
+      expect(res.data.value.length).to.be.eq(2)
+    })
+  
+    test('contains with explicit not equals boolean value', async () => {
+      const res = await GET("/browse/Books?$filter=contains(author,'Allen') ne false")
+      expect(res.status).to.be.eq(200)
+      expect(res.data.value.length).to.be.eq(2)
+    })
+  
+    test('not contains with explicit equals boolean value', async () => {
+      const res = await GET("/browse/Books?$filter=not contains(author,'Allen') eq false")
+      expect(res.status).to.be.eq(200)
+      expect(res.data.value.length).to.be.eq(2)
+    })
+
     test('avg', async () => {
       const { Books } = cds.entities
       const res = await cds.run(CQL`SELECT from ${Books} {

--- a/test/scenarios/bookshop/funcs.test.js
+++ b/test/scenarios/bookshop/funcs.test.js
@@ -23,20 +23,26 @@ describe('Bookshop - Functions', () => {
       expect(res.data.value.length).to.be.eq(2)
     })
 
+    test('contains with search string that can not be found', async () => {
+      const res = await GET(`/browse/Books?$filter=contains(author,'string that can not be found in any author name')`)
+      expect(res.status).to.be.eq(200)
+      expect(res.data.value.length).to.be.eq(0)
+    })
+
+    test('contains with search string null', async () => {
+      const res = await GET(`/browse/Books?$filter=contains(author,null)`)
+      expect(res.status).to.be.eq(200)
+      expect(res.data.value.length).to.be.eq(0)
+    })
+
     test('contains with explicit equals boolean value', async () => {
       const res = await GET("/browse/Books?$filter=contains(author,'Allen') eq true")
       expect(res.status).to.be.eq(200)
       expect(res.data.value.length).to.be.eq(2)
     })
-  
+
     test('contains with explicit not equals boolean value', async () => {
       const res = await GET("/browse/Books?$filter=contains(author,'Allen') ne false")
-      expect(res.status).to.be.eq(200)
-      expect(res.data.value.length).to.be.eq(2)
-    })
-  
-    test('not contains with explicit equals boolean value', async () => {
-      const res = await GET("/browse/Books?$filter=not contains(author,'Allen') eq false")
       expect(res.status).to.be.eq(200)
       expect(res.data.value.length).to.be.eq(2)
     })


### PR DESCRIPTION
Compare the result of sqlite contains realization using `instr` to 0, to make it evaluate to a boolean. The same problem does not exist for HANA or Postgres. 