### PR TITLE
fix: postgres build plugin w `--production`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+      - run: npm install -g @sap/cds-dk
       - run: npm run lint
       - id: hxe
         uses: ./.github/actions/hxe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # testing
-      - run: npm test -ws -- --unmute
+      - run: npm test -ws
         env:
           FORCE_COLOR: true
           TAG: ${{ steps.hxe.outputs.TAG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # testing
-      - run: npm test -ws
+      - run: npm test -ws -- --unmute
         env:
           FORCE_COLOR: true
           TAG: ${{ steps.hxe.outputs.TAG }}

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -59,7 +59,7 @@
         },
         "postgres": {
           "impl": "@cap-js/postgres",
-          "kind": "postgres",
+          "kind": "sqlite",
           "dialect": "postgres",
           "vcap": {
             "label": "postgresql-db"

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -59,7 +59,7 @@
         },
         "postgres": {
           "impl": "@cap-js/postgres",
-          "kind": "sqlite",
+          "kind": "postgres",
           "dialect": "postgres",
           "vcap": {
             "label": "postgresql-db"

--- a/postgres/test/cds-build.test.js
+++ b/postgres/test/cds-build.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+// make sure the build plugin works
+
+const path = require('path')
+const fs = require('fs')
+const { execSync } = require('child_process')
+const { expect } = require('chai')
+
+const workDir = path.join(__dirname, 'tiny-sample')
+const genDir = path.join(workDir, 'gen')
+const dbDest = path.join(genDir, 'pg/db')
+
+// delete the generated folder after each test
+afterEach(() => {
+  if (fs.existsSync(genDir)) {
+    fs.rmSync(genDir, { recursive: true })
+  }
+})
+
+it('should run pg build with explicit build task', () => {
+  execSync('cds build --for postgres', { cwd: workDir })
+  expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
+})
+
+it('should run pg build with production profile', () => {
+  execSync('cds build --production', { cwd: workDir })
+  expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
+})

--- a/postgres/test/cds-build.test.js
+++ b/postgres/test/cds-build.test.js
@@ -19,11 +19,11 @@ afterEach(() => {
 })
 
 it('should run pg build with explicit build task', () => {
-  execSync('cds build --for postgres', { cwd: workDir })
+  execSync('npx cds build --for postgres', { cwd: workDir })
   expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
 })
 
 it('should run pg build with production profile', () => {
-  execSync('cds build --production', { cwd: workDir })
+  execSync('npx cds build --production', { cwd: workDir })
   expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
 })

--- a/postgres/test/cds-build.test.js
+++ b/postgres/test/cds-build.test.js
@@ -5,7 +5,7 @@
 const path = require('path')
 const fs = require('fs')
 const { execSync } = require('child_process')
-const { expect } = require('chai')
+const cds = require('../../test/cds.js')
 
 const workDir = path.join(__dirname, 'tiny-sample')
 const genDir = path.join(workDir, 'gen')
@@ -13,17 +13,18 @@ const dbDest = path.join(genDir, 'pg/db')
 
 // delete the generated folder after each test
 afterEach(() => {
-  if (fs.existsSync(genDir)) {
-    fs.rmSync(genDir, { recursive: true })
-  }
+  if (fs.existsSync(genDir)) fs.rmSync(genDir, { recursive: true })
 })
 
-it('should run pg build with explicit build task', () => {
-  execSync('npx cds build --for postgres', { cwd: workDir })
-  expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
-})
+describe('cds build plugin', () => {
+  const { expect } = cds.test
+  test('should run pg build with explicit build task', () => {
+    execSync('npx cds build --for postgres', { cwd: workDir })
+    expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
+  })
 
-it('should run pg build with production profile', () => {
-  execSync('npx cds build --production', { cwd: workDir })
-  expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
+  test('should run pg build with production profile', () => {
+    execSync('npx cds build --production', { cwd: workDir })
+    expect(fs.existsSync(path.join(dbDest, 'csn.json'))).to.be.true
+  })
 })

--- a/postgres/test/tiny-sample/db/data/my.bookshop-Books.csv
+++ b/postgres/test/tiny-sample/db/data/my.bookshop-Books.csv
@@ -1,0 +1,3 @@
+ID,title,stock
+1,Wuthering Heights,100
+2,Jane Eyre,500

--- a/postgres/test/tiny-sample/db/schema.cds
+++ b/postgres/test/tiny-sample/db/schema.cds
@@ -1,0 +1,7 @@
+namespace my.bookshop;
+
+entity Books {
+  key ID : Integer;
+  title  : String;
+  stock  : Integer;
+}

--- a/postgres/test/tiny-sample/package.json
+++ b/postgres/test/tiny-sample/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tiny-sample",
+  "version": "1.0.0",
+  "description": "A simple CAP project, to test the build plugin",
+  "dependencies": {
+    "@cap-js/postgres": "../../."
+  }
+}

--- a/postgres/test/tiny-sample/srv/cat-service.cds
+++ b/postgres/test/tiny-sample/srv/cat-service.cds
@@ -1,0 +1,5 @@
+using my.bookshop as my from '../db/schema';
+
+service CatalogService {
+    @readonly entity Books as projection on my.Books;
+}


### PR DESCRIPTION
as reported in the issue, with default `cds build --production` no postgres build artifacts have been generated.

this was due to a misconfiguration in our `postgres/package.json`

---

```shell
cds init reproduce --add tiny-sample
cd reproduce
cds add postgres
```

you can now observe the malformed `cds env`

```shell
❯ cds env requires.db --profile production
{
  impl: '@cap-js/postgres',
  credentials: { url: 'db.sqlite' },
  kind: 'sqlite',
  dialect: 'postgres',
  vcap: { label: 'postgresql-db' },
  schema_evolution: 'auto'
}
```

and the broken build (missing postgres build task):

```
❯ cds build --production
building project [/Users/patricebender/SAPDevelop/dev/cds-dbs/postgres/test/tiny-sample], clean [true]
cds-dk [8.7.1], cds [8.8.0], compiler [5.7.5], home [/Users/patricebender/SAPDevelop/dev/cds]

{
  build: {
    target: 'gen',
    tasks: [
      { for: 'nodejs', src: 'srv', options: { model: ['db', 'srv'] }}
    ]
  }
}
```