### PR TITLE
ci: pin versions for 3rd party github actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: googleapis/release-please-action@v4
+      # v4.1.3
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f
         id: release
         with:
           token: ${{secrets.CDS_DBS_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      - run: npm install -g @sap/cds-dk
       # Run tests
       - run: npm ci
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
         # v1.3.1
         uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b
       - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
+        # v1.15.0
+        uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87
         with:
           tag: 'v${{ steps.package-version.outputs.current-version}}'
           name: 'Release v${{ steps.package-version.outputs.current-version}}'


### PR DESCRIPTION
as suggested by:
https://github.com/cap-js/cds-dbs/security/code-scanning/1 https://github.com/cap-js/cds-dbs/security/code-scanning/2