### PR TITLE
fix: nested ternary in calculated element

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -859,7 +859,7 @@ function infer(originalQuery, model) {
       } else if (arg.xpr || arg.args) {
         const prop = arg.xpr ? 'xpr' : 'args'
         arg[prop].forEach(step => {
-          const subPath = { $refLinks: [...basePath.$refLinks], ref: [...basePath.ref] }
+          let subPath = { $refLinks: [...basePath.$refLinks], ref: [...basePath.ref] }
           if (step.ref) {
             step.$refLinks.forEach((link, i) => {
               const { definition } = link
@@ -874,6 +874,10 @@ function infer(originalQuery, model) {
           } else if (step.args || step.xpr) {
             const nestedProp = step.xpr ? 'xpr' : 'args'
             step[nestedProp].forEach(a => {
+              // reset sub path for each nested argument
+              // e.g. case when <path> then <otherPath> else <anotherPath> end
+              if(!a.ref)
+                subPath = { $refLinks: [...basePath.$refLinks], ref: [...basePath.ref] }
               mergePathsIntoJoinTree(a, subPath)
             })
           }

--- a/db-service/test/bookshop/db/booksWithExpr.cds
+++ b/db-service/test/bookshop/db/booksWithExpr.cds
@@ -99,3 +99,10 @@ entity VariableReplacements {
   // with variable replacements
   authorAlive = author[dateOfBirth <= $now and dateOfDeath >= $now and $user.unknown.foo.bar = 'Bob'];
 }
+
+entity Ternary {
+  key ID        : Integer;
+      value     : Integer;
+      book      : Association to Books;
+      nestedTernary : Integer = (1 > 0 ? 1 : (book.stock > 10 ? value : 3));
+}

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -46,6 +46,16 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
 
+  it('in ternary', () => {
+    let query = cqn4sql(CQL`SELECT from booksCalc.Ternary { ID, nestedTernary }`, model)
+    const expected = CQL`SELECT from booksCalc.Ternary as Ternary
+      left join booksCalc.Books as book on book.ID = Ternary.book_ID
+    {
+        Ternary.ID,
+        (case when 1 > 0 then 1 else (case when book.stock > 10 then Ternary.value else 3 end) end) as nestedTernary
+      }`
+    expect(query).to.deep.equal(expected)
+  })
   it('in function', () => {
     let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, round(area, 2) as f }`, model)
     const expected = CQL`SELECT from booksCalc.Books as Books {


### PR DESCRIPTION
calculated elements may reference other calcuated elements and so forth.. that is why we have logic in place which constructs subpaths for such scenarios which enables us to calculate joins deeply built into a given calculated element hierarchy. However, the logic had a flaw for e.g. nested ternary expressions.

For `(1 > 0 ? 1 : (book.stock > 10 ? value : 3));`

we accidentally constructed subpaths like `book.stock.value` which led to an error because we tried to create a join for `value`, where no association prefix is present.

fix cap/issue#17660