### PR TITLE
fix(`UPDATE`): only perform subselect matching if necessary

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -134,7 +134,7 @@ function cqn4sql(originalQuery, model) {
         const primaryKey = { list: [] }
         for (const k of Object.keys(queryTarget.elements)) {
           const e = queryTarget.elements[k]
-          if (e.key === true && !e.virtual) {
+          if (e.key === true && !e.virtual && e.isAssociation !== true) {
             subquery.SELECT.columns.push({ ref: [e.name] })
             primaryKey.list.push({ ref: [transformedFrom.as, e.name] })
           }

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -963,7 +963,8 @@ function infer(originalQuery, model) {
           if (element.type !== 'cds.LargeBinary') {
             queryElements[k] = element
           }
-          if (isCalculatedOnRead(element)) {
+          // only relevant if we actually select the calculated element
+          if (originalQuery.SELECT && isCalculatedOnRead(element)) {
             linkCalculatedElement(element)
           }
         }

--- a/db-service/test/cqn4sql/model/update.cds
+++ b/db-service/test/cqn4sql/model/update.cds
@@ -15,6 +15,14 @@ entity Authors {
   alive  : Boolean;
 }
 
+entity Orders {
+  key ID: UUID;
+  Items: composition of many {
+    key book: Association to Books;
+    price: Decimal = book.stock * 2;
+  }
+}
+
 service CatalogService {
    @odata.draft.enabled
    entity Books as projection on bookshop.Books;


### PR DESCRIPTION
the issue was that while calculating the `UPDATE.elements`, we accidentially assumed that the calculated element would lead to a join, hence we did our subselect matching. This logic is not necessary for non `SELECT` queries --> there we need joins if we do a `SELECT * from <entity with calculated element /w path expression>`

---

fix(`UPDATE`): no assocs in list which matches subquery results