### PR TITLE
fix: expand + groupby may return null, dont attach `.element`

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -877,8 +877,8 @@ function cqn4sql(originalQuery, model) {
 
       // to be attached to dummy query
       const elements = {}
-      const wildcardIndex = column.expand.includes('*')
-      if (wildcardIndex) {
+      const containsWildcard = column.expand.includes('*')
+      if (containsWildcard) {
         // expand with wildcard vanishes as expand is part of the group by (OData $apply + $expand)
         return null
       }

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -912,7 +912,7 @@ function cqn4sql(originalQuery, model) {
           elements[c.as || c.ref.at(-1)] = c.element
         })
         return res
-      }).filter(c => c !== null)
+      }).filter(c => c)
 
       if (expandedColumns.length === 0) {
         return null

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -877,8 +877,8 @@ function cqn4sql(originalQuery, model) {
 
       // to be attached to dummy query
       const elements = {}
-      const wildcardIndex = column.expand.findIndex(e => e === '*')
-      if (wildcardIndex !== -1) {
+      const wildcardIndex = column.expand.includes('*')
+      if (wildcardIndex) {
         // expand with wildcard vanishes as expand is part of the group by (OData $apply + $expand)
         return null
       }
@@ -888,8 +888,10 @@ function cqn4sql(originalQuery, model) {
 
         if (expand.expand) {
           const nested = _subqueryForGroupBy(expand, fullRef, expand.as || expand.ref.map(idOnly).join('_'))
-          setElementOnColumns(nested, expand.element)
-          elements[expand.as || expand.ref.map(idOnly).join('_')] = nested
+          if(nested) {
+            setElementOnColumns(nested, expand.element)
+            elements[expand.as || expand.ref.map(idOnly).join('_')] = nested
+          }
           return nested
         }
 
@@ -910,7 +912,11 @@ function cqn4sql(originalQuery, model) {
           elements[c.as || c.ref.at(-1)] = c.element
         })
         return res
-      })
+      }).filter(c => c !== null)
+
+      if (expandedColumns.length === 0) {
+        return null
+      }
 
       const SELECT = {
         from: null,

--- a/db-service/test/cqn4sql/expand.test.js
+++ b/db-service/test/cqn4sql/expand.test.js
@@ -1092,7 +1092,8 @@ describe('Expands with aggregations are special', () => {
 
   it('wildcard expand vanishes for aggregations', () => {
     const q = CQL`SELECT from bookshop.TestPublisher {
-      ID
+      ID,
+      texts { publisher {*} }
     } group by ID, publisher.structuredKey_ID, publisher.title`
 
     const qx = CQL`SELECT from bookshop.TestPublisher as TestPublisher


### PR DESCRIPTION
this resolves an `Uncaught Object.defineProperty called on non-object` dump

this is a workaround for an issue reported in cap/issues#17907

--> we need to put all this logic in the OData protocol adapter, this coding should not be necessary for the DB. This initiative has already started in #990