### PR TITLE
chore: rm default from `Books:genre`

### DIFF
--- a/test/bookshop/db/schema.cds
+++ b/test/bookshop/db/schema.cds
@@ -11,7 +11,7 @@ entity Books : managed {
       title          : localized String(111);
       descr          : localized String(1111);
       author         : Association to Authors;
-      genre          : Association to Genres default 10;
+      genre          : Association to Genres;
       stock          : Integer;
       price          : Decimal;
       currency       : Currency;


### PR DESCRIPTION
looks like an accidental change?