### PR TITLE
feat(collate): only collate if locale is provided

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -908,7 +908,7 @@ SELECT ${mixing} FROM JSON_TABLE(SRC.JSON, '$' COLUMNS(${extraction})) AS NEW LE
         localized
           ? c =>
             this.expr(c) +
-            (c.element?.[this.class._localized]
+            (c.element?.[this.class._localized] && this.context.locale
               ? ` COLLATE ${collations[this.context.locale] || collations[this.context.locale.split('_')[0]] || collations['']
               }`
               : '') +

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -348,7 +348,7 @@ GROUP BY k
         localized
           ? c =>
             this.expr(c) +
-            (c.element?.[this.class._localized] ? ` COLLATE "${locale}"` : '') +
+            (c.element?.[this.class._localized] && locale ? ` COLLATE "${locale}"` : '') +
             (c.sort?.toLowerCase() === 'desc' || c.sort === -1 ? ' DESC NULLS LAST' : ' ASC NULLS FIRST')
           : c => this.expr(c) + (c.sort?.toLowerCase() === 'desc' || c.sort === -1 ? ' DESC NULLS LAST' : ' ASC NULLS FIRST'),
       )


### PR DESCRIPTION
with cds8 `cds.context.locale` is defaulted to `en` which always enforces `COLLATE`.
with cds9, it's planned to keep `cds.context.locale` `undefined` if not explicitly requested.

This change prepares the DB layer for the upcoming change in cds.