### PR TITLE
feat: query modifiers on expand `ref` are propagated to subquery

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -807,11 +807,13 @@ function cqn4sql(originalQuery, model) {
     // `SELECT from Authors {  books.genre as genreOfBooks { name } } becomes `SELECT from Books:genre as genreOfBooks`
     const from = { ref: subqueryFromRef, as: uniqueSubqueryAlias }
     const subqueryBase = {}
-    for (const [key, value] of Object.entries(column)) {
-      if (!(key in { ref: true, expand: true })) {
-        subqueryBase[key] = value
-      }
+    const queryModifiers = { ...column, ...ref.at(-1) }
+    for (const [key, value] of Object.entries(queryModifiers)) {
+      if (key in { limit: 1, orderBy: 1, groupBy: 1, excluding: 1, where: 1, having: 1 }) subqueryBase[key] = value
     }
+    // where at leaf already part of subqueryBase
+    if (from.ref.at(-1).where) from.ref[from.ref.length - 1] = [from.ref.at(-1).id]
+
     const subquery = {
       SELECT: {
         ...subqueryBase,
@@ -1225,8 +1227,7 @@ function cqn4sql(originalQuery, model) {
         if (flattenThisForeignKey) {
           const fkElement = getElementForRef(k.ref, getDefinition(element.target))
           let fkBaseName
-          if (!leafAssoc || leafAssoc.onlyForeignKeyAccess)
-            fkBaseName = `${baseName}_${k.as || k.ref.at(-1)}`
+          if (!leafAssoc || leafAssoc.onlyForeignKeyAccess) fkBaseName = `${baseName}_${k.as || k.ref.at(-1)}`
           // e.g. if foreign key is accessed via infix filter - use join alias to access key in target
           else fkBaseName = k.ref.at(-1)
           const fkPath = [...csnPath, k.ref.at(-1)]
@@ -1478,8 +1479,7 @@ function cqn4sql(originalQuery, model) {
           // reject associations in expression, except if we are in an infix filter -> $baseLink is set
           assertNoStructInXpr(token, $baseLink)
           // reject virtual elements in expressions as they will lead to a sql error down the line
-          if(definition?.virtual)
-            throw new Error(`Virtual elements are not allowed in expressions`)
+          if (definition?.virtual) throw new Error(`Virtual elements are not allowed in expressions`)
 
           let result = is_regexp(token?.val) ? token : copy(token) // REVISIT: too expensive! //
           if (token.ref) {

--- a/db-service/test/cqn4sql/expand.test.js
+++ b/db-service/test/cqn4sql/expand.test.js
@@ -280,6 +280,70 @@ describe('Unfold expands on associations to special subselects', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
+  it('do not loose additional properties on expand column if defined in ref', () => {
+    const q = cds.ql`SELECT from bookshop.Authors { books[order by price] { title } }`
+    const res = cqn4sql(q)
+    const expected = CQL`SELECT from bookshop.Authors as Authors {
+      (
+        SELECT from bookshop.Books as books {
+          books.title
+        }
+        where Authors.ID = books.author_ID
+        order by books.price
+      ) as books
+    }`
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
+  })
+
+  it('query modifiers in ref have precedence over expand siblings', () => {
+    const q = {
+      SELECT: {
+        from: {
+          ref: ['bookshop.Books'],
+        },
+        columns: [
+          {
+            ref: [{id: 'author', orderBy: [{ref:['dateOfBirth'], sort: 'desc'}]}],
+            expand: [
+              {
+                ref: ['name'],
+              },
+            ],
+            limit: {
+              offset: {
+                val: 1,
+              },
+              rows: {
+                val: 1,
+              },
+            },
+            // this order by is overwritten by the one in the ref
+            orderBy: [
+              {
+                ref: ['name'],
+                sort: 'asc',
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    const res = cqn4sql(q)
+    const expected = CQL`SELECT from bookshop.Books as Books {
+      (
+        SELECT from bookshop.Authors as author {
+          author.name
+        }
+        where Books.author_ID = author.ID
+        order by author.dateOfBirth desc
+        limit 1
+        offset 1
+      ) as author
+    }`
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
+  })
+
   it('add where exists <assoc> shortcut to expand subquery where condition', () => {
     const q = {
       SELECT: {


### PR DESCRIPTION
enable the following:

```js
cds.ql`SELECT name, books[order by price] { * } FROM Authors`
```

it is still possible to have query modifiers defined as sibling property to `expand`:

```js
{
            ref: ['author'],
            expand: [
              {
                ref: ['name'],
              },
            ],
            limit: {
              offset: {
                val: 1,
              },
              rows: {
                val: 1,
              },
            },
            orderBy: [
              {
                ref: ['name'],
                sort: 'asc',
              },
            ],
          }
```

--> If both are set, the modifiers in the `ref` of the expanded association have precedence