### PR TITLE
fix: groupby path expression with overlapping identifier

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -548,7 +548,7 @@ class HANAService extends SQLService {
                     // if (col.ref?.length === 1) { col.ref.unshift(parent.as) }
                     if (col.ref?.length > 1) {
                       const colName = this.column_name(col)
-                      if (!parent.SELECT.columns.some(c => this.column_name(c) === colName)) {
+                      if (!parent.SELECT.columns.some(c => !c.elements && this.column_name(c) === colName)) {
                         const isSource = from => {
                           if (from.as === col.ref[0]) return true
                           return from.args?.some(a => {

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -638,8 +638,7 @@ describe('SELECT', () => {
 
     test('navigation with duplicate identifier in path', async () => {
       const { Books } = cds.entities('complex.associations')
-      const cqn = CQL`SELECT name { name } FROM ${Books} GROUP BY name.name`
-      const res = await cds.run(cqn)
+      const res = await cds.ql`SELECT name { name } FROM ${Books} GROUP BY name.name`
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
 

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -638,7 +638,14 @@ describe('SELECT', () => {
 
     test('navigation with duplicate identifier in path', async () => {
       const { Books } = cds.entities('complex.associations')
-      const cqn = CQL`SELECT FROM ${Books} { name { name } } GROUP BY name.name`
+      const cqn = CQL`SELECT name { name } FROM ${Books} GROUP BY name.name`
+      const res = await cds.run(cqn)
+      assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
+    })
+
+    test('navigation with duplicate identifier in path and aggregation', async () => {
+      const { Books } = cds.entities('complex.associations')
+      const cqn = CQL`SELECT name { name }, count(1) as total FROM ${Books} GROUP BY name.name`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -644,8 +644,7 @@ describe('SELECT', () => {
 
     test('navigation with duplicate identifier in path and aggregation', async () => {
       const { Books } = cds.entities('complex.associations')
-      const cqn = CQL`SELECT name { name }, count(1) as total FROM ${Books} GROUP BY name.name`
-      const res = await cds.run(cqn)
+      const res = await cds.ql`SELECT name { name }, count(1) as total FROM ${Books} GROUP BY name.name`
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
   })

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -635,6 +635,13 @@ describe('SELECT', () => {
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
+
+    test('navigation with duplicate identifier in path', async () => {
+      const { Books } = cds.entities('complex.associations')
+      const cqn = CQL`SELECT FROM ${Books} { name { name } } GROUP BY name.name`
+      const res = await cds.run(cqn)
+      assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
+    })
   })
 
   describe('having', () => {

--- a/test/compliance/resources/db/complex/associations.cds
+++ b/test/compliance/resources/db/complex/associations.cds
@@ -4,6 +4,7 @@ entity Books {
   key ID : Integer;
   title  : String(111);
   author : Association to Authors;
+  name   : Association to Authors on $self.author.ID = ID;
 }
 
 entity Authors {

--- a/test/compliance/resources/db/complex/associations.cds
+++ b/test/compliance/resources/db/complex/associations.cds
@@ -4,7 +4,7 @@ entity Books {
   key ID : Integer;
   title  : String(111);
   author : Association to Authors;
-  name   : Association to Authors on $self.author.ID = ID;
+  name   : Association to Authors on $self.author.ID = name.ID;
 }
 
 entity Authors {


### PR DESCRIPTION
Currently, the HANA service is unable to `GROUP BY foobar.foobar`, raising an error like `invalid column name: foobar.foobar`, if the query includes an aggregation and `sql syntax error: incorrect syntax near "FROM"`, if it does not. The problem is caused by the overlapping column names and the HANA service not correctly injecting the column groupby requires into the parent select - if the parent includes a column with the same `column_name` as the 'grouped-by' column. 

This fix enables the required injection, by skipping the overlapping names check for columns that contain a select. 