### PR TITLE
test: add jaeger docker image with HANA trace information

### DIFF
--- a/hana/lib/drivers/hana-client.js
+++ b/hana/lib/drivers/hana-client.js
@@ -45,13 +45,12 @@ class HANAClientDriver extends driver {
     super(creds)
     this._native = hdb.createConnection(creds)
     this._native = wrap_client(this._native, creds, creds.tenant)
-    this._native.setAutoCommit(false)
-  }
-
-  set(variables) {
-    for (const key in variables) {
-      this._native.setClientInfo(key, variables[key])
+    this._native.set = function (variables) {
+      for (const key in variables) {
+        this.setClientInfo(key, variables[key])
+      }
     }
+    this._native.setAutoCommit(false)
   }
 
   async prepare(sql, hasBlobs) {

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -47,15 +47,14 @@ class HDBDriver extends driver {
     this._native = wrap_client(this._native, creds, creds.tenant)
     this._native.setAutoCommit(false)
     this._native.on('close', () => this.destroy?.())
+    this._native.set = function(variables) {
+      const clientInfo = this._connection.getClientInfo()
+      for (const key in variables) {
+        clientInfo.setProperty(key, variables[key])
+      }
+    }
 
     this.connected = false
-  }
-
-  set(variables) {
-    const clientInfo = this._native._connection.getClientInfo()
-    for (const key in variables) {
-      clientInfo.setProperty(key, variables[key])
-    }
   }
 
   async validate() {
@@ -438,6 +437,7 @@ const readString = function (state, isJson = false) {
 }
 
 const { readInt64LE } = require('hdb/lib/util/bignum.js')
+const { func } = require('@sap/cds/lib/ql/cds-ql')
 const readBlob = function (state, encoding) {
   // Check if the blob is null
   let ens = state.ensure(2)

--- a/hana/tools/docker/hce/hana.yml
+++ b/hana/tools/docker/hce/hana.yml
@@ -5,6 +5,8 @@ services:
     image: hana-master:current
     restart: always
     hostname: hcehost
+    networks:
+      - backend
     command:
       - --init
       - role=worker:services=indexserver,dpserver,diserver:database=H00:create
@@ -20,3 +22,31 @@ services:
       # - '30040:30040'
       # - '30042:30042'
       # - '30043:30043'
+
+  jaeger:
+    networks:
+      backend:
+        # This is the host name used in Prometheus scrape configuration.
+        aliases: [ spm_metrics_source ]
+    image: jaegertracing/jaeger:${JAEGER_VERSION:-latest}
+    volumes:
+      - "./jaeger.yaml:/etc/jaeger/config.yml"
+    command: ["--config", "/etc/jaeger/config.yml"]
+    ports:
+      - "16686:16686"
+      - "8888:8888"
+      - "8889:8889"
+      - "4317:4317"
+      - "4318:4318"
+
+  prometheus:
+    networks:
+      - backend
+    image: prom/prometheus:v3.1.0
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+    ports:
+      - "9090:9090"
+
+networks:
+  backend:

--- a/hana/tools/docker/hce/jaeger.yaml
+++ b/hana/tools/docker/hce/jaeger.yaml
@@ -1,0 +1,55 @@
+service:
+  extensions: [jaeger_storage, jaeger_query]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter, spanmetrics]
+    metrics/spanmetrics:
+      receivers: [spanmetrics]
+      exporters: [prometheus]
+  telemetry:
+    resource:
+      service.name: jaeger
+    metrics:
+      level: detailed
+      address: 0.0.0.0:8888
+    logs:
+      level: DEBUG
+
+extensions:
+  jaeger_query:
+    max_clock_skew_adjust: 30s
+    storage:
+      traces: some_storage
+      metrics: some_metrics_storage
+  jaeger_storage:
+    backends:
+      some_storage:
+        memory:
+          max_traces: 100000
+    metric_backends:
+      some_metrics_storage:
+        prometheus:
+          endpoint: http://prometheus:9090
+          normalize_calls: true
+          normalize_duration: true
+
+connectors:
+  spanmetrics:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+        endpoint: "0.0.0.0:4318"
+
+processors:
+  batch:
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: some_storage
+  prometheus:
+    endpoint: "0.0.0.0:8889"

--- a/hana/tools/docker/hce/otel.sh
+++ b/hana/tools/docker/hce/otel.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Directory containing the trace files
+TRACE_DIR="/hana/mounts/trace/hana/DB_H00"
+
+# OpenTelemetry endpoint
+OTEL_ENDPOINT="http://jaeger:4318/v1/traces"
+
+# Function to process a trace file
+process_trace_file() {
+  local trace_file="$1"
+  tail -F "$trace_file" | awk -v RS='\n\n' 'function generate_span_id() {
+    cmd = "cat /proc/sys/kernel/random/uuid | tr -d \"-\" | cut -c1-16 | tr -d \"\n\""
+    cmd | getline span_id
+    close(cmd)
+    return span_id
+  }
+  {
+    split($0, fields, ";");
+    traceId=fields[22];
+    spanId=generate_span_id();
+    parentSpanId=substr(fields[24], 17);
+    startTime=fields[6] "000";  # Convert to nanoseconds
+    duration=fields[7] "000";   # Convert to nanoseconds
+    endTime=startTime + duration;
+    operation=fields[9];
+    statementString=fields[54];
+    memSize=fields[19];
+    cpuTime=fields[21];
+    gsub(/^#/, "", statementString);
+    gsub(/\n/, " ", statementString);
+    gsub(/"/, "\\\"", statementString);
+    
+    # Prepare the JSON payload according to OpenTelemetry API structure
+    print sprintf("{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"@sap/hana-cloud\"}}]},\"scopeSpans\":[{\"spans\":[{\"traceId\":\"%s\",\"spanId\":\"%s\",\"parentSpanId\":\"%s\",\"name\":\"%s\",\"kind\":2,\"startTimeUnixNano\":\"%s\",\"endTimeUnixNano\":\"%s\",\"attributes\":[{\"key\":\"db.statement\",\"value\":{\"stringValue\":\"%s\"}},{\"key\":\"db.operation\",\"value\":{\"stringValue\":\"%s\"}},{\"key\":\"db.mem_size\",\"value\":{\"intValue\":%s}},{\"key\":\"db.cpu_time\",\"value\":{\"intValue\":%s}}]}]}]}]}", traceId, spanId, parentSpanId, operation, startTime, endTime, statementString, operation, memSize, cpuTime);
+  }' | while read -r json_payload; do
+    echo "$json_payload"
+    echo "$json_payload" | curl -X POST "$OTEL_ENDPOINT" -H "Content-Type: application/json" -d @-
+  done
+}
+
+# Function to handle script termination
+cleanup() {
+  echo "Cleaning up..."
+  pkill -P $$
+  exit 0
+}
+
+# Trap signals to ensure cleanup
+trap cleanup SIGINT SIGTERM
+
+# Monitor the directory for new trace files and changes
+declare -A processed_files
+
+while true; do
+  for trace_file in "$TRACE_DIR"/*.expensive_statements.*.trc; do
+    if [ -f "$trace_file" ] && [ -z "${processed_files[$trace_file]}" ]; then
+      echo "Listening to $trace_file..."
+      process_trace_file "$trace_file" &
+      processed_files["$trace_file"]=1
+    fi
+  done
+  sleep 10
+done

--- a/hana/tools/docker/hce/prometheus.yml
+++ b/hana/tools/docker/hce/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+scrape_configs:
+  - job_name: aggregated-trace-metrics
+    static_configs:
+    - targets: ['spm_metrics_source:8889']

--- a/hana/tools/docker/hce/ready.sh
+++ b/hana/tools/docker/hce/ready.sh
@@ -1,4 +1,9 @@
-docker exec hce-hana-1 /bin/bash -c "while ! ./check_hana_health ; do sleep 10 ; done;"
+until docker cp ./otel.sh hce-hana-1:/otel.sh
+do
+  sleep 1
+done
+
+docker exec hce-hana-1 /bin/bash -c "while ! ./check_hana_health ; do sleep 10 ; done;/otel.sh &;"
 docker exec -it hce-hana-1 /bin/bash -c "\
 cd /usr/sap/H00/HDB00;\
 . ./hdbenv.sh;\
@@ -6,4 +11,8 @@ hdbuserstore -i SET SYSDBKEY localhost:30013@SYSTEMDB SYSTEM Manager1;\
 hdbsql -U \"SYSDBKEY\" -e -ssltrustcert \"SELECT COUNT(ACTIVE_STATUS) FROM SYS_DATABASES.M_SERVICES WHERE ACTIVE_STATUS='YES'\";\
 hdbsql -U \"SYSDBKEY\" -e -ssltrustcert \"ALTER SYSTEM ALTER CONFIGURATION ('indexserver.ini', 'DATABASE', 'H00') SET ('session', 'enable_proxy_protocol') = 'false' WITH RECONFIGURE;\";\
 hdbsql -U \"SYSDBKEY\" -e -ssltrustcert \"ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'System') SET ('public_hostname_resolution', 'use_default_route') = 'name' WITH RECONFIGURE;\";\
+hdbsql -U \"SYSDBKEY\" -e -ssltrustcert \"ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'System') SET ('expensive_statement', 'enable') = 'TRUE' WITH RECONFIGURE;\";\
+hdbsql -U \"SYSDBKEY\" -e -ssltrustcert \"ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'System') SET ('expensive_statement', 'threshold_duration') = '0' WITH RECONFIGURE;\";\
+hdbsql -U \"SYSDBKEY\" -e -ssltrustcert \"ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'System') SET ('expensive_statement', 'trace_parameter_values') = 'FALSE' WITH RECONFIGURE;\";\
+hdbsql -U \"SYSDBKEY\" -e -ssltrustcert \"ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'System') SET ('expensive_statement', 'use_in_memory_tracing') = 'FALSE' WITH RECONFIGURE;\";\
 "


### PR DESCRIPTION
This PR adds a `jaeger` and `prometheus` docker image to the `hce` docker setup. This allow the HANA Cloud instance to share its trace information with the `jaeger` Open Telemetry trace APIs. The value that the `prometheus` image provides is the ability to use the `monitoring` view of `jaeger`. Which aggregates the trace information to highlight possible performance pain points.

![image](https://github.com/user-attachments/assets/e7aaec0d-39b6-4789-a985-aae3d097b6a0)

By leveraging `@cap-js/telemetry`, `SAP Passport` and `HANA` traces. It is possible to get a full stack performance overview while in a local development environment. Which is usually only possible in productive landscapes by using `dynatrace`. By having the detailed trace information locally it enables experimental analysis which is not possible in productive landscapes. Additionally removing the hyper scaler from the equation reduces the number of un controllable factors from the measurement (e.g. noise neighbors, network latency, etc.).

![image](https://github.com/user-attachments/assets/1bbd1fa6-1c10-4e72-90b3-da4f81019fe0)

This feature combined with `explain` (https://github.com/cap-js/cds-dbs/pull/462) create a powerful foundation for ensuring a good performance base line and analysis of poor performing requests.
