### PR TITLE
fix: align debug log format of stmt values

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -92,7 +92,7 @@ class CQN2SQLRenderer {
       if (values && !Array.isArray(values)) {
         values = [values]
       }
-      DEBUG(this.sql, ...values)
+      DEBUG(this.sql, values)
     }
 
 


### PR DESCRIPTION
logged in the same format here: https://github.com/cap-js/cds-dbs/blob/cf2e0a215e89f9055e28d9f0984adf292e220aee/db-service/lib/SQLService.js#L294C22-L294C26