### PR TITLE
fix: replace polynomial regex with simple string op

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -116,9 +116,11 @@ function infer(originalQuery, model) {
 
       inferArg(from, null, null, { inFrom: true })
       const alias =
-        from.uniqueSubqueryAlias ||
-        from.as ||
-        (ref.length === 1 ? first.match(/[^.]+$/)[0] : ref[ref.length - 1].id || ref[ref.length - 1])
+      from.uniqueSubqueryAlias ||
+      from.as ||
+      (ref.length === 1
+        ? first.substring(first.lastIndexOf('.') + 1)
+        : (ref.at(-1).id || ref.at(-1)));    
       if (alias in querySources) throw new Error(`Duplicate alias "${alias}"`)
       querySources[alias] = { definition: target, args }
       const last = from.$refLinks.at(-1)
@@ -134,7 +136,7 @@ function infer(originalQuery, model) {
     } else if (typeof from === 'string') {
       // TODO: Create unique alias, what about duplicates?
       const definition = getDefinition(from) || cds.error`"${from}" not found in the definitions of your model`
-      querySources[/([^.]*)$/.exec(from)[0]] = { definition }
+      querySources[from.substring(from.lastIndexOf('.') + 1)] = { definition }
     } else if (from.SET) {
       infer(from, model)
     }


### PR DESCRIPTION
This change not only removes the potential for catastrophic backtracking, but it is also more direct and generally more efficient, resolves:
https://github.com/cap-js/cds-dbs/security/code-scanning/4 & https://github.com/cap-js/cds-dbs/security/code-scanning/3