### PR TITLE
fix: infer when unresolved

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -120,7 +120,7 @@ class HANAService extends SQLService {
   async onSELECT(req) {
     const { query, data } = req
 
-    if (!query.target) {
+    if (!query.target || query.target._unresolved) {
       try { this.infer(query) } catch { /**/ }
     }
     if (!query.target || query.target._unresolved) {


### PR DESCRIPTION
Some queries based upon sub selects would be considered `_unresolved`, but `infer` is able to make them `resolved`.