### PR TITLE
fix: Prioritize element name over implicit alias in path resolution

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -626,8 +626,9 @@ function infer(originalQuery, model) {
             } else {
               // if the navigation the user has written differs from the final flat ref - e.g. for renamed foreign keys -
               // the inferred name of the element equals the flat version of the user-written ref.
+              const firstStepIsTableAlias = (firstStepIsExplicitTableAlias || firstStepIsImplicitTableAlias) && arg.$refLinks.at(0).definition.kind !== 'element'
               const refNavigation = arg.ref
-                .slice(firstStepIsSelf || firstStepIsImplicitTableAlias ? 1 : 0)
+                .slice(firstStepIsSelf || firstStepIsTableAlias ? 1 : 0)
                 .map(idOnly)
                 .join('_')
               if (refNavigation !== flatName) elementName = refNavigation

--- a/db-service/lib/infer/join-tree.js
+++ b/db-service/lib/infer/join-tree.js
@@ -163,7 +163,7 @@ class JoinTree {
   mergeColumn(col, outerQueries = null) {
     if (this.isInitial) this.isInitial = false
     const head = col.$refLinks[0]
-    let node = this._roots.get(head.alias)
+    let node = (head.definition.kind === 'entity' || head.definition.SELECT) ? this._roots.get(head.alias) : null
     let i = 0
     if (!node) {
       this._roots.forEach(r => {

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -1153,7 +1153,7 @@ describe('Where exists in combination with assoc to join', () => {
   })
   it('aliases for recursive assoc in column + recursive assoc in from must not clash', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent
+      CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent as parent
       { parent.parent.parent.descr, }`,
       model,
     )
@@ -1179,7 +1179,7 @@ describe('Where exists in combination with assoc to join', () => {
   // Revisit: Alias count order in where + from could be flipped
   it('aliases for recursive assoc in column + recursive assoc in from + where exists <assoc> must not clash', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent
+      CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent as parent
       { parent.parent.parent.descr } where exists parent`,
       model,
     )

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -1043,7 +1043,7 @@ describe('Scoped queries', () => {
   })
 
   it('handles paths with three associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre.parent {parent.ID}`, model)
+    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre.parent as parent {parent.ID}`, model)
     expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as parent {parent.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Genres as genre where genre.parent_ID = parent.ID and EXISTS (
           SELECT 1 from bookshop.Books as books where books.genre_ID = genre.ID and EXISTS (
@@ -1054,7 +1054,7 @@ describe('Scoped queries', () => {
   })
 
   it('handles paths with recursive associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent {parent.ID}`, model)
+    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent as parent {parent.ID}`, model)
     expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as parent {parent.ID}
       WHERE EXISTS (
         SELECT 1 from bookshop.Genres as parent2 where parent2.parent_ID = parent.ID and EXISTS (
@@ -1086,13 +1086,13 @@ describe('Scoped queries', () => {
   // (SMW) need more tests with unmanaged ON conds using all sorts of stuff -> e.g. struc access in ON, FK of mgd assoc in FROM ...
 
   it('transforms unmanaged association to where exists subquery and infix filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent[id<20] {parent.id}`, model)
+    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent[id<20] as parent {parent.id}`, model)
     expect(query).to.deep.equal(CQL`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
         SELECT 1 from bookshop.Baz as Baz where parent.id = Baz.parent_id or parent.id > 17
       ) AND parent.id < 20`)
   })
   it('transforms unmanaged association to where exists subquery with multiple infix filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent[id<20 or id > 12] {parent.id}`, model)
+    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent[id<20 or id > 12] as parent {parent.id}`, model)
     expect(query).to.deep.equal(CQL`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
         SELECT 1 from bookshop.Baz as Baz where parent.id = Baz.parent_id or parent.id > 17
       ) AND (parent.id < 20 or parent.id > 12)`)


### PR DESCRIPTION
For recursive entity structures like:

```cds
entity Genres {
  ID:   Integer;
  name: String;
  parent: Association to Genres;
}
```

an OData request such as:

`http://localhost:4004/odata/v4/CatalogService/Genres(42)/dependsOn?$orderby=parent/name`

leads to a cqn like `select from Genres:parent order by parent.name`

this would previously resolve the first path step in `parent.name` as _implicit_ table alias `parent`, even though there is an element (the association `parent`)with the same name. With this change, the first reference of any multi-segment path is resolved using the following order:

1. Explicit table alias: If provided (e.g., in `select from Genres:parent as parent order by parent.name`), use the explicit alias.
2. Element reference: If no explicit alias exists, resolve the element (e.g., `parent` resolves to `Genres:parent`).
3. Implicit table alias: Fallback to the implicit alias.
4. Error: Throw an error if none of the above can be matched.

This update maintains compatibility with standard SQL implicit alias behavior while ensuring that element names take precedence where applicable.