### PR TITLE
chore(tests): replace `CQL` with `cds.ql`

### DIFF
--- a/db-service/test/cds-infer/api.test.js
+++ b/db-service/test/cds-infer/api.test.js
@@ -16,7 +16,7 @@ describe('infer elements', () => {
 
   describe('all query elements are linked', () => {
     it('expands and inlines are linked', () => {
-      let query = CQL`SELECT from bookshop.Books {
+      let query = cds.ql`SELECT from bookshop.Books {
         ID,
         author  as expandOnAssoc { * },
         dedication as expandOnStruct { * },
@@ -29,7 +29,7 @@ describe('infer elements', () => {
       })
     })
     it('values / functions / expr with type are linked', () => {
-      let query = CQL`SELECT from bookshop.Books {
+      let query = cds.ql`SELECT from bookshop.Books {
         1,
         true,
         'foo',
@@ -45,7 +45,7 @@ describe('infer elements', () => {
   })
 
   it('element has the same name as the query alias', () => {
-    let query = CQL`SELECT from bookshop.Books as dedication { ID, dedication.dedication.text }`
+    let query = cds.ql`SELECT from bookshop.Books as dedication { ID, dedication.dedication.text }`
     let inferred = _inferred(query)
     let { Books } = model.entities
     expect(inferred.elements).to.deep.equal({
@@ -55,7 +55,7 @@ describe('infer elements', () => {
   })
 
   it('infer inferred query multiple times', () => {
-    let query = CQL`SELECT from bookshop.Books as dedication { ID, dedication.dedication.text }`
+    let query = cds.ql`SELECT from bookshop.Books as dedication { ID, dedication.dedication.text }`
     let inferred = _inferred(query)
     let inferredInferred = _inferred(inferred)
     expect(inferred).to.eql(inferredInferred)
@@ -66,7 +66,7 @@ describe('infer elements', () => {
     const keepModel = cds.model
     cds.model = null
     // subsequent infer calls should always use explicitly passed model parameter
-    let query = CQL`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books) as triggerRecursiveInfer }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books) as triggerRecursiveInfer }`
     let inferred = _inferred(query, model)
     let { Books } = model.entities
     expect(inferred.elements).to.deep.equal({

--- a/db-service/test/cds-infer/calculated-elements.test.js
+++ b/db-service/test/cds-infer/calculated-elements.test.js
@@ -11,7 +11,7 @@ describe('Infer types of calculated elements in select list', () => {
   })
   it('calc element has type or has cast', () => {
     let inferred = _inferred(
-      CQL`SELECT from booksCalc.Books {
+      cds.ql`SELECT from booksCalc.Books {
           ID,
           area,
           area as strArea : String,
@@ -33,7 +33,7 @@ describe('Infer types of calculated elements in select list', () => {
   })
   it('calc elements via wildcard', () => {
     let inferred = _inferred(
-      CQL`SELECT from booksCalc.Books { * } excluding { length, width, height, stock, price}`,
+      cds.ql`SELECT from booksCalc.Books { * } excluding { length, width, height, stock, price}`,
       model,
     )
     let { Books } = model.entities

--- a/db-service/test/cds-infer/column.element.test.js
+++ b/db-service/test/cds-infer/column.element.test.js
@@ -20,7 +20,7 @@ describe('assign element onto columns', () => {
 
   describe('assigns element property for path expressions', () => {
     it('along simple association', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, currency.code }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, currency.code }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       // ID
@@ -32,7 +32,7 @@ describe('assign element onto columns', () => {
     })
 
     it('with filter conditions', () => {
-      let query = CQL`SELECT from bookshop.Books { dedication.addressee[placeOfBirth <> 'foo'].name, dedication.addressee.name as nameWithoutFilter }`
+      let query = cds.ql`SELECT from bookshop.Books { dedication.addressee[placeOfBirth <> 'foo'].name, dedication.addressee.name as nameWithoutFilter }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       // dedication_addressee_name
@@ -48,7 +48,7 @@ describe('assign element onto columns', () => {
 
   describe('literals', () => {
     it('should allow selecting simple literal values', () => {
-      const inferred = _inferred(CQL`
+      const inferred = _inferred(cds.ql`
         SELECT 11, 'foo', true, false from bookshop.Books
       `)
       // '11'
@@ -72,7 +72,7 @@ describe('assign element onto columns', () => {
 
   describe('virtual', () => {
     it("infers a query's virtual elements", () => {
-      let query = CQL`SELECT from bookshop.Foo { ID, virtualField }`
+      let query = cds.ql`SELECT from bookshop.Foo { ID, virtualField }`
       let inferred = _inferred(query)
       let { Foo } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -90,7 +90,7 @@ describe('assign element onto columns', () => {
 
   describe('scoped queries', () => {
     it('use table alias of scoped query (assoc defined via type reference)', () => {
-      let inferred = _inferred(CQL`SELECT from bookshop.Books:coAuthor {
+      let inferred = _inferred(cds.ql`SELECT from bookshop.Books:coAuthor {
       coAuthor.name as name
     }`)
       let { Authors } = model.entities
@@ -106,7 +106,7 @@ describe('assign element onto columns', () => {
   })
   describe('subqueries', () => {
     it('supports expressions and subqueries in the select list', () => {
-      let query = CQL`
+      let query = cds.ql`
     SELECT from bookshop.Books {
       1 + 1 as Two,
       (select from bookshop.Authors { name }) as subquery
@@ -128,7 +128,7 @@ describe('assign element onto columns', () => {
   })
   describe('expressions', () => {
     it('anonymous functions are inferred by their func property name', () => {
-      let functionWithoutAlias = CQL`SELECT from bookshop.Books { sum(1 + 1), count(*) }`
+      let functionWithoutAlias = cds.ql`SELECT from bookshop.Books { sum(1 + 1), count(*) }`
       const inferred = _inferred(functionWithoutAlias)
       // 'sum'
       expect(inferred.SELECT.columns[0].element).to.deep.equal(inferred.elements['sum']).to.deep.equal({})
@@ -137,7 +137,7 @@ describe('assign element onto columns', () => {
     })
 
     it('supports an expression with fields in the select list', () => {
-      let query = CQL`SELECT from bookshop.Books { title + descr as noType }`
+      let query = cds.ql`SELECT from bookshop.Books { title + descr as noType }`
       let inferred = _inferred(query)
       // 'noType'
       expect(inferred.SELECT.columns[0].element).to.deep.equal(inferred.elements['noType']).to.deep.equal({})
@@ -158,7 +158,7 @@ describe('assign element onto columns', () => {
     })
 
     it('supports a cast expression in the select list', () => {
-      let query = CQL`SELECT from bookshop.Books {
+      let query = cds.ql`SELECT from bookshop.Books {
         cast(cast(ID as Integer) as String) as IDS,
         cast(ID as bookshop.DerivedFromDerivedString) as IDCustomType
       }`
@@ -174,7 +174,7 @@ describe('assign element onto columns', () => {
     })
 
     it('supports a cdl-style cast in the select list', () => {
-      let query = CQL`
+      let query = cds.ql`
         SELECT from bookshop.Books {
           dedication.sub.foo: Integer,
           ID as IDS: String,
@@ -211,7 +211,7 @@ describe('assign element onto columns', () => {
           },
         },
       }
-      let query = CQL`SELECT from bookshop.Bar {
+      let query = cds.ql`SELECT from bookshop.Bar {
         $user,
         $user.tenant,
         $user.unknown.foo.bar,
@@ -234,7 +234,7 @@ describe('assign element onto columns', () => {
 
   describe('binding params', () => {
     it('put binding parameter into query elements as empty object', () => {
-      const query = CQL`
+      const query = cds.ql`
         SELECT from bookshop.Books {
           ID,
           ? as discount
@@ -245,7 +245,7 @@ describe('assign element onto columns', () => {
       expect(inferred.SELECT.columns[1].element).to.deep.equal(inferred.elements['discount']).to.deep.equal({})
     })
     it('respect cast type on binding parameter', () => {
-      const query = CQL`
+      const query = cds.ql`
         SELECT from bookshop.Books {
           ID,
           ? as discount: Integer

--- a/db-service/test/cds-infer/elements.test.js
+++ b/db-service/test/cds-infer/elements.test.js
@@ -16,7 +16,7 @@ describe('infer elements', () => {
 
   describe('path expressions', () => {
     it('along simple association', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, currency.code }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, currency.code }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -26,7 +26,7 @@ describe('infer elements', () => {
     })
 
     it('along multiple associations', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, Books.genre.parent.ID }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, Books.genre.parent.ID }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -36,7 +36,7 @@ describe('infer elements', () => {
     })
 
     it.skip('represents the formal correct behavior w.r.t. the name of the structured element', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, currency.code, dedication.text }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, currency.code, dedication.text }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -47,7 +47,7 @@ describe('infer elements', () => {
     })
 
     it('along structs (name of element is ref.join("_"))', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, dedication.sub.foo, dedication.sub }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, dedication.sub.foo, dedication.sub }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -57,7 +57,7 @@ describe('infer elements', () => {
       })
     })
     it('with filter conditions', () => {
-      let query = CQL`SELECT from bookshop.Books { dedication.addressee[placeOfBirth <> 'foo'].name, dedication.addressee.name as nameWithoutFilter }`
+      let query = cds.ql`SELECT from bookshop.Books { dedication.addressee[placeOfBirth <> 'foo'].name, dedication.addressee.name as nameWithoutFilter }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -69,7 +69,7 @@ describe('infer elements', () => {
 
   describe('literals', () => {
     it('should allow selecting simple literal values', () => {
-      const inferred = _inferred(CQL`
+      const inferred = _inferred(cds.ql`
         SELECT 11, 'foo', true, false from bookshop.Books
       `)
       expect(inferred.elements).to.deep.equal({
@@ -83,7 +83,7 @@ describe('infer elements', () => {
 
   describe('virtual and persistence skip', () => {
     it('infers a queries virtual elements', () => {
-      let query = CQL`SELECT from bookshop.Foo { ID, virtualField }`
+      let query = cds.ql`SELECT from bookshop.Foo { ID, virtualField }`
       let inferred = _inferred(query)
       let { Foo } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -92,7 +92,7 @@ describe('infer elements', () => {
       })
     })
     it('infers paths with ”@cds.persistence.skip” as query element', () => {
-      const q = CQL`SELECT from bookshop.NotSkipped {
+      const q = cds.ql`SELECT from bookshop.NotSkipped {
         ID,
         skipped.notSkipped.text as skippedPath
       }`
@@ -107,7 +107,7 @@ describe('infer elements', () => {
 
   describe('everything but "columns" is not relevant for queries elements', () => {
     it('does not infer an element only used in a WHERE condition as the queries element', () => {
-      let query = CQL`SELECT from bookshop.Books { ID } WHERE dedication.text = 'bar'`
+      let query = cds.ql`SELECT from bookshop.Books { ID } WHERE dedication.text = 'bar'`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -118,7 +118,7 @@ describe('infer elements', () => {
 
   describe('access elements via table alias', () => {
     it('implicit alias via entity name', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, Books.author }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, Books.author }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -128,7 +128,7 @@ describe('infer elements', () => {
     })
 
     it('user defined aliases', () => {
-      let query = CQL`SELECT from bookshop.Books as Foo { ID as identifier, dedication.sub.foo as foo, Foo.dedication.sub as sub }`
+      let query = cds.ql`SELECT from bookshop.Books as Foo { ID as identifier, dedication.sub.foo as foo, Foo.dedication.sub as sub }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -138,7 +138,7 @@ describe('infer elements', () => {
       })
     })
     it('query alias shadows an element name', () => {
-      let query = CQL`SELECT from bookshop.Books as dedication { ID, dedication, dedication.title, dedication.dedication.text }`
+      let query = cds.ql`SELECT from bookshop.Books as dedication { ID, dedication, dedication.title, dedication.dedication.text }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -149,7 +149,7 @@ describe('infer elements', () => {
       })
     })
     it('element has the same name as the query alias and is still addressable', () => {
-      let query = CQL`SELECT from bookshop.Books as dedication { ID, dedication.dedication.text }`
+      let query = cds.ql`SELECT from bookshop.Books as dedication { ID, dedication.dedication.text }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.elements).to.deep.equal({
@@ -162,7 +162,7 @@ describe('infer elements', () => {
   describe('$self', () => {
     // REVISIT: we don't need to handle annotations at runtime
     it('$self addresses an element of the select list', () => {
-      let query = CQL`SELECT from bookshop.Books {
+      let query = cds.ql`SELECT from bookshop.Books {
       $self.ID as BeforeItWasOverwritten,
       key 1 + 1 as ID @foo,
       $self.ID as AfterItWasOverwritten,
@@ -229,7 +229,7 @@ describe('infer elements', () => {
   })
   describe('multiple sources', () => {
     it('supports queries based on multiple sources without projections', () => {
-      let query = CQL`SELECT from bookshop.Books, bookshop.Receipt`
+      let query = cds.ql`SELECT from bookshop.Books, bookshop.Receipt`
       let inferred = _inferred(query)
       let { Books, Receipt } = model.entities
       expect(inferred.sources).to.have.nested.property('Books.definition', Books)
@@ -240,7 +240,7 @@ describe('infer elements', () => {
     })
 
     it('supports queries based on multiple sources with a *', () => {
-      let query = CQL`SELECT from bookshop.Books, bookshop.Receipt { * }`
+      let query = cds.ql`SELECT from bookshop.Books, bookshop.Receipt { * }`
       let inferred = _inferred(query)
       let { Books, Receipt } = model.entities
       expect(inferred.sources).to.have.nested.property('Books.definition', Books)
@@ -252,7 +252,7 @@ describe('infer elements', () => {
   })
   describe('scoped queries', () => {
     it('use table alias of scoped query', () => {
-      let inferred = _inferred(CQL`SELECT from bookshop.Books:genre.foo {
+      let inferred = _inferred(cds.ql`SELECT from bookshop.Books:genre.foo {
       foo.ID as fooID
       }`)
       let { Books, Genres } = model.entities
@@ -267,7 +267,7 @@ describe('infer elements', () => {
     })
 
     it('use table alias of scoped query (assoc defined via type reference)', () => {
-      let inferred = _inferred(CQL`SELECT from bookshop.Books:coAuthor {
+      let inferred = _inferred(cds.ql`SELECT from bookshop.Books:coAuthor {
       coAuthor.name as name
     }`)
       let { Books, Authors } = model.entities
@@ -280,7 +280,7 @@ describe('infer elements', () => {
   })
   describe('subqueries', () => {
     it('supports expressions and subqueries in the select list', () => {
-      let query = CQL`
+      let query = cds.ql`
     SELECT from bookshop.Books {
       1 + 1 as Two,
       (select from (select from bookshop.Authors) as A) as subquery
@@ -298,7 +298,7 @@ describe('infer elements', () => {
   })
   describe('expressions', () => {
     it('supports expressions and subqueries in the select list', () => {
-      let query = CQL`
+      let query = cds.ql`
     SELECT from bookshop.Books {
       1 + 1 as Two,
       (select from (select from bookshop.Authors) as A) as subquery
@@ -315,13 +315,13 @@ describe('infer elements', () => {
     })
 
     it('anonymous functions are inferred by their func property name', () => {
-      let functionWithoutAlias = CQL`SELECT from bookshop.Books { sum(1 + 1), count(*) }`
+      let functionWithoutAlias = cds.ql`SELECT from bookshop.Books { sum(1 + 1), count(*) }`
       const inferred = _inferred(functionWithoutAlias)
       expect(inferred.elements).to.have.keys(['sum', 'count'])
     })
 
     it('infers functions results as query element', () => {
-      let query = CQL`
+      let query = cds.ql`
     SELECT from bookshop.Books {
       func(stock*price) as net,
     }`
@@ -336,7 +336,7 @@ describe('infer elements', () => {
     })
 
     it('supports an expression with fields in the select list', () => {
-      let query = CQL`SELECT from bookshop.Books { title + descr as noType }`
+      let query = cds.ql`SELECT from bookshop.Books { title + descr as noType }`
       let inferred = _inferred(query)
 
       let { Books } = model.entities
@@ -412,7 +412,7 @@ describe('infer elements', () => {
     })
 
     it('supports a cast expression in the select list', () => {
-      let query = CQL`SELECT from bookshop.Books { cast(cast(ID as Integer) as String) as IDS, cast(ID as bookshop.DerivedFromDerivedString) as IDCustomType }`
+      let query = cds.ql`SELECT from bookshop.Books { cast(cast(ID as Integer) as String) as IDS, cast(ID as bookshop.DerivedFromDerivedString) as IDCustomType }`
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.sources).to.have.nested.property('Books.definition', Books)
@@ -429,7 +429,7 @@ describe('infer elements', () => {
 
     it('supports a cdl-style cast in the select list', () => {
       // Revisit: clarify what the cast should mean
-      let query = CQL`
+      let query = cds.ql`
         SELECT from bookshop.Books {
           dedication.sub.foo: Integer,
           ID as IDS: String,
@@ -453,7 +453,7 @@ describe('infer elements', () => {
 
   describe('wildcards', () => {
     it('* in the column list', () => {
-      let query = CQL`SELECT from bookshop.Books { * }`
+      let query = cds.ql`SELECT from bookshop.Books { * }`
       let inferred = _inferred(query)
 
       let { Books } = model.entities
@@ -465,7 +465,7 @@ describe('infer elements', () => {
     })
 
     it('query without projections', () => {
-      let query = CQL`SELECT from bookshop.Books`
+      let query = cds.ql`SELECT from bookshop.Books`
       let inferred = _inferred(query)
       let { Books } = model.entities
       // blobs are not part of the query elements
@@ -475,7 +475,7 @@ describe('infer elements', () => {
     })
 
     it('respects "excluding" when inferring elements from a *', () => {
-      let query = CQL`SELECT from bookshop.Bar { *, ID, note } excluding { ID, stock }`
+      let query = cds.ql`SELECT from bookshop.Bar { *, ID, note } excluding { ID, stock }`
       let inferred = _inferred(query)
       let { Bar } = model.entities
       const expectedElements = { ...Bar.elements }
@@ -486,7 +486,7 @@ describe('infer elements', () => {
     })
 
     it('excluding only acts on "*" - not on explicit select items', () => {
-      let query = CQL`SELECT from bookshop.Bar { ID, note } excluding { ID }`
+      let query = cds.ql`SELECT from bookshop.Bar { ID, note } excluding { ID }`
       let inferred = _inferred(query)
       let { Bar } = model.entities
       const expectedElements = { ID: Bar.elements.ID, note: Bar.elements.note }
@@ -496,7 +496,7 @@ describe('infer elements', () => {
     // some more excluding tests
 
     it('replaces a select item coming from wildcard if it is overridden', () => {
-      let query = CQL`SELECT from bookshop.Books { 5 * 5 as price, *, 1 + 1 as ID, author.name as author }` // TODO: take care of order
+      let query = cds.ql`SELECT from bookshop.Books { 5 * 5 as price, *, 1 + 1 as ID, author.name as author }` // TODO: take care of order
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.sources).to.have.nested.property('Books.definition', Books)
@@ -530,7 +530,7 @@ describe('infer elements', () => {
           $tenant: { type: 'cds.String' },
         },
       }
-      let query = CQL`SELECT from bookshop.Bar {
+      let query = cds.ql`SELECT from bookshop.Bar {
       $user,
       $user.id,
       $user.locale,
@@ -562,9 +562,9 @@ describe('infer elements', () => {
     })
 
     it('$variables in where do not matter for infer', () => {
-      let query = CQL`SELECT from bookshop.Bar where createdAt < $now`
-      // let query2 = CQL`SELECT from bookshop.Orders where buyer = $user`
-      // let query3 = CQL`SELECT from bookshop.Orders where buyer = $user.id`
+      let query = cds.ql`SELECT from bookshop.Bar where createdAt < $now`
+      // let query2 = cds.ql`SELECT from bookshop.Orders where buyer = $user`
+      // let query3 = cds.ql`SELECT from bookshop.Orders where buyer = $user.id`
 
       let inferred = _inferred(query)
       let { Bar } = model.entities

--- a/db-service/test/cds-infer/negative.test.js
+++ b/db-service/test/cds-infer/negative.test.js
@@ -17,92 +17,92 @@ describe('negative', () => {
 
   describe('filters', () => {
     it('filter must not be provided along a structure in a column', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.Books { ID, dedication[text='foo'].sub.foo }`, model)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.Books { ID, dedication[text='foo'].sub.foo }`, model)).to.throw(
         /A filter can only be provided when navigating along associations/,
       )
     })
     it('filter must not be provided along a structure in from path expression', () => {
       expect(() => {
-        _inferred(CQL`SELECT from bookshop.Books:dedication[sub.foo = 'bar'].addressee`, model)
+        _inferred(cds.ql`SELECT from bookshop.Books:dedication[sub.foo = 'bar'].addressee`, model)
       }).to.throw('A filter can only be provided when navigating along associations')
     })
     it('dangling filter must not be used on association in column', () => {
       expect(() => {
-        _inferred(CQL`SELECT from bookshop.Books { author[ID=42] }`, model)
+        _inferred(cds.ql`SELECT from bookshop.Books { author[ID=42] }`, model)
       }).to.throw('A filter can only be provided when navigating along associations')
     })
     it('dangling filter must not be used on association in where', () => {
       expect(() => {
-        _inferred(CQL`SELECT from bookshop.Books { * } where author[id=42]`, model)
+        _inferred(cds.ql`SELECT from bookshop.Books { * } where author[id=42]`, model)
       }).to.throw('A filter can only be provided when navigating along associations')
     })
   })
 
   describe('reference not resolvable', () => {
     it("element can't be found", () => {
-      let query = CQL`SELECT from bookshop.Books as Foo { boz }`
+      let query = cds.ql`SELECT from bookshop.Books as Foo { boz }`
       expect(() => _inferred(query)).to.throw(/"boz" not found in the elements of "bookshop.Books"/) // revisit: or Foo?
     })
 
     it('deeply nested element is not found', () => {
-      let query = CQL`SELECT from bookshop.Books as Foo { Foo.dedication.sub.boz }`
+      let query = cds.ql`SELECT from bookshop.Books as Foo { Foo.dedication.sub.boz }`
       expect(() => _inferred(query)).to.throw(/"boz" not found in "bookshop.Books:dedication.sub"/) // revisit: Foo:dedication.sub ?
     })
 
     it("element can't be found in elements of subquery", () => {
-      let query = CQL`SELECT from (select from bookshop.Books { ID as FooID }) as Foo { ID }`
+      let query = cds.ql`SELECT from (select from bookshop.Books { ID as FooID }) as Foo { ID }`
       expect(() => _inferred(query)).to.throw(/"ID" not found in the elements of "Foo"/)
     })
     it("reference in group by can't be found in alias of subquery", () => {
-      let query = CQL`SELECT from (select from bookshop.Books { ID as FooID }) as Foo group by Foo.ID`
+      let query = cds.ql`SELECT from (select from bookshop.Books { ID as FooID }) as Foo group by Foo.ID`
       expect(() => _inferred(query)).to.throw(/"ID" not found in "Foo"/)
     })
 
     it('intermediate step in path expression is not found', () => {
-      let query = CQL`SELECT from bookshop.Books as Foo { Foo.notExisting.sub.boz }`
+      let query = cds.ql`SELECT from bookshop.Books as Foo { Foo.notExisting.sub.boz }`
       expect(() => _inferred(query)).to.throw(/"notExisting" not found in "bookshop.Books"/) // or Foo:dedication.sub ?
     })
 
     it('table alias shadows element of query source', () => {
       // could be addressed via `dedication.dedication.text`
-      let query = CQL`SELECT from bookshop.Books as dedication { dedication.text }`
+      let query = cds.ql`SELECT from bookshop.Books as dedication { dedication.text }`
       expect(() => _inferred(query)).to.throw(/"text" not found in "bookshop.Books"/)
     })
 
     it('first path step of from is not resolvable without absolute name', () => {
-      let query = CQL`SELECT from Books`
+      let query = cds.ql`SELECT from Books`
       expect(() => _inferred(query)).to.throw(/"Books" not found in the definitions of your model/)
     })
 
     it('user defined table alias overwrites implicit table alias', () => {
-      let query = CQL`SELECT from bookshop.Books as dedication { Books.dedication }`
+      let query = cds.ql`SELECT from bookshop.Books as dedication { Books.dedication }`
       expect(() => _inferred(query)).to.throw(/"Books" not found in the elements of "bookshop.Books"/)
     })
 
     it('$self reference is not found in the queries elements', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, $self.boo }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, $self.boo }`
       expect(() => _inferred(query)).to.throw(/"boo" not found in the columns list of query/) // revisit: error message
     })
 
     it('filter path is not resolvable in column', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, dedication.addressee[title = 'Harry Potter'].ID }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, dedication.addressee[title = 'Harry Potter'].ID }`
       expect(() => _inferred(query)).to.throw(/"title" not found in "addressee"/) // revisit: better error location "bookshop.Books:dedication.addressee"
     })
 
     it('filter path is not resolvable in where', () => {
-      let query = CQL`SELECT from bookshop.Books where exists author[title = 'Harry Potter']`
+      let query = cds.ql`SELECT from bookshop.Books where exists author[title = 'Harry Potter']`
       expect(() => _inferred(query)).to.throw(/"title" not found in "author"/) // revisit: better error location ""bookshop.Books:author"
     })
 
     it('$self reference is not found in the query elements -> infer hints alternatives', () => {
-      let query = CQL`SELECT from bookshop.Books { ID, $self.author }`
+      let query = cds.ql`SELECT from bookshop.Books { ID, $self.author }`
       expect(() => _inferred(query)).to.throw(
         /"author" not found in the columns list of query, did you mean "Books.author"?/, // revisit: error message
       )
     })
 
     it('$self reference is not found in the query elements with subquery -> infer hints alternatives', () => {
-      let query = CQL`SELECT from (select from bookshop.Books) as Foo { $self.author }`
+      let query = cds.ql`SELECT from (select from bookshop.Books) as Foo { $self.author }`
       // _inferred(query)
       // wording? select list not optimal, did you mean to refer to bookshop.Books?
       expect(() => _inferred(query)).to.throw(
@@ -111,26 +111,26 @@ describe('negative', () => {
     })
 
     it('lone $self ref is treated as regular element', () => {
-      let query = CQL`SELECT from bookshop.Books { $self }`
+      let query = cds.ql`SELECT from bookshop.Books { $self }`
       expect(() => _inferred(query)).to.throw(/"\$self" not found in the elements of "bookshop.Books"/)
     })
 
     it('lone query alias ref is treated as regular element', () => {
-      let query = CQL`SELECT from bookshop.Books as Foo { Foo }`
+      let query = cds.ql`SELECT from bookshop.Books as Foo { Foo }`
       expect(() => _inferred(query)).to.throw(/"Foo" not found in the elements of "bookshop.Books"/) // or Foo?
     })
 
     it('scoped query does not end in queryable artifact', () => {
-      let query = CQL`SELECT from bookshop.Books:name { * }` // name does not exist
+      let query = cds.ql`SELECT from bookshop.Books:name { * }` // name does not exist
       expect(() => _inferred(query)).to.throw(/No association “name” in entity “bookshop.Books”/)
-      let fromEndsWithScalar = CQL`SELECT from bookshop.Books:title { * }`
+      let fromEndsWithScalar = cds.ql`SELECT from bookshop.Books:title { * }`
       expect(() => _inferred(fromEndsWithScalar)).to.throw(/Query source must be a an entity or an association/)
     })
 
     // queries with multiple sources are not supported for cqn4sql transformation  (at least for now)
     // however, such queries can still be inferred
     it("element can't be found in one of multiple query sources", () => {
-      let query = CQL`SELECT from bookshop.Books:author as Bar, bookshop.Books { doesNotExist }`
+      let query = cds.ql`SELECT from bookshop.Books:author as Bar, bookshop.Books { doesNotExist }`
       expect(() => _inferred(query)).to.throw(
         /"doesNotExist" not found in the elements of "bookshop.Authors", "bookshop.Books"/,
       )
@@ -139,14 +139,14 @@ describe('negative', () => {
 
   describe('expressions', () => {
     it('expression needs alias', () => {
-      let expressionWithoutAlias = CQL`SELECT from bookshop.Books as Foo { 1 + 1 }`
-      let subqueryExpressionWithoutAlias = CQL`SELECT from bookshop.Books as Foo { (select from bookshop.Books) }`
+      let expressionWithoutAlias = cds.ql`SELECT from bookshop.Books as Foo { 1 + 1 }`
+      let subqueryExpressionWithoutAlias = cds.ql`SELECT from bookshop.Books as Foo { (select from bookshop.Books) }`
       expect(() => _inferred(expressionWithoutAlias)).to.throw(/Expecting expression to have an alias name/)
       expect(() => _inferred(subqueryExpressionWithoutAlias)).to.throw(/Expecting expression to have an alias name/)
     })
     it('no cast on structure', () => {
-      let castOnStruct = CQL`SELECT from bookshop.Books as Foo { dedication: cds.String }`
-      let castFuncOnStruct = CQL`SELECT from bookshop.Books as Foo { cast(dedication as cds.Binary) as foo }`
+      let castOnStruct = cds.ql`SELECT from bookshop.Books as Foo { dedication: cds.String }`
+      let castFuncOnStruct = cds.ql`SELECT from bookshop.Books as Foo { cast(dedication as cds.Binary) as foo }`
       expect(() => _inferred(castOnStruct)).to.throw(/Structured elements can't be cast to a different type/)
       expect(() => _inferred(castFuncOnStruct)).to.throw(/Structured elements can't be cast to a different type/)
     })
@@ -156,28 +156,28 @@ describe('negative', () => {
     // same name twice in result set -> error
     // SQL would allow that, but different databases may return different column names
     it('duplicate field name', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.Books { ID, ID }`)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.Books { ID, ID }`)).to.throw(
         /Duplicate definition of element “ID”/,
       )
     })
 
     it('anonymous functions are inferred by their func property name, ambiguities are rejected', () => {
-      let ambiguousFunctions = CQL`SELECT from bookshop.Books { sum(1 + 1), sum(1 + 1) }`
+      let ambiguousFunctions = cds.ql`SELECT from bookshop.Books { sum(1 + 1), sum(1 + 1) }`
       expect(() => _inferred(ambiguousFunctions)).to.throw(/Duplicate definition of element “sum”/)
     })
 
     it('multiple subqueries/xprs have same alias', () => {
-      let ambiguousFunctions = CQL`SELECT from bookshop.Books { (select * from bookshop.Books) as foo, (1+1) as foo }`
+      let ambiguousFunctions = cds.ql`SELECT from bookshop.Books { (select * from bookshop.Books) as foo, (1+1) as foo }`
       expect(() => _inferred(ambiguousFunctions)).to.throw(/Duplicate definition of element “foo”/)
     })
 
     it('multiple values have same alias', () => {
-      let ambiguousFunctions = CQL`SELECT from bookshop.Books { 1 as foo, 2 as foo }`
+      let ambiguousFunctions = cds.ql`SELECT from bookshop.Books { 1 as foo, 2 as foo }`
       expect(() => _inferred(ambiguousFunctions)).to.throw(/Duplicate definition of element “foo”/)
     })
 
     it('value has same (implicit) alias as other column', () => {
-      let ambiguousFunctions = CQL`SELECT from bookshop.Books { ID as ![false], false }`
+      let ambiguousFunctions = cds.ql`SELECT from bookshop.Books { ID as ![false], false }`
       expect(() => _inferred(ambiguousFunctions)).to.throw(/Duplicate definition of element “false”/)
     })
 
@@ -185,27 +185,27 @@ describe('negative', () => {
       // queries with multiple sources are not supported for cqn4sql transformation  (at least for now)
       // however, such queries can still be inferred
       it('element reference is ambiguous', () => {
-        let query = CQL`SELECT from bookshop.Books, bookshop.Authors { ID }`
+        let query = cds.ql`SELECT from bookshop.Books, bookshop.Authors { ID }`
         expect(() => _inferred(query)).to.throw(/ambiguous reference to "ID", write "Books.ID", "Authors.ID" instead/)
       })
 
       it('table alias is ambiguous', () => {
-        let query = CQL`SELECT from bookshop.Books, bookshop.Books { * }`
+        let query = cds.ql`SELECT from bookshop.Books, bookshop.Books { * }`
         expect(() => _inferred(query)).to.throw(/Duplicate alias "Books"/)
       })
 
       it('table alias via association is ambiguous', () => {
-        let query = CQL`SELECT from bookshop.Books:author join bookshop.Books:author on 1 = 1 { * }`
+        let query = cds.ql`SELECT from bookshop.Books:author join bookshop.Books:author on 1 = 1 { * }`
         expect(() => _inferred(query)).to.throw(/Duplicate alias "author"/)
       })
 
       it('wildcard (no projection) is ambiguous', () => {
-        let query = CQL`SELECT from bookshop.Books, bookshop.Foo`
+        let query = cds.ql`SELECT from bookshop.Books, bookshop.Foo`
         expect(() => _inferred(query)).to.throw(/select "ID" explicitly with "Books.ID", "Foo.ID"/)
       })
 
       it('wildcard (*) is ambiguous', () => {
-        let query = CQL`SELECT from bookshop.Books, bookshop.Authors { * }`
+        let query = cds.ql`SELECT from bookshop.Books, bookshop.Authors { * }`
         expect(() => _inferred(query)).to.throw(
           `Ambiguous wildcard elements:
        select "createdAt" explicitly with "Books.createdAt", "Authors.createdAt"
@@ -217,7 +217,7 @@ describe('negative', () => {
       })
 
       it('wildcard (*) is ambiguous with subqueries', () => {
-        let query = CQL`SELECT from (select from bookshop.Books) as BooksSub, bookshop.Authors { * }`
+        let query = cds.ql`SELECT from (select from bookshop.Books) as BooksSub, bookshop.Authors { * }`
         expect(() => _inferred(query)).to.throw(
           `Ambiguous wildcard elements:
        select "createdAt" explicitly with "BooksSub.createdAt", "Authors.createdAt"
@@ -236,7 +236,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author,
         $self.author.name
       }`,
@@ -249,7 +249,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author
       } order by $self.author.name`,
           model,
@@ -261,7 +261,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author
       } group by $self.author.name`,
           model,
@@ -273,7 +273,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author
       } where $self.author.name = 'King'`,
           model,
@@ -285,7 +285,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, name ]'
       expect(() =>
         _inferred(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author,
         'bar' + $self.author.name as barAuthor
       }`,
@@ -298,7 +298,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, dedication, addressee, ID ]'
       expect(() =>
         _inferred(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         dedication,
         $self.dedication.addressee.ID
       }`,
@@ -310,7 +310,7 @@ describe('negative', () => {
       const errorMessage = `Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author, ID ]`
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author,
         $self.author[ID = 42].ID as a
       }`,
@@ -323,7 +323,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author ]'
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author,
         $self.author.{name}
       }`,
@@ -336,7 +336,7 @@ describe('negative', () => {
         'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author ]'
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Books{
+          cds.ql`SELECT from bookshop.Books{
         author,
         $self.author {name}
       }`,
@@ -348,13 +348,13 @@ describe('negative', () => {
 
   describe('restrictions', () => {
     it('UNION queries are not supported', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.Books union all select from bookshop.Authors`)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.Books union all select from bookshop.Authors`)).to.throw(
         /”UNION” based queries are not supported/,
       )
     })
 
     it('selecting from structures is not supported', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.Books:dedication.addressee.address`, model)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.Books:dedication.addressee.address`, model)).to.throw(
         /Query source must be a an entity or an association/,
       )
     })
@@ -364,30 +364,30 @@ describe('negative', () => {
       // in case of nested subqueries
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Books { ID, (SELECT from bookshop.Authors { ID } where name = title) as foo }`,
+          cds.ql`SELECT from bookshop.Books { ID, (SELECT from bookshop.Authors { ID } where name = title) as foo }`,
           model,
         ),
       ).to.throw(/"title" not found in the elements of "bookshop.Authors"/)
     })
 
     it('expand on `.items` not possible', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name, emails { address } }`, model)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.SoccerPlayers { name, emails { address } }`, model)).to.throw(
         'Unexpected “expand” on “emails”; can only be used after a reference to a structure, association or table alias',
       )
     })
     it('expand on scalar not possible', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name { address } }`, model)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.SoccerPlayers { name { address } }`, model)).to.throw(
         'Unexpected “expand” on “name”; can only be used after a reference to a structure, association or table alias',
       )
     })
 
     it('inline on `.items` not possible', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name, emails.{ address } }`, model)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.SoccerPlayers { name, emails.{ address } }`, model)).to.throw(
         'Unexpected “inline” on “emails”; can only be used after a reference to a structure, association or table alias',
       )
     })
     it('inline on scalar not possible', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.SoccerPlayers { name.{ address } }`, model)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.SoccerPlayers { name.{ address } }`, model)).to.throw(
         'Unexpected “inline” on “name”; can only be used after a reference to a structure, association or table alias',
       )
     })
@@ -395,24 +395,24 @@ describe('negative', () => {
 
   describe('infix filters', () => {
     it('rejects non fk traversal in infix filter in from', () => {
-      expect(() => _inferred(CQL`SELECT from bookshop.Books[author.name = 'Kurt']`, model)).to.throw(
+      expect(() => _inferred(cds.ql`SELECT from bookshop.Books[author.name = 'Kurt']`, model)).to.throw(
         /Only foreign keys of “author” can be accessed in infix filter, but found “name”/,
       )
     })
     it('does not reject non fk traversal in infix filter in where exists', () => {
-      let query = CQL`SELECT from bookshop.Books where exists author.books[author.name = 'John Doe']`
+      let query = cds.ql`SELECT from bookshop.Books where exists author.books[author.name = 'John Doe']`
       expect(() => _inferred(query)).to.not.throw(
         /Only foreign keys of “author” can be accessed in infix filter, but found “name”/,
       )
     })
     it('rejects non fk traversal in infix filter in where', () => {
-      let query = CQL`SELECT from bookshop.Books where author.books[author.name = 'John Doe'].title = 'foo'`
+      let query = cds.ql`SELECT from bookshop.Books where author.books[author.name = 'John Doe'].title = 'foo'`
       expect(() => _inferred(query)).to.throw(
         /Only foreign keys of “author” can be accessed in infix filter, but found “name”/,
       )
     })
     it('does not reject unmanaged traversal in infix filter in where exists', () => {
-      let query = CQL`SELECT from bookshop.Books where exists author.books[coAuthorUnmanaged.name = 'John Doe']`
+      let query = cds.ql`SELECT from bookshop.Books where exists author.books[coAuthorUnmanaged.name = 'John Doe']`
       expect(() => _inferred(query)).to.not.throw(
         /Unexpected unmanaged association “coAuthorUnmanaged” in filter expression of “books”/,
       )
@@ -421,7 +421,7 @@ describe('negative', () => {
     it('rejects non fk traversal in infix filter in column', () => {
       expect(() =>
         _inferred(
-          CQL`SELECT from bookshop.Authors {
+          cds.ql`SELECT from bookshop.Authors {
         books[author.name = 'Kurt'].ID as kurtsBooks
       }`,
           model,
@@ -432,7 +432,7 @@ describe('negative', () => {
 
   describe('order by', () => {
     it('reject join relevant path via queries own columns', () => {
-      let query = CQL`SELECT from bookshop.Books  {
+      let query = cds.ql`SELECT from bookshop.Books  {
         ID,
         author,
         coAuthor as co

--- a/db-service/test/cds-infer/nested-projections.test.js
+++ b/db-service/test/cds-infer/nested-projections.test.js
@@ -16,7 +16,7 @@ describe('nested projections', () => {
 
     describe('structs', () => {
       it('simple element access', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, dedication { text } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, dedication { text } }`
         let inferred = _inferred(query)
         let { Books } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -29,7 +29,7 @@ describe('nested projections', () => {
         })
       })
       it('wildcard access in structs', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, dedication { * } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, dedication { * } }`
         let inferred = _inferred(query)
         let { Books } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -40,7 +40,7 @@ describe('nested projections', () => {
         })
       })
       it('respect alias of element in expand, combined with wildcard', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, dedication { dedication as foo, * } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, dedication { dedication as foo, * } }`
         let inferred = _inferred(query)
         let { Books } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -55,7 +55,7 @@ describe('nested projections', () => {
       })
 
       it('explicit column and wildcard do not clash - explicit first', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, dedication { dedication, * } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, dedication { dedication, * } }`
         let inferred = _inferred(query)
         let { Books } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -72,7 +72,7 @@ describe('nested projections', () => {
       })
 
       it('wildcard first, explicit follows with alias', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, dedication { *, dedication as foo } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, dedication { *, dedication as foo } }`
         let inferred = _inferred(query)
         let { Books } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -89,7 +89,7 @@ describe('nested projections', () => {
 
     describe('associations', () => {
       it('expand assocs via *', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, author { * } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, author { * } }`
         let inferred = _inferred(query)
         let { Books, Authors } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -100,7 +100,7 @@ describe('nested projections', () => {
         })
       })
       it('supports nested projections for assocs with a * (2)', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, author { ID as baz, * } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, author { ID as baz, * } }`
         let inferred = _inferred(query)
         let { Books, Authors } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -111,7 +111,7 @@ describe('nested projections', () => {
         })
       })
       it('supports nested projections for assocs with a * and respects column alias', () => {
-        let query = CQL`SELECT from bookshop.Books { ID, author as BUBU { ID as baz, * } }`
+        let query = cds.ql`SELECT from bookshop.Books { ID, author as BUBU { ID as baz, * } }`
         let inferred = _inferred(query)
         let { Books, Authors } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -122,7 +122,7 @@ describe('nested projections', () => {
         })
       })
       it('deeply nested ', () => {
-        let query = CQL`SELECT from bookshop.Authors { books { author { name } } }`
+        let query = cds.ql`SELECT from bookshop.Authors { books { author { name } } }`
         let inferred = _inferred(query)
         let { Authors } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -140,7 +140,7 @@ describe('nested projections', () => {
         })
       })
       it('to many', () => {
-        let query = CQL`SELECT from bookshop.Authors { books { title } }`
+        let query = cds.ql`SELECT from bookshop.Authors { books { title } }`
         let inferred = _inferred(query)
         let { Authors } = model.entities
         expect(inferred.elements).to.deep.equal({
@@ -157,7 +157,7 @@ describe('nested projections', () => {
 
     describe('anonymous', () => {
       it('scalar elements', () => {
-        const q = CQL`SELECT from bookshop.Books {
+        const q = cds.ql`SELECT from bookshop.Books {
           ID,
           {
             title,
@@ -178,7 +178,7 @@ describe('nested projections', () => {
           })
       })
       it('wildcard expand with explicit table alias', () => {
-        const q = CQL`SELECT from bookshop.Books {
+        const q = cds.ql`SELECT from bookshop.Books {
           Books { *, 'overwrite ID' as ID }
         }`
         let { Books } = model.entities
@@ -192,7 +192,7 @@ describe('nested projections', () => {
           })
       })
       it('wildcard expand without explicit table alias', () => {
-        const q = CQL`SELECT from bookshop.Books {
+        const q = cds.ql`SELECT from bookshop.Books {
           { *, 'overwrite ID' as ID } as FOO
         }`
         let { Books } = model.entities
@@ -215,13 +215,13 @@ describe('nested projections', () => {
     })
 
     it('prefix notation equivalent to structured access', () => {
-      let queryInlineNotation = CQL`select from Employee {
+      let queryInlineNotation = cds.ql`select from Employee {
         office.{
           floor,
           room
         }
       }`
-      let queryStructuredAccess = CQL`select from Employee {
+      let queryStructuredAccess = cds.ql`select from Employee {
         office.floor,
         office.room
       }`
@@ -234,7 +234,7 @@ describe('nested projections', () => {
       })
     })
     it('mixed with expand', () => {
-      let queryInlineNotation = CQL`select from Employee {
+      let queryInlineNotation = cds.ql`select from Employee {
             office {
               floor,
               address.{
@@ -243,7 +243,7 @@ describe('nested projections', () => {
               }
             }
       }`
-      let variantWithoutInline = CQL`select from Employee {
+      let variantWithoutInline = cds.ql`select from Employee {
         office {
           floor,
           address.city,
@@ -266,7 +266,7 @@ describe('nested projections', () => {
         })
     })
     it('deep inline', () => {
-      let queryInlineNotation = CQL`select from Employee {
+      let queryInlineNotation = cds.ql`select from Employee {
         office.{
           floor,
           address.{
@@ -276,7 +276,7 @@ describe('nested projections', () => {
           }
         }
       }`
-      let variantWithoutInline = CQL`select from Employee {
+      let variantWithoutInline = cds.ql`select from Employee {
         office.floor,
         office.address.city,
         office.address.street,
@@ -294,7 +294,7 @@ describe('nested projections', () => {
     })
     it('deep expand in inline', () => {
       // revisit: naming
-      let queryInlineNotation = CQL`select from Employee {
+      let queryInlineNotation = cds.ql`select from Employee {
         office.{
           floor,
           address {
@@ -303,7 +303,7 @@ describe('nested projections', () => {
           }
         }
       }`
-      let variantWithoutInline = CQL`select from Employee {
+      let variantWithoutInline = cds.ql`select from Employee {
         office.floor,
         office.address {
             city,
@@ -326,10 +326,10 @@ describe('nested projections', () => {
         })
     })
     it('wildcard inline toplevel', () => {
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged {
         office.{ * }
       }`
-      let inlineExplicit = CQL`select from EmployeeNoUnmanaged {
+      let inlineExplicit = cds.ql`select from EmployeeNoUnmanaged {
         office.{
           floor,
           room,
@@ -338,7 +338,7 @@ describe('nested projections', () => {
           furniture
         }
       }`
-      let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+      let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
         office.floor,
         office.room,
         office.building,
@@ -365,10 +365,10 @@ describe('nested projections', () => {
         })
     })
     it('wildcard inline deep w/o brackets', () => {
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged {
         office.{ address.* }
       }`
-      let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+      let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
         office.address.city,
         office.address.street,
         office.address.country,
@@ -384,10 +384,10 @@ describe('nested projections', () => {
     })
     it('smart wildcard - column overwrite after *', () => {
       // office.address.city replaces office.floor
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged {
         office.{ *, address.city as floor }
       }`
-      let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+      let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
         office.address.city as office_floor,
         office.room,
         office.building,
@@ -413,10 +413,10 @@ describe('nested projections', () => {
     })
     it('smart wildcard - column overwrite before *', () => {
       // office.furniture.chairs replaces office.furniture
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged {
         office.{'skip' as building, furniture.chairs as furniture, *, 'replace' as floor}
       }`
-      let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+      let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
         'skip' as office_building,
         office.furniture.chairs as office_furniture,
         'replace' as office_floor,
@@ -444,7 +444,7 @@ describe('nested projections', () => {
 
     it('smart wildcard only works in local scope', () => {
       // duplicate error, as * already contains a field "office_address"
-      let queryInlineNotation = CQL`select from Employee {
+      let queryInlineNotation = cds.ql`select from Employee {
         office.*,
         office.address.city as office_address
       }`
@@ -452,10 +452,10 @@ describe('nested projections', () => {
     })
 
     it('wildcard - excluding elements from inline', () => {
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged {
         office.{*} excluding { building, address }
       }`
-      let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+      let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
         office.floor,
         office.room,
         office.furniture
@@ -470,13 +470,13 @@ describe('nested projections', () => {
       })
     })
     it('wildcard - sql style on table alias', () => {
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged as E {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged as E {
         E.{*}
       }`
-      let queryInlineNotationWithoutBrackets = CQL`select from EmployeeNoUnmanaged as E {
+      let queryInlineNotationWithoutBrackets = cds.ql`select from EmployeeNoUnmanaged as E {
         E.*
       }`
-      let regularWildcard = CQL`select from EmployeeNoUnmanaged as E{
+      let regularWildcard = cds.ql`select from EmployeeNoUnmanaged as E{
         *
       }`
       let inferredWithoutBrackets = _inferred(queryInlineNotation)
@@ -489,10 +489,10 @@ describe('nested projections', () => {
         .to.deep.equal(EmployeeNoUnmanaged.elements)
     })
     it('wildcard - sql style on table alias with excluding', () => {
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged as E {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged as E {
         E.{ *, office.room as office } excluding { department }
       }`
-      let regularWildcard = CQL`select from EmployeeNoUnmanaged as E{
+      let regularWildcard = cds.ql`select from EmployeeNoUnmanaged as E{
         *,
         office.room as office
       } excluding { department }`
@@ -508,7 +508,7 @@ describe('nested projections', () => {
     })
 
     it('wildcard - sql style on table alias with excluding and hand written joins', () => {
-      let queryInlineNotation = CQL`select from EmployeeNoUnmanaged as E join Department as D on E.department.id = D.id {
+      let queryInlineNotation = cds.ql`select from EmployeeNoUnmanaged as E join Department as D on E.department.id = D.id {
         E.{ *, office.room as office } excluding { department },
         D.name as depName
       }`

--- a/db-service/test/cds-infer/source.test.js
+++ b/db-service/test/cds-infer/source.test.js
@@ -15,7 +15,7 @@ describe('simple', () => {
   })
 
   it('infer single source', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, author }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, author }`
     let inferred = _inferred(query)
     expect(inferred).to.deep.equal(query)
     expect(inferred).to.have.property('target')
@@ -47,7 +47,7 @@ describe('scoped queries', () => {
   })
 
   it('select from association', () => {
-    let query = CQL`SELECT from bookshop.Books:author { ID }`
+    let query = cds.ql`SELECT from bookshop.Books:author { ID }`
     let inferred = _inferred(query)
 
     let { Authors } = model.entities
@@ -58,13 +58,13 @@ describe('scoped queries', () => {
     expect(Object.keys(inferred.elements)).to.have.lengthOf(query.SELECT.columns.length)
   })
   it('navigate along multiple assocs', () => {
-    let query = CQL`SELECT from bookshop.Books:author.books`
+    let query = cds.ql`SELECT from bookshop.Books:author.books`
     let inferred = _inferred(query)
     let { Books } = model.entities
     expect(inferred.sources).to.have.nested.property('books.definition', Books)
   })
   it('multiple assocs with filter', () => {
-    let query = CQL`SELECT from bookshop.Books[201]:author[111].books`
+    let query = cds.ql`SELECT from bookshop.Books[201]:author[111].books`
     let inferred = _inferred(query)
     let { Books } = model.entities
     expect(inferred.sources).to.have.nested.property('books.definition', Books)
@@ -77,7 +77,7 @@ describe('subqueries', () => {
   })
 
   it('subquery in from', () => {
-    let query = CQL`SELECT from (select from bookshop.Books { ID as barID }) as Bar { barID }`
+    let query = cds.ql`SELECT from (select from bookshop.Books { ID as barID }) as Bar { barID }`
     let inferred = _inferred(query)
 
     let { Books } = model.entities
@@ -89,7 +89,7 @@ describe('subqueries', () => {
   })
 
   it('subquery in from with wildcard', () => {
-    let query = CQL`SELECT from (select from bookshop.Books) as Bar { ID, author }`
+    let query = cds.ql`SELECT from (select from bookshop.Books) as Bar { ID, author }`
     let inferred = _inferred(query)
 
     let { Books } = model.entities
@@ -108,7 +108,7 @@ describe('multiple sources', () => {
     model = cds.model = await await cds.load(__dirname + '/../bookshop/db/schema').then(cds.linked)
   })
   it('infers multiple table aliases as the queries source with a simple cross join', () => {
-    let inferred = _inferred(CQL`
+    let inferred = _inferred(cds.ql`
     SELECT from bookshop.Books:author as A, bookshop.Books {
       A.ID as aID,
       Books.ID as bID,
@@ -126,7 +126,7 @@ describe('multiple sources', () => {
   })
 
   it('infers multiple table aliases as the queries source with a nested join', () => {
-    let inferred = _inferred(CQL`
+    let inferred = _inferred(cds.ql`
     SELECT from bookshop.Books:author as Authors join bookshop.Books on 1 = 1 join bookshop.Foo on 1 = 1 {
       Authors.ID as aID,
       Books.ID as bID,
@@ -142,7 +142,7 @@ describe('multiple sources', () => {
   })
 
   it('infers multiple table aliases for the same query source if aliases differ', () => {
-    let inferred = _inferred(CQL`
+    let inferred = _inferred(cds.ql`
     SELECT from bookshop.Books as firstBook, bookshop.Books as secondBook {
       firstBook.ID as firstBookID,
       secondBook.ID as secondBookID

--- a/db-service/test/cqn4sql/API.test.js
+++ b/db-service/test/cqn4sql/API.test.js
@@ -14,16 +14,16 @@ describe('Repetitive calls to cqn4sql must work', () => {
   })
 
   it('query can be extended by another element', () => {
-    const original = CQL`SELECT from bookshop.Books { ID }`
+    const original = cds.ql`SELECT from bookshop.Books { ID }`
     let query = cqn4sql(original, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }`)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }`)
     original.SELECT.columns.push({ ref: ['title'] })
     query = cqn4sql(original, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID, Books.title }`)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.title }`)
     original.SELECT.where = ['exists', { ref: ['author'] }]
     query = cqn4sql(original, model)
     expect(query).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books
       { Books.ID, Books.title }
       WHERE EXISTS (
@@ -34,18 +34,18 @@ describe('Repetitive calls to cqn4sql must work', () => {
   })
 
   it('accepts empty select list', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { }`)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { }`)
   })
 
   it('yields the same result if same query is transformed multiple times', () => {
-    const input = CQL`SELECT from bookshop.Books:author`
+    const input = cds.ql`SELECT from bookshop.Books:author`
     let query = cqn4sql(input, model)
     let query2 = cqn4sql(input, model)
     expect(query).to.deep.equal(query2)
   })
   it('yields the same result if same query is transformed multiple times (2)', () => {
-    const input = CQL`SELECT from bookshop.Books where author.name like '%Poe'`
+    const input = cds.ql`SELECT from bookshop.Books where author.name like '%Poe'`
     let query = cqn4sql(input, model)
     let query2 = cqn4sql(input, model)
     expect(query2).to.deep.equal(query)

--- a/db-service/test/cqn4sql/DELETE.test.js
+++ b/db-service/test/cqn4sql/DELETE.test.js
@@ -77,7 +77,7 @@ describe('DELETE', () => {
     const query = cqn4sql(d, forNodeModel)
 
     // this is the final exists subquery
-    const subquery = CQL`
+    const subquery = cds.ql`
      SELECT author.ID from bookshop.Authors as author
       left join bookshop.Books as books on books.author_ID = author.ID
      where exists (

--- a/db-service/test/cqn4sql/UPDATE.test.js
+++ b/db-service/test/cqn4sql/UPDATE.test.js
@@ -81,7 +81,7 @@ describe('UPDATE', () => {
     expected.UPDATE.where = [
       { list: [{ ref: ['Books2', 'ID'] }] },
       'in',
-      CQL`
+      cds.ql`
             (SELECT Books.ID from bookshop.Books as Books
               left join bookshop.Authors as author on author.ID = Books.author_ID
               where author.name LIKE '%Bron%' or ( author.name LIKE '%King' and Books.title = 'The Dark Tower') and Books.stock >= 15
@@ -105,7 +105,7 @@ describe('UPDATE', () => {
     expected.UPDATE.where = [
       { list: [{ ref: ['Authors2', 'ID'] }] },
       'in',
-      CQL`
+      cds.ql`
       (SELECT Authors.ID from bookshop.Authors as Authors
                 left join bookshop.Books as books on books.author_ID = Authors.ID
                 where books.title LIKE '%Heights%'
@@ -186,7 +186,7 @@ describe('UPDATE with path expression', () => {
     expected.UPDATE.where = [
       { list: [{ ref: ['Books2', 'ID'] }] },
       'in',
-      CQL`
+      cds.ql`
             (SELECT Books.ID from bookshop.CatalogService.Books as Books
               left join bookshop.CatalogService.Authors as author on author.ID = Books.author_ID
               where author.name LIKE '%Bron%'

--- a/db-service/test/cqn4sql/assocs2joins.test.js
+++ b/db-service/test/cqn4sql/assocs2joins.test.js
@@ -15,8 +15,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // (SMW) need to decide: which fields to put on lhs of ON and which on right?
   // this test assumes that the "target" fields come on lhs
   it('in select, one assoc, one field', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, author.name }`, model)
-    const expected = CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author.name }`, model)
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID, author.name as author_name }
       `
@@ -24,8 +24,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   })
 
   it('in select, one deep assoc, with filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, dedication.addressee[name = 'Hasso'].name }`, model)
-    const expected = CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, dedication.addressee[name = 'Hasso'].name }`, model)
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Person as addressee on addressee.ID = Books.dedication_addressee_ID and addressee.name = 'Hasso'
         { Books.ID, addressee.name as dedication_addressee_name }
       `
@@ -33,24 +33,24 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   })
 
   it('in select, two assocs, second navigates to foreign key', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID, books.genre.ID }`, model)
-    const expected = CQL`SELECT from bookshop.Authors as Authors
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID, books.genre.ID }`, model)
+    const expected = cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID
         { Authors.ID, books.genre_ID as books_genre_ID }
       `
     expect(query).to.deep.equal(expected)
   })
   it('in select, two assocs, second shortcuts to foreign key', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID, books.genre }`, model)
-    const expected = CQL`SELECT from bookshop.Authors as Authors
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID, books.genre }`, model)
+    const expected = cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID
         { Authors.ID, books.genre_ID as books_genre_ID }
       `
     expect(query).to.deep.equal(expected)
   })
   it('in select, three assocs, last navigates to foreign key', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID, books.genre.parent.ID as foo }`, model)
-    const expected = CQL`SELECT from bookshop.Authors as Authors
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID, books.genre.parent.ID as foo }`, model)
+    const expected = cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID
         { Authors.ID, genre.parent_ID as foo }
@@ -58,8 +58,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
     expect(query).to.deep.equal(expected)
   })
   it('in select, two assocs, last shortcuts to structured foreign key', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Intermediate { ID, toAssocWithStructuredKey.toStructuredKey }`, model)
-    const expected = CQL`SELECT from bookshop.Intermediate as Intermediate
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Intermediate { ID, toAssocWithStructuredKey.toStructuredKey }`, model)
+    const expected = cds.ql`SELECT from bookshop.Intermediate as Intermediate
         left outer join bookshop.AssocWithStructuredKey as toAssocWithStructuredKey on toAssocWithStructuredKey.ID = Intermediate.toAssocWithStructuredKey_ID
         { Intermediate.ID,
           toAssocWithStructuredKey.toStructuredKey_struct_mid_leaf as toAssocWithStructuredKey_toStructuredKey_struct_mid_leaf,
@@ -70,8 +70,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
     expect(query).to.deep.equal(expected)
   })
   it('in select, one assoc, structured access', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.EStrucSibling { ID, self.struc1 }`, model)
-    const expected = CQL`SELECT from bookshop.EStrucSibling as EStrucSibling
+    let query = cqn4sql(cds.ql`SELECT from bookshop.EStrucSibling { ID, self.struc1 }`, model)
+    const expected = cds.ql`SELECT from bookshop.EStrucSibling as EStrucSibling
         left outer join bookshop.EStrucSibling as self on self.ID = EStrucSibling.self_ID
         {
           EStrucSibling.ID,
@@ -84,8 +84,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   // same assoc used twice -> only one JOIN
   it('in select, two paths, same assoc', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, author.name, author.dateOfBirth }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author.name, author.dateOfBirth }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID, author.name as author_name, author.dateOfBirth as author_dateOfBirth }
       `)
@@ -93,8 +93,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   // same assoc used twice -> only one JOIN
   it('in select, path with assoc.struct', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, author.name, author.address.street }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author.name, author.address.street }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID, author.name as author_name, author.address_street as author_address_street }
       `)
@@ -102,8 +102,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   // same assoc used twice -> only one JOIN
   it('in select, path with assoc.struc, with explicit table alias', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books as B { ID, author.name, B.author.address.street }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as B
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books as B { ID, author.name, B.author.address.street }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as B
         left outer join bookshop.Authors as author on author.ID = B.author_ID
         { B.ID, author.name as author_name, author.address_street as author_address_street }
       `)
@@ -112,8 +112,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // assoc inside struc
   // -> to be clarified: what should be the table alias?
   it('in select, path with struct.assoc', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, dedication.addressee.name }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, dedication.addressee.name }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Person as addressee on addressee.ID = Books.dedication_addressee_ID
         { Books.ID, addressee.name as dedication_addressee_name }
       `)
@@ -122,7 +122,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // order of select items should stay untouched, no matter what path they follow
   it('in select, path with two assocs', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors {
+      cds.ql`SELECT from bookshop.Authors {
               name,
               books.genre.descr,
               books.title as books_title,
@@ -130,7 +130,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
             }`,
       model,
     )
-    const expected = CQL`SELECT from bookshop.Authors as Authors
+    const expected = cds.ql`SELECT from bookshop.Authors as Authors
       left outer join bookshop.Books as books on books.author_ID = Authors.ID
       left outer join bookshop.Genres as genre on genre.ID = books.genre_ID
       { Authors.name,
@@ -145,7 +145,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, path with two assocs / respect explicit column alias', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors {
+      cds.ql`SELECT from bookshop.Authors {
               name,
               books.genre.descr as foo,
               books.title as books_title,
@@ -153,7 +153,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
             }`,
       model,
     )
-    const expected = CQL`SELECT from bookshop.Authors as Authors
+    const expected = cds.ql`SELECT from bookshop.Authors as Authors
       left outer join bookshop.Books as books on books.author_ID = Authors.ID
       left outer join bookshop.Genres as genre on genre.ID = books.genre_ID
       { Authors.name,
@@ -168,10 +168,10 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, unrelated paths', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { ID, author.name, genre.descr, dedication.addressee.name, author.dateOfBirth }`,
+      cds.ql`SELECT from bookshop.Books { ID, author.name, genre.descr, dedication.addressee.name, author.dateOfBirth }`,
       model,
     )
-    let expected = CQL`SELECT from bookshop.Books as Books
+    let expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       left outer join bookshop.Genres as genre on genre.ID = Books.genre_ID
       left outer join bookshop.Person as addressee on addressee.ID = Books.dedication_addressee_ID
@@ -186,8 +186,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   // 2 different assocs lead to 2 JOINs, even if they have same target
   it('in select, different assocs with same target', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, author.name, coAuthor.name }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author.name, coAuthor.name }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         left outer join bookshop.Authors as coAuthor on coAuthor.ID = Books.coAuthor_ID
         { Books.ID, author.name as author_name, coAuthor.name as coAuthor_name }
@@ -196,11 +196,11 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, paths with common prefix path', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors {
+      cds.ql`SELECT from bookshop.Authors {
         name, books.genre.descr, books.coAuthor.name, books.genre.code, books.coAuthor.dateOfBirth }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID
         left outer join bookshop.Authors as coAuthor on coAuthor.ID = books.coAuthor_ID
@@ -215,7 +215,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, following recursive assoc', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
         title,
         genre.descr,
         genre.parent.descr,
@@ -225,7 +225,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
       }`,
       model,
     )
-    const expected = CQL`SELECT from bookshop.Books as Books
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Genres as genre on genre.ID = Books.genre_ID
         left outer join bookshop.Genres as parent on parent.ID = genre.parent_ID
         left outer join bookshop.Genres as parent2 on parent2.ID = parent.parent_ID
@@ -242,13 +242,13 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   })
   it('in select, following recursive assoc with same name as table alias', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Genres as parent {
+      cds.ql`SELECT from bookshop.Genres as parent {
         parent.parent.parent.descr
       }`,
       model,
     )
 
-    const expected = CQL`SELECT from bookshop.Genres as parent
+    const expected = cds.ql`SELECT from bookshop.Genres as parent
         left outer join bookshop.Genres as parent2 on parent2.ID = parent.parent_ID
         left outer join bookshop.Genres as parent3 on parent3.ID = parent2.parent_ID
         {
@@ -259,8 +259,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   })
 
   it('in select, follow managed assoc, select FK', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { author.ID }`, model)
-    const expected = CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { author.ID }`, model)
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         {
           Books.author_ID
         }
@@ -271,8 +271,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // TODO (SMW) decide: if we generate a join, should we then take the FK from source or from target?
   //                    currently we take it from the source
   it('in select, follow managed assoc, select FK and other field', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { author.ID, author.name }`, model)
-    const expected = CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { author.ID, author.name }`, model)
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         {
           Books.author_ID,
@@ -283,24 +283,24 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   })
 
   it('in where, one assoc, one field', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where author.name = 'Schiller'`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where author.name = 'Schiller'`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID } WHERE author.name = 'Schiller'
       `)
   })
 
   it('in where, one assoc, one field (2)', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where author.name like 'Schiller'`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where author.name like 'Schiller'`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID } WHERE author.name like 'Schiller'
       `)
   })
 
   it('in where, one assoc in xpr, one field', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where ((author.name + 's') = 'Schillers')`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where ((author.name + 's') = 'Schillers')`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID } WHERE ((author.name + 's') = 'Schillers')
       `)
@@ -308,33 +308,33 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in where, one assoc in multiple xpr, one field', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { ID } where ((author.name + 's') = 'Schillers') or ((author.name + 's') = 'Goethes')`,
+      cds.ql`SELECT from bookshop.Books { ID } where ((author.name + 's') = 'Schillers') or ((author.name + 's') = 'Goethes')`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID } WHERE ((author.name + 's') = 'Schillers') or ((author.name + 's') = 'Goethes')
       `)
   })
 
   it('list in where', () => {
-    let query = CQL`SELECT from bookshop.Books { ID } where (author.name, 1) in ('foo', 'bar')`
-    let expected = CQL`SELECT from bookshop.Books as Books
+    let query = cds.ql`SELECT from bookshop.Books { ID } where (author.name, 1) in ('foo', 'bar')`
+    let expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       { Books.ID }where (author.name, 1) in ('foo', 'bar')`
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('tuple list in where', () => {
-    let query = CQL`SELECT from bookshop.Books { ID } where ((author.name, genre.name), 1) in (('foo', 1), ('bar', 2))`
-    let expected = CQL`SELECT from bookshop.Books as Books
+    let query = cds.ql`SELECT from bookshop.Books { ID } where ((author.name, genre.name), 1) in (('foo', 1), ('bar', 2))`
+    let expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       left outer join bookshop.Genres as genre on genre.ID = Books.genre_ID
       { Books.ID }where ((author.name, genre.name), 1) in (('foo', 1), ('bar', 2))`
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('list in having', () => {
-    let query = CQL`SELECT from bookshop.Books { ID } having (author.name, 1) in ('foo', 'bar')`
-    let expected = CQL`SELECT from bookshop.Books as Books
+    let query = cds.ql`SELECT from bookshop.Books { ID } having (author.name, 1) in ('foo', 'bar')`
+    let expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       { Books.ID } having (author.name, 1) in ('foo', 'bar')`
     expect(cqn4sql(query, model)).to.deep.equal(expected)
@@ -342,10 +342,10 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select & where, same assoc', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { ID, author.name } where author.placeOfBirth = 'Marbach'`,
+      cds.ql`SELECT from bookshop.Books { ID, author.name } where author.placeOfBirth = 'Marbach'`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID, author.name as author_name } WHERE author.placeOfBirth = 'Marbach'
       `)
@@ -357,23 +357,23 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   // filters are not part of the implicit alias generated for the result columns
   it('in select, assoc with filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, author[placeOfBirth='Marbach'].name }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author[placeOfBirth='Marbach'].name }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID AND author.placeOfBirth = 'Marbach'
         { Books.ID, author.name as author_name }
       `)
   })
 
   it('in select, assoc with filter - no special handling for FK access in filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, author[ID=2].name }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author[ID=2].name }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID AND author.ID = 2
         { Books.ID, author.name as author_name }
       `)
   })
 
   it('in select, same field with different filters requires alias', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author[ID=1].name, author[ID=2].name }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author[ID=1].name, author[ID=2].name }`, model)).to.throw(
       /Duplicate definition of element “author_name”/,
     )
   })
@@ -381,10 +381,10 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // TODO (SMW) new test
   it('in select, assoc with filter using OR', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { ID, author[placeOfBirth='Marbach' OR placeOfDeath='Marbach'].name }`,
+      cds.ql`SELECT from bookshop.Books { ID, author[placeOfBirth='Marbach' OR placeOfDeath='Marbach'].name }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
                                                   AND (author.placeOfBirth = 'Marbach' OR author.placeOfDeath = 'Marbach')
         { Books.ID, author.name as author_name }
@@ -394,8 +394,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // TODO (SMW) new test
   // if FK field is accessed with filter, a JOIN is generated and the FK must be fetched from the association target
   it('in select, access to FK field with filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { title, author[name='Mr. X' or name = 'Mr. Y'].ID }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { title, author[name='Mr. X' or name = 'Mr. Y'].ID }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID AND (author.name='Mr. X' or author.name = 'Mr. Y')
         { Books.title, author.ID as author_ID }
       `)
@@ -403,14 +403,14 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select + having, assoc with filter is always join relevant', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
         ID,
         author[placeOfBirth='Marbach'].ID as aID1,
       } having author[placeOfBirth='Foobach'].ID and genre[parent.ID='fiction'].ID`,
       model,
     )
 
-    const expected = CQL`SELECT from bookshop.Books as Books
+    const expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID AND author.placeOfBirth = 'Marbach'
       left outer join bookshop.Authors as author2 on author2.ID = Books.author_ID AND author2.placeOfBirth = 'Foobach'
       left outer join bookshop.Genres as genre on genre.ID = Books.genre_ID AND genre.parent_ID = 'fiction'
@@ -425,14 +425,14 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // same assoc with and without filter -> 2 joins
   it('in select, assoc with and without filter', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
         ID,
         author[placeOfBirth='Marbach'].name as n1,
         author.name as n2
       }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID AND author.placeOfBirth = 'Marbach'
         left outer join bookshop.Authors as author2 on author2.ID = Books.author_ID
         { Books.ID,
@@ -445,7 +445,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // same filter - same join
   it('in select, several assocs with filter', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books
+      cds.ql`SELECT from bookshop.Books
        { ID,
          author[placeOfBirth='Marbach'].name as n1,
          author[placeOfBirth='Erfurt'].name as n2,
@@ -454,7 +454,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID AND author.placeOfBirth = 'Marbach'
         left outer join bookshop.Authors as author2 on author2.ID = Books.author_ID AND author2.placeOfBirth = 'Erfurt'
         { Books.ID,
@@ -469,14 +469,14 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // we compare filters based on AST
   it('in select, filters with reversed conditino are not treated as equal', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books
+      cds.ql`SELECT from bookshop.Books
        { ID,
          author[placeOfBirth='Marbach'].name as n1,
          author['Marbach'=placeOfBirth].name as n2
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID AND author.placeOfBirth = 'Marbach'
         left outer join bookshop.Authors as author2 on author2.ID = Books.author_ID AND 'Marbach' = author2.placeOfBirth
         { Books.ID,
@@ -488,14 +488,14 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, two levels of assocs (1)', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          books[stock=1].genre[code='A'].descr as d1,
          books[stock=1].genre[code='A'].descr as d2
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND books.stock = 1
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID AND genre.code = 'A'
         { Authors.ID,
@@ -507,14 +507,14 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, two levels of assocs (2)', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          books[stock=1].genre[code='A'].descr as d1,
          books[stock=1].genre[code='B'].descr as d2
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND books.stock = 1
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID AND genre.code = 'A'
         left outer join bookshop.Genres as genre2 on genre2.ID = books.genre_ID AND genre2.code = 'B'
@@ -527,14 +527,14 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, two levels of assocs (3)', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          books[stock=1].genre[code='A'].descr as d1,
          books[stock=2].genre[code='A'].descr as d2
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND books.stock = 1
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID AND genre.code = 'A'
         left outer join bookshop.Books as books2 on books2.author_ID = Authors.ID AND books2.stock = 2
@@ -548,13 +548,13 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select/where, two levels of assocs', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          books[stock=1].genre[code='A'].descr
        } where books[stock=1].genre[code='B'].descr = 'foo'`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND books.stock = 1
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID AND genre.code = 'A'
         left outer join bookshop.Genres as genre2 on genre2.ID = books.genre_ID AND genre2.code = 'B'
@@ -566,7 +566,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, two levels of assocs, with case', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          case when ID<4 then books[stock=1].genre[code='A'].descr
               when ID>4 then books[stock=1].genre[code='B'].descr
@@ -574,7 +574,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND books.stock = 1
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID AND genre.code = 'A'
         left outer join bookshop.Genres as genre2 on genre2.ID = books.genre_ID AND genre2.code = 'B'
@@ -589,7 +589,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   // TODO (SMW) new test
   it('in select, two levels of assocs, with case and exists', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          case when exists books[price>10]  then books[stock=1].genre[code='A'].descr
               when exists books[price>100] then books[stock=1].genre[code='B' or code='C'].descr
@@ -597,7 +597,7 @@ describe('Unfolding Association Path Expressions to Joins', () => {
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND books.stock = 1
         left outer join bookshop.Genres as genre on genre.ID = books.genre_ID AND genre.code = 'A'
         left outer join bookshop.Genres as genre2 on genre2.ID = books.genre_ID AND (genre2.code = 'B' or genre2.code = 'C')
@@ -613,13 +613,13 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, filter with exists', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          books[exists genre[code='A']].title
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND
           exists (select 1 from bookshop.Genres as genre where genre.ID = books.genre_ID and genre.code = 'A')
         { Authors.ID,
@@ -630,13 +630,13 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select, filter (with OR needs bracelets) with exists ', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
        { ID,
          books[exists genre[code='A' or code='B']].title
        }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         left outer join bookshop.Books as books on books.author_ID = Authors.ID AND
           exists (select 1 from bookshop.Genres as genre where genre.ID = books.genre_ID and (genre.code = 'A' or genre.code = 'B'))
         { Authors.ID,
@@ -646,8 +646,8 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   })
 
   it('in having, one assoc, one field', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } having author.name = 'Schiller'`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } having author.name = 'Schiller'`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID } having author.name = 'Schiller'
       `)
@@ -655,51 +655,51 @@ describe('Unfolding Association Path Expressions to Joins', () => {
 
   it('in select & having, same assoc', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { ID, author.name } having author.placeOfBirth = 'Marbach'`,
+      cds.ql`SELECT from bookshop.Books { ID, author.name } having author.placeOfBirth = 'Marbach'`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID, author.name as author_name } having author.placeOfBirth = 'Marbach'
       `)
   })
   it('in select & having, same assoc with same filter -> only one join', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { ID, author[placeOfBirth='Marbach'].name } having author[placeOfBirth='Marbach'].name = 'King'`,
+      cds.ql`SELECT from bookshop.Books { ID, author[placeOfBirth='Marbach'].name } having author[placeOfBirth='Marbach'].name = 'King'`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID and author.placeOfBirth = 'Marbach'
         { Books.ID, author.name as author_name } having author.name = 'King'
       `)
   })
 
   it('in group by, one assoc, one field', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } group by author.name`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } group by author.name`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID } group by author.name
       `)
   })
   it('in order by, one assoc, one field', () => {
-    const input = CQL`SELECT from bookshop.Books { ID } order by author.name asc`
+    const input = cds.ql`SELECT from bookshop.Books { ID } order by author.name asc`
     let query = cqn4sql(input, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         { Books.ID } order by author.name asc
       `)
   })
   it('in order by, via wildcard', () => {
-    const input = CQL`SELECT from bookshop.Books.twin order by author.name asc`
+    const input = cds.ql`SELECT from bookshop.Books.twin order by author.name asc`
     let query = cqn4sql(input, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books.twin as twin
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books.twin as twin
         left outer join bookshop.Authors as author on author.ID = twin.author_ID
         { twin.ID, twin.author_ID, twin.stock } order by author.name asc
       `)
   })
   it('in group by, one assoc, wildcard select', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books group by author.name`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books group by author.name`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         {
         Books.createdAt,
@@ -728,10 +728,10 @@ describe('Unfolding Association Path Expressions to Joins', () => {
   it('properly rewrite association chains if intermediate assoc is not fk', () => {
     // this issue came up for ref: [genre.parent.ID] because "ID" is fk of "parent"
     // but "parent" is not fk of "genre"
-    const q = CQL`SELECT from (select genre, ID from bookshop.Books) as book {
+    const q = cds.ql`SELECT from (select genre, ID from bookshop.Books) as book {
       ID
     } group by genre.parent.ID, genre.parent.name`
-    const qx = CQL`
+    const qx = cds.ql`
     SELECT from (select Books.genre_ID, Books.ID from bookshop.Books as Books) as book
                                 left join bookshop.Genres as genre on genre.ID = book.genre_ID
                                 left join bookshop.Genres as parent on parent.ID = genre.parent_ID
@@ -753,8 +753,8 @@ describe('Variations on ON', () => {
   })
 
   it('unmanaged 1', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, coAuthorUnmanaged.name }`, model)
-    const expected = CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, coAuthorUnmanaged.name }`, model)
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as coAuthorUnmanaged
           on coAuthorUnmanaged.ID = Books.coAuthor_ID_unmanaged
         { Books.ID, coAuthorUnmanaged.name as coAuthorUnmanaged_name }
@@ -763,8 +763,8 @@ describe('Variations on ON', () => {
   })
 
   it('unmanaged 2', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz { id, parent.id as pid }`, model)
-    const expected = CQL`SELECT from bookshop.Baz as Baz
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Baz { id, parent.id as pid }`, model)
+    const expected = cds.ql`SELECT from bookshop.Baz as Baz
         left outer join bookshop.Baz as parent
           on parent.id = Baz.parent_id or parent.id > 17
         { Baz.id, parent.id as pid }
@@ -774,8 +774,8 @@ describe('Variations on ON', () => {
 
   // TODO (SMW) original ON condition must be enclosed in parens if there is a filter
   it('unmanaged 2 plus filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz { id, parent[id < 19].id as pid }`, model)
-    const expected = CQL`SELECT from bookshop.Baz as Baz
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Baz { id, parent[id < 19].id as pid }`, model)
+    const expected = cds.ql`SELECT from bookshop.Baz as Baz
         left outer join bookshop.Baz as parent
           on (parent.id = Baz.parent_id or parent.id > 17) and parent.id < 19
         { Baz.id, parent.id as pid }
@@ -784,8 +784,8 @@ describe('Variations on ON', () => {
   })
 
   it('managed complicated', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocYA.a as x }`, model)
-    const expected = CQL`SELECT from bookshop.AssocMaze1 as AM
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocYA.a as x }`, model)
+    const expected = cds.ql`SELECT from bookshop.AssocMaze1 as AM
         left outer join bookshop.AssocMaze2 as a_assocYA
           on  a_assocYA.A_1_a    = AM.a_assocYA_B_1_a
           and a_assocYA.A_1_b_ID = AM.a_assocYA_B_1_b_ID
@@ -797,8 +797,8 @@ describe('Variations on ON', () => {
   })
 
   it('managed complicated backlink', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze2 as AM { a, a_assocYA_back.ID as x }`, model)
-    const expected = CQL`SELECT from bookshop.AssocMaze2 as AM
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze2 as AM { a, a_assocYA_back.ID as x }`, model)
+    const expected = cds.ql`SELECT from bookshop.AssocMaze2 as AM
         left outer join bookshop.AssocMaze1 as a_assocYA_back
           on   a_assocYA_back.a_assocYA_B_1_a    = AM.A_1_a
           and  a_assocYA_back.a_assocYA_B_1_b_ID = AM.A_1_b_ID
@@ -810,16 +810,16 @@ describe('Variations on ON', () => {
   })
 
   it('unmanaged assoc with on condition with length === 1', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.BooksWithWeirdOnConditions { ID, onlyOneRef.foo }`, model)
-    const expected = CQL`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
+    let query = cqn4sql(cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions { ID, onlyOneRef.foo }`, model)
+    const expected = cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
         left outer join bookshop.BooksWithWeirdOnConditions as onlyOneRef on BooksWithWeirdOnConditions.ID
         { BooksWithWeirdOnConditions.ID, onlyOneRef.foo as onlyOneRef_foo }
       `
     expect(query).to.deep.equal(expected)
   })
   it('unmanaged assoc with on condition with odd length', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.BooksWithWeirdOnConditions { ID, oddNumber.foo }`, model)
-    const expected = CQL`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
+    let query = cqn4sql(cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions { ID, oddNumber.foo }`, model)
+    const expected = cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
         left outer join bookshop.BooksWithWeirdOnConditions as oddNumber on BooksWithWeirdOnConditions.foo / 5 + BooksWithWeirdOnConditions.ID = BooksWithWeirdOnConditions.ID + BooksWithWeirdOnConditions.foo
         { BooksWithWeirdOnConditions.ID, oddNumber.foo as oddNumber_foo }
       `
@@ -827,10 +827,10 @@ describe('Variations on ON', () => {
   })
   it('unmanaged assoc with on condition accessing structured foreign keys', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.BooksWithWeirdOnConditions { ID, oddNumberWithForeignKeyAccess.second }`,
+      cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions { ID, oddNumberWithForeignKeyAccess.second }`,
       model,
     )
-    const expected = CQL`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
+    const expected = cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
     left outer join bookshop.WithStructuredKey as oddNumberWithForeignKeyAccess on oddNumberWithForeignKeyAccess.struct_mid_anotherLeaf = oddNumberWithForeignKeyAccess.struct_mid_leaf / oddNumberWithForeignKeyAccess.second
     { BooksWithWeirdOnConditions.ID, oddNumberWithForeignKeyAccess.second as oddNumberWithForeignKeyAccess_second }
       `
@@ -838,10 +838,10 @@ describe('Variations on ON', () => {
   })
   it('unmanaged assoc with on condition comparing to val', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.BooksWithWeirdOnConditions { ID, refComparedToVal.refComparedToValFlipped.foo }`,
+      cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions { ID, refComparedToVal.refComparedToValFlipped.foo }`,
       model,
     )
-    const expected = CQL`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
+    const expected = cds.ql`SELECT from bookshop.BooksWithWeirdOnConditions as BooksWithWeirdOnConditions
         left outer join bookshop.BooksWithWeirdOnConditions as refComparedToVal on BooksWithWeirdOnConditions.ID != 1
         left outer join bookshop.BooksWithWeirdOnConditions as refComparedToValFlipped on 1 != refComparedToVal.ID
         { BooksWithWeirdOnConditions.ID, refComparedToValFlipped.foo as refComparedToVal_refComparedToValFlipped_foo }
@@ -850,9 +850,9 @@ describe('Variations on ON', () => {
   })
 
   it('accessing partial key after association implies join if not part of explicit FK', () => {
-    const original = CQL`SELECT from bookshop.PartialStructuredKey { toSelf.struct.one, toSelf.struct.two }`
+    const original = cds.ql`SELECT from bookshop.PartialStructuredKey { toSelf.struct.one, toSelf.struct.two }`
     const transformed = cqn4sql(original, model)
-    const expected = CQL`SELECT from bookshop.PartialStructuredKey as PartialStructuredKey
+    const expected = cds.ql`SELECT from bookshop.PartialStructuredKey as PartialStructuredKey
         left outer join bookshop.PartialStructuredKey as toSelf on toSelf.struct_one = PartialStructuredKey.toSelf_partial
         {
           PartialStructuredKey.toSelf_partial as toSelf_struct_one,
@@ -873,10 +873,10 @@ describe('subqueries in from', () => {
 
   it('in select, use one assoc in FROM subquery', () => {
     let query = cqn4sql(
-      CQL`SELECT from (SELECT from bookshop.Books { author.name as author_name  }) as Bar { Bar.author_name }`,
+      cds.ql`SELECT from (SELECT from bookshop.Books { author.name as author_name  }) as Bar { Bar.author_name }`,
       model,
     )
-    const expected = CQL`SELECT from (
+    const expected = cds.ql`SELECT from (
         SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
          { author.name as author_name }
@@ -886,8 +886,8 @@ describe('subqueries in from', () => {
   })
 
   it('expose managed assoc in FROM subquery, expose in main select', () => {
-    let query = cqn4sql(CQL`SELECT from (SELECT from bookshop.Books { author }) as Bar { Bar.author }`, model)
-    const expected = CQL`SELECT from (
+    let query = cqn4sql(cds.ql`SELECT from (SELECT from bookshop.Books { author }) as Bar { Bar.author }`, model)
+    const expected = cds.ql`SELECT from (
         SELECT from bookshop.Books as Books { Books.author_ID }
       ) as Bar { Bar.author_ID }
       `
@@ -895,8 +895,8 @@ describe('subqueries in from', () => {
   })
 
   it('expose managed assoc in FROM subquery with alias, expose in main select', () => {
-    let query = cqn4sql(CQL`SELECT from (SELECT from bookshop.Books { author as a }) as Bar { Bar.a }`, model)
-    const expected = CQL`SELECT from (
+    let query = cqn4sql(cds.ql`SELECT from (SELECT from bookshop.Books { author as a }) as Bar { Bar.a }`, model)
+    const expected = cds.ql`SELECT from (
         SELECT from bookshop.Books as Books { Books.author_ID as a_ID }
       ) as Bar { Bar.a_ID }
       `
@@ -907,11 +907,11 @@ describe('subqueries in from', () => {
   // the JOIN happens in the main query.
   it('expose managed assoc in FROM subquery, use in main select', () => {
     let query = cqn4sql(
-      CQL`SELECT from (SELECT from bookshop.Books { author }) as Bar
+      cds.ql`SELECT from (SELECT from bookshop.Books { author }) as Bar
         { Bar.author.name }`,
       model,
     )
-    const expected = CQL`SELECT from (
+    const expected = cds.ql`SELECT from (
           SELECT from bookshop.Books as Books { Books.author_ID }
         ) as Bar
         left outer join bookshop.Authors as author on author.ID = Bar.author_ID
@@ -922,11 +922,11 @@ describe('subqueries in from', () => {
 
   it('expose managed assoc with alias in FROM subquery, use in main select', () => {
     let query = cqn4sql(
-      CQL`SELECT from (SELECT from bookshop.Books { author as a}) as Bar
+      cds.ql`SELECT from (SELECT from bookshop.Books { author as a}) as Bar
         { Bar.a.name }`,
       model,
     )
-    const expected = CQL`SELECT from (
+    const expected = cds.ql`SELECT from (
           SELECT from bookshop.Books as Books { Books.author_ID as a_ID }
         ) as Bar
         left outer join bookshop.Authors as a on a.ID = Bar.a_ID
@@ -938,11 +938,11 @@ describe('subqueries in from', () => {
   // TODO (SMW) check again ...
   it('in select, assoc exposure multiple joins in subquery', () => {
     let query = cqn4sql(
-      CQL`SELECT from (SELECT from bookshop.Books { author.ID, author as a, author.name as author_name  }) as Bar
+      cds.ql`SELECT from (SELECT from bookshop.Books { author.ID, author as a, author.name as author_name  }) as Bar
         { Bar.author_name, Bar.a.books.descr }`,
       model,
     )
-    const expected = CQL`SELECT from (
+    const expected = cds.ql`SELECT from (
           SELECT from bookshop.Books as Books2
             left outer join bookshop.Authors as author on author.ID = Books2.author_ID
           { Books2.author_ID, Books2.author_ID as a_ID, author.name as author_name }
@@ -958,13 +958,13 @@ describe('subqueries in from', () => {
   // TODO move to extra section?
   it('assoc path in value subquery', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
           title,
           (select from bookshop.Genres { parent.code } where Genres.ID = Books.genre.ID) as pc
         }`,
       model,
     )
-    const expected = CQL`SELECT from bookshop.Books as Books
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         {
           Books.title,
           (select from bookshop.Genres as Genres left outer join bookshop.Genres as parent
@@ -983,12 +983,12 @@ describe('Backlink Associations', () => {
   })
   it('self managed', () => {
     let query = cqn4sql(
-      CQL`select from a2j.Header {
+      cds.ql`select from a2j.Header {
         toItem_selfMgd.id,
       }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from a2j.Header as Header
+    expect(query).to.deep.equal(cds.ql`SELECT from a2j.Header as Header
         left outer join a2j.Item as toItem_selfMgd on toItem_selfMgd.toHeader_id = Header.id and toItem_selfMgd.toHeader_id2 = Header.id2
         { toItem_selfMgd.id as toItem_selfMgd_id}
       `)
@@ -996,12 +996,12 @@ describe('Backlink Associations', () => {
 
   it('self unmanaged', () => {
     let query = cqn4sql(
-      CQL`select from a2j.Header {
+      cds.ql`select from a2j.Header {
         toItem_selfUmgd.id,
       }`,
       model,
     )
-    const expected = CQL`SELECT from a2j.Header as Header
+    const expected = cds.ql`SELECT from a2j.Header as Header
         left outer join a2j.Item as toItem_selfUmgd on (toItem_selfUmgd.elt2 = Header.elt)
         { toItem_selfUmgd.id as toItem_selfUmgd_id}
       `
@@ -1010,12 +1010,12 @@ describe('Backlink Associations', () => {
 
   it('self combined', () => {
     let query = cqn4sql(
-      CQL`select from a2j.Header {
+      cds.ql`select from a2j.Header {
         toItem_combined.id,
       }`,
       model,
     )
-    const expected = CQL`SELECT from a2j.Header as Header
+    const expected = cds.ql`SELECT from a2j.Header as Header
         left outer join a2j.Item as toItem_combined
           on (
                   (toItem_combined.toHeader_id = Header.id and toItem_combined.toHeader_id2 = Header.id2)
@@ -1029,12 +1029,12 @@ describe('Backlink Associations', () => {
 
   it('forward', () => {
     let query = cqn4sql(
-      CQL`select from a2j.Header {
+      cds.ql`select from a2j.Header {
         toItem_fwd.id,
       }`,
       model,
     )
-    const expected = CQL`SELECT from a2j.Header as Header
+    const expected = cds.ql`SELECT from a2j.Header as Header
         left outer join a2j.Item as toItem_fwd on Header.id = toItem_fwd.id
         { toItem_fwd.id as toItem_fwd_id}
       `
@@ -1043,7 +1043,7 @@ describe('Backlink Associations', () => {
 
   it('all of the above combined', () => {
     let query = cqn4sql(
-      CQL`select from a2j.Header {
+      cds.ql`select from a2j.Header {
         toItem_selfMgd.id as selfMgd_id,
         toItem_selfUmgd.id as selfUmgd_id,
         toItem_combined.id as combined_id,
@@ -1051,7 +1051,7 @@ describe('Backlink Associations', () => {
       }`,
       model,
     )
-    const expected = CQL`SELECT from a2j.Header as Header
+    const expected = cds.ql`SELECT from a2j.Header as Header
         left outer join a2j.Item as toItem_selfMgd
           on toItem_selfMgd.toHeader_id = Header.id and toItem_selfMgd.toHeader_id2 = Header.id2
         left outer join a2j.Item as toItem_selfUmgd
@@ -1072,13 +1072,13 @@ describe('Backlink Associations', () => {
 
   it('backlink usage', () => {
     let query = cqn4sql(
-      CQL`select from a2j.Folder {
+      cds.ql`select from a2j.Folder {
         nodeCompanyCode.assignments.data
       }`,
       model,
     )
 
-    const expected = CQL`SELECT from a2j.Folder as Folder
+    const expected = cds.ql`SELECT from a2j.Folder as Folder
       left outer join a2j.Folder as nodeCompanyCode on nodeCompanyCode.id = Folder.nodeCompanyCode_id
       left outer join a2j.Assignment as assignments on assignments.toFolder_id = nodeCompanyCode.id
         {
@@ -1091,13 +1091,13 @@ describe('Backlink Associations', () => {
   // compiler generates '$user.id' // cqn4sql generates `ref: ['$user', 'id']`
   it('Backlinks with other items in same on-condition', () => {
     let query = cqn4sql(
-      CQL`select from a2j.F {
+      cds.ql`select from a2j.F {
         toE.data
       }`,
       model,
     )
 
-    const expected = CQL`select from a2j.F as F
+    const expected = cds.ql`select from a2j.F as F
       left outer join a2j.E as toE on (toE.toF_id = F.id) and
       toE.id = $user.id
       {
@@ -1115,13 +1115,13 @@ describe('Shared foreign key identity', () => {
   })
   it('identifies FKs following toB', () => {
     let query = cqn4sql(
-      CQL`select from A {
+      cds.ql`select from A {
         a.b.c.toB.b.c.d.parent.c.d.e.ID  as a_b_c_toB_foo_boo,
         a.b.c.toB.e.f.g.child.c.d.e.ID  as a_b_c_toB_bar_bas
       }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from A as A
+    expect(query).to.deep.equal(cds.ql`SELECT from A as A
         {
           A.a_b_c_toB_foo_boo AS a_b_c_toB_foo_boo,
           A.a_b_c_toB_bar_bas AS a_b_c_toB_bar_bas
@@ -1138,12 +1138,12 @@ describe('Where exists in combination with assoc to join', () => {
 
   it('one assoc + one where exists / aliases are treated case insensitive', () => {
     let query = cqn4sql(
-      CQL`select from bookshop.Books:author {
+      cds.ql`select from bookshop.Books:author {
       books.genre.name,
     }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as author
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as author
       left outer join bookshop.Books as books on books.author_ID = author.ID
       left outer join bookshop.Genres as genre on genre.ID = books.genre_ID
       { genre.name as books_genre_name } where exists (
@@ -1153,11 +1153,11 @@ describe('Where exists in combination with assoc to join', () => {
   })
   it('aliases for recursive assoc in column + recursive assoc in from must not clash', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent
+      cds.ql`SELECT from bookshop.Authors:books.genre.parent.parent.parent
       { parent.parent.parent.descr, }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as parent
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as parent
     left outer join bookshop.Genres as parent2 on parent2.ID = parent.parent_ID
     left outer join bookshop.Genres as parent3 on parent3.ID = parent2.parent_ID
     {
@@ -1179,11 +1179,11 @@ describe('Where exists in combination with assoc to join', () => {
   // Revisit: Alias count order in where + from could be flipped
   it('aliases for recursive assoc in column + recursive assoc in from + where exists <assoc> must not clash', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent
+      cds.ql`SELECT from bookshop.Authors:books.genre.parent.parent.parent
       { parent.parent.parent.descr } where exists parent`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as parent
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as parent
     left outer join bookshop.Genres as parent2 on parent2.ID = parent.parent_ID
     left outer join bookshop.Genres as parent3 on parent3.ID = parent2.parent_ID
     {
@@ -1212,8 +1212,8 @@ describe('comparisons of associations in on condition of elements needs to be ex
   })
 
   it('assoc comparison needs to be expanded in on condition calculation', () => {
-    const query = cqn4sql(CQL`SELECT from a2j.Foo { ID, buz.foo }`, model)
-    const expected = CQL`
+    const query = cqn4sql(cds.ql`SELECT from a2j.Foo { ID, buz.foo }`, model)
+    const expected = cds.ql`
       SELECT from a2j.Foo as Foo left join a2j.Buz as buz on ((buz.bar_ID = Foo.bar_ID AND buz.bar_foo_ID = Foo.bar_foo_ID) and buz.foo_ID = Foo.ID){
         Foo.ID,
         buz.foo_ID as buz_foo_ID
@@ -1221,8 +1221,8 @@ describe('comparisons of associations in on condition of elements needs to be ex
     expect(query).to.eql(expected)
   })
   it('unmanaged association path traversal in on condition needs to be flattened', () => {
-    const query = cqn4sql(CQL`SELECT from a2j.Foo { ID, buzUnmanaged.foo }`, model)
-    const expected = CQL`
+    const query = cqn4sql(cds.ql`SELECT from a2j.Foo { ID, buzUnmanaged.foo }`, model)
+    const expected = cds.ql`
       SELECT from a2j.Foo as Foo left join a2j.Buz as buzUnmanaged
         on buzUnmanaged.bar_foo_ID = Foo.bar_foo_ID and buzUnmanaged.bar_ID = Foo.bar_ID and buzUnmanaged.foo_ID = Foo.ID
       {
@@ -1239,10 +1239,10 @@ describe('optimize fk access', () => {
     model = cds.model = await cds.load(__dirname + '/A2J/classes').then(cds.linked)
   })
   it('association (with multiple, structured, renamed fks) is key', () => {
-    const query = CQL`SELECT from ForeignKeyIsAssoc {
+    const query = cds.ql`SELECT from ForeignKeyIsAssoc {
       my.room as teachersRoom,
     }`
-    const expected = CQL`SELECT from ForeignKeyIsAssoc as ForeignKeyIsAssoc {
+    const expected = cds.ql`SELECT from ForeignKeyIsAssoc as ForeignKeyIsAssoc {
                           ForeignKeyIsAssoc.my_room_number as teachersRoom_number,
                           ForeignKeyIsAssoc.my_room_name as teachersRoom_name,
                           ForeignKeyIsAssoc.my_room_location as teachersRoom_info_location
@@ -1251,10 +1251,10 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('association as key leads to non-key field', () => {
-    const query = CQL`SELECT from Pupils {
+    const query = cds.ql`SELECT from Pupils {
       ID
     } group by classrooms.classroom.ID, classrooms.classroom.name`
-    const expected = CQL`SELECT from Pupils as Pupils
+    const expected = cds.ql`SELECT from Pupils as Pupils
                         left join ClassroomsPupils as classrooms
                           on classrooms.pupil_ID = Pupils.ID
                         left join Classrooms as classroom
@@ -1266,10 +1266,10 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('association as key leads to nested non-key field', () => {
-    const query = CQL`SELECT from Pupils {
+    const query = cds.ql`SELECT from Pupils {
       ID
     } group by classrooms.classroom.ID, classrooms.classroom.info.capacity`
-    const expected = CQL`SELECT from Pupils as Pupils
+    const expected = cds.ql`SELECT from Pupils as Pupils
                         left join ClassroomsPupils as classrooms
                           on classrooms.pupil_ID = Pupils.ID
                         left join Classrooms as classroom
@@ -1281,10 +1281,10 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('two step path ends in foreign key simple ref', () => {
-    const query = CQL`SELECT from Classrooms {
+    const query = cds.ql`SELECT from Classrooms {
       pupils.pupil.ID as studentCount,
     } where Classrooms.ID = 1`
-    const expected = CQL`SELECT from Classrooms as Classrooms left join ClassroomsPupils as pupils
+    const expected = cds.ql`SELECT from Classrooms as Classrooms left join ClassroomsPupils as pupils
                         on pupils.classroom_ID = Classrooms.ID {
                           pupils.pupil_ID as studentCount
                         } where Classrooms.ID = 1`
@@ -1292,10 +1292,10 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('filters are always join relevant', () => {
-    const query = CQL`SELECT from ClassroomsPupils {
+    const query = cds.ql`SELECT from ClassroomsPupils {
       pupil[ID = 5].ID as student,
     }`
-    const expected = CQL`SELECT from ClassroomsPupils as ClassroomsPupils
+    const expected = cds.ql`SELECT from ClassroomsPupils as ClassroomsPupils
                           left join Pupils as pupil on pupil.ID = ClassroomsPupils.pupil_ID
                           and pupil.ID = 5
                         {
@@ -1305,11 +1305,11 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('optimized next to non-optimized', () => {
-    const query = CQL`SELECT from ClassroomsPupils {
+    const query = cds.ql`SELECT from ClassroomsPupils {
       pupil[ID = 5].ID as nonOptimized,
       pupil.ID as optimized,
     }`
-    const expected = CQL`SELECT from ClassroomsPupils as ClassroomsPupils
+    const expected = cds.ql`SELECT from ClassroomsPupils as ClassroomsPupils
                           left join Pupils as pupil on pupil.ID = ClassroomsPupils.pupil_ID
                           and pupil.ID = 5
                         {
@@ -1320,11 +1320,11 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('optimized next to join relevant', () => {
-    const query = CQL`SELECT from ClassroomsPupils {
+    const query = cds.ql`SELECT from ClassroomsPupils {
       classroom.ID as classroom_ID,
       classroom.name as classroom,
     }`
-    const expected = CQL`SELECT from ClassroomsPupils as ClassroomsPupils
+    const expected = cds.ql`SELECT from ClassroomsPupils as ClassroomsPupils
                           left join Classrooms as classroom on classroom.ID = ClassroomsPupils.classroom_ID
                         {
                           ClassroomsPupils.classroom_ID as classroom_ID,
@@ -1334,7 +1334,7 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('two step path ends in foreign key simple ref in aggregation clauses', () => {
-    const query = CQL`SELECT from Classrooms {
+    const query = cds.ql`SELECT from Classrooms {
       pupils.pupil.ID as studentCount,
     }
       where pupils.pupil.ID = 1
@@ -1342,7 +1342,7 @@ describe('optimize fk access', () => {
       having pupils.pupil.ID = 1
       order by pupils.pupil.ID
     `
-    const expected = CQL`SELECT from Classrooms as Classrooms left join ClassroomsPupils as pupils
+    const expected = cds.ql`SELECT from Classrooms as Classrooms left join ClassroomsPupils as pupils
                         on pupils.classroom_ID = Classrooms.ID {
                           pupils.pupil_ID as studentCount
                         } where pupils.pupil_ID = 1
@@ -1354,10 +1354,10 @@ describe('optimize fk access', () => {
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('two step path ends in foreign key nested ref', () => {
-    const query = CQL`SELECT from Classrooms {
+    const query = cds.ql`SELECT from Classrooms {
       count(pupils.pupil.ID) as studentCount,
     } where Classrooms.ID = 1`
-    const expected = CQL`SELECT from Classrooms as Classrooms left join ClassroomsPupils as pupils
+    const expected = cds.ql`SELECT from Classrooms as Classrooms left join ClassroomsPupils as pupils
                         on pupils.classroom_ID = Classrooms.ID {
                           count(pupils.pupil_ID) as studentCount
                         } where Classrooms.ID = 1`
@@ -1366,11 +1366,11 @@ describe('optimize fk access', () => {
   })
 
   it('multi step path ends in foreign key', () => {
-    const query = CQL`SELECT from Classrooms {
+    const query = cds.ql`SELECT from Classrooms {
       count(pupils.pupil.classrooms.classroom.ID) as classCount,
     } where    pupils.pupil.classrooms.classroom.ID = 1
       order by pupils.pupil.classrooms.classroom.ID`
-    const expected = CQL`SELECT from Classrooms as Classrooms
+    const expected = cds.ql`SELECT from Classrooms as Classrooms
                         left join ClassroomsPupils as pupils on pupils.classroom_ID = Classrooms.ID
                         left join Pupils as pupil on pupil.ID = pupils.pupil_ID
                         left join ClassroomsPupils as classrooms2 on classrooms2.pupil_ID = pupil.ID

--- a/db-service/test/cqn4sql/basic.test.js
+++ b/db-service/test/cqn4sql/basic.test.js
@@ -13,23 +13,23 @@ describe('query clauses', () => {
   })
 
   it('limit + offset', () => {
-    const original = CQL`SELECT from bookshop.Books { ID } limit 50 offset 25`
+    const original = cds.ql`SELECT from bookshop.Books { ID } limit 50 offset 25`
     expect(cqn4sql(original, model)).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books { Books.ID } limit 50 offset 25
      `,
     )
   })
 
   it('`sort` and `nulls` are passed along in order by', () => {
-    const original = CQL`
+    const original = cds.ql`
         SELECT from bookshop.Books { ID }
             order by Books.ID asc nulls first,
                      1 + 1 desc nulls last,
                      func() desc nulls first
     `
     expect(cqn4sql(original, model)).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books { Books.ID }
         order by Books.ID asc nulls first,
                  1 + 1 desc nulls last,
@@ -38,9 +38,9 @@ describe('query clauses', () => {
     )
   })
   it('`sort` and `nulls` are passed along also to flat field in order by', () => {
-    const original = CQL`SELECT from bookshop.Books { ID } order by Books.dedication.sub asc nulls first`
+    const original = cds.ql`SELECT from bookshop.Books { ID } order by Books.dedication.sub asc nulls first`
     expect(cqn4sql(original, model)).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books { Books.ID }
         order by Books.dedication_sub_foo asc nulls first
      `,
@@ -48,12 +48,12 @@ describe('query clauses', () => {
   })
   it('preserves cast property on column', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Bar {
+      cds.ql`SELECT from bookshop.Bar {
             ID as castedID: cds.String
           }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
             Bar.ID as castedID: cds.String
           }`)
   })
@@ -62,12 +62,12 @@ describe('query clauses', () => {
   //     hence we should make the alias explicit for the cds style cast
   it('adds explicit alias for cast property on column', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Bar {
+      cds.ql`SELECT from bookshop.Bar {
             ID: cds.String
           }`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
             Bar.ID as ID: cds.String
           }`)
   })

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -11,8 +11,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('simple reference', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, stock2 }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, stock2 }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         Books.stock as stock2
       }`
@@ -20,8 +20,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('simple val', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID, IBAN }`, model)
-    const expected = CQL`SELECT from booksCalc.Authors as Authors {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors { ID, IBAN }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors {
         Authors.ID,
         'DE' || Authors.checksum || Authors.sortCode || Authors.accountNumber as IBAN
       }`
@@ -29,8 +29,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('directly', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, area }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, area }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         Books.length * Books.width as area
       }`
@@ -38,8 +38,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('in expression', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, stock * area as f }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, stock * area as f }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         Books.stock * ( Books.length * Books.width ) as f
       }`
@@ -47,8 +47,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('in ternary', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Ternary { ID, nestedTernary }`, model)
-    const expected = CQL`SELECT from booksCalc.Ternary as Ternary
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Ternary { ID, nestedTernary }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Ternary as Ternary
       left join booksCalc.Books as book on book.ID = Ternary.book_ID
       {
         Ternary.ID,
@@ -58,8 +58,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('calcualted element in nested ternary', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Ternary { ID, calculatedElementInNestedTernary }`, model)
-    const expected = CQL`SELECT from booksCalc.Ternary as Ternary
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Ternary { ID, calculatedElementInNestedTernary }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Ternary as Ternary
       left join booksCalc.Books as book on book.ID = Ternary.book_ID
       left join booksCalc.Authors as author on author.ID = book.author_ID
       {
@@ -70,8 +70,8 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
   it('list in ternary', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Ternary { ID, nestedTernaryWithNestedXpr }`, model)
-    const expected = CQL`SELECT from booksCalc.Ternary as Ternary
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Ternary { ID, nestedTernaryWithNestedXpr }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Ternary as Ternary
       left join booksCalc.Books as book on book.ID = Ternary.book_ID
       {
         Ternary.ID,
@@ -80,16 +80,16 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
   it('in function', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, round(area, 2) as f }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, round(area, 2) as f }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         round(Books.length * Books.width, 2) as f
       }`
     expect(query).to.deep.equal(expected)
   })
   it('in function with named param', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID, ageNamedParams as f }`, model)
-    const expected = CQL`SELECT from booksCalc.Authors as Authors {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors { ID, ageNamedParams as f }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors {
       Authors.ID,
       years_between(DOB => Authors.dateOfBirth, DOD => Authors.dateOfDeath) as f
     }`
@@ -97,16 +97,16 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('calc elem is function', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, ctitle }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, ctitle }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         substring(Books.title, 3, Books.stock) as ctitle
       }`
     expect(query).to.deep.equal(expected)
   })
   it('calc elem is xpr with multiple functions as args', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, authorAgeNativePG }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, authorAgeNativePG }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left join booksCalc.Authors as author on author.ID = Books.author_ID
       {
         Books.ID,
@@ -115,8 +115,8 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
   it('calc elem is xpr with nested xpr which has multiple functions as args', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, authorAgeInDogYears }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, authorAgeInDogYears }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left join booksCalc.Authors as author on author.ID = Books.author_ID
       {
         Books.ID,
@@ -125,8 +125,8 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
   it('calc elem is xpr with multiple functions as args - back and forth', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author.books.authorAgeNativePG }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author.books.authorAgeNativePG }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left join booksCalc.Authors as author on author.ID = Books.author_ID
       left join booksCalc.Books as books2 on books2.author_ID = author.ID
       left join booksCalc.Authors as author2 on author2.ID = books2.author_ID
@@ -138,8 +138,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('calc elem is function, nested in direct expression', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, ctitle || title as f }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, ctitle || title as f }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         substring(Books.title, 3, Books.stock) || Books.title as f
       }`
@@ -147,8 +147,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('nested calc elems', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, volume, storageVolume }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, volume, storageVolume }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         (Books.length * Books.width) * Books.height as volume,
         Books.stock * ((Books.length * Books.width) * Books.height) as storageVolume
@@ -157,8 +157,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('nested calc elems, nested in direct expression', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, storageVolume / volume as f }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, storageVolume / volume as f }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         (Books.stock * ((Books.length * Books.width) * Books.height))
           / ((Books.length * Books.width) * Books.height) as f
@@ -171,9 +171,9 @@ describe('Unfolding calculated elements in select list', () => {
   //
 
   it('via an association path', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author.name }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author.name }`, model)
     // revisit: alias follows our "regular" naming scheme -> ref.join('_')
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID {
         Books.ID,
         author.firstName || ' ' || author.lastName as author_name
@@ -182,9 +182,9 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('via an association in columns and where', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author.name } where author.name like '%Bro%'`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author.name } where author.name like '%Bro%'`, model)
     // revisit: alias follows our "regular" naming scheme -> ref.join('_')
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID {
         Books.ID,
         author.firstName || ' ' || author.lastName as author_name
@@ -193,8 +193,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('via an association path, nested in direct expression', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, substring(author.name, 2, stock) as f }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, substring(author.name, 2, stock) as f }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID {
         Books.ID,
         substring(author.firstName || ' ' || author.lastName, 2, Books.stock) as f
@@ -203,8 +203,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('via two association paths', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID, books[stock<5].area, books[stock>5].area as a2}`, model)
-    const expected = CQL`SELECT from booksCalc.Authors as Authors
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors { ID, books[stock<5].area, books[stock>5].area as a2}`, model)
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors
       left outer join booksCalc.Books as books  on books.author_ID  = Authors.ID and books.stock  < 5
       left outer join booksCalc.Books as books2 on books2.author_ID = Authors.ID and books2.stock > 5
       {
@@ -216,10 +216,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('in filter', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID, books[area >17].title }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors { ID, books[area >17].title }`, model)
     // intermediate:
     // SELECT from booksCalc.Authors { ID, books[(length * width) > 1].title }
-    const expected = CQL`SELECT from booksCalc.Authors as Authors
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors
       left outer join booksCalc.Books as books on  books.author_ID  = Authors.ID
                                                and (books.length * books.width) > 17
       {
@@ -230,10 +230,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('calc elem contains association', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, authorName, authorLastName }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, authorName, authorLastName }`, model)
     // intermediate:
     // SELECT from booksCalc.Books { ID, author.name, author.lastName }
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID
       {
         Books.ID,
@@ -244,10 +244,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('calc elem contains associations in xpr', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, authorFullName }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, authorFullName }`, model)
     // intermediate:
     // SELECT from booksCalc.Books { ID, author.name, author.lastName }
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID
       {
         Books.ID,
@@ -258,12 +258,12 @@ describe('Unfolding calculated elements in select list', () => {
 
   it('calc elem contains other calculated element in xpr with nested joins', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books { ID, authorFullNameWithAddress } where authorFullNameWithAddress = 'foo'`,
+      cds.ql`SELECT from booksCalc.Books { ID, authorFullNameWithAddress } where authorFullNameWithAddress = 'foo'`,
       model,
     )
     // intermediate:
     // SELECT from booksCalc.Books { ID, author.name, author.lastName }
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID
       left outer join booksCalc.Addresses as address on address.ID = author.address_ID
       {
@@ -275,10 +275,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('calc elem contains association, nested', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, authorAdrText }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, authorAdrText }`, model)
     // intermediate:
     // SELECT from booksCalc.Books { ID, author.address.{street || ', ' || city} }
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID
       left outer join booksCalc.Addresses as address on address.ID = author.address_ID
       {
@@ -289,10 +289,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('calc elem contains association with filter', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID, addressTextFilter }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors { ID, addressTextFilter }`, model)
     // intermediate:
     // SELECT from booksCalc.Authors { ID, address[number * 2 > 17].{street || ', ' || city}  }
-    const expected = CQL`SELECT from booksCalc.Authors as Authors
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors
       left outer join booksCalc.Addresses as address on address.ID = Authors.address_ID
                                                      and (address.number * 2) > 17
       {
@@ -306,8 +306,8 @@ describe('Unfolding calculated elements in select list', () => {
   // inline, expand
   //
   it('in inline', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author.{name, IBAN } }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author.{name, IBAN } }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID
       {
         Books.ID,
@@ -317,8 +317,8 @@ describe('Unfolding calculated elements in select list', () => {
     expect(query).to.deep.equal(expected)
   })
   it('in inline back and forth', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author.books.author.{name, IBAN } }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author.books.author.{name, IBAN } }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID
       left outer join booksCalc.Books as books2 on books2.author_ID = author.ID
       left outer join booksCalc.Authors as author2 on author2.ID = books2.author_ID
@@ -331,7 +331,7 @@ describe('Unfolding calculated elements in select list', () => {
   })
   it('in subquery, using the same calc element - not join relevant in subquery', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books {
+      cds.ql`SELECT from booksCalc.Books {
       ID,
       (
         SELECT from booksCalc.Authors {
@@ -344,7 +344,7 @@ describe('Unfolding calculated elements in select list', () => {
     }`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors as author on author.ID = Books.author_ID
       left outer join booksCalc.Books as books2 on books2.author_ID = author.ID
       left outer join booksCalc.Authors as author2 on author2.ID = books2.author_ID
@@ -367,10 +367,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('in inline, 2 assocs', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author.{name, addressText } }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author.{name, addressText } }`, model)
     // intermediate:
     // SELECT from booksCalc.Authors { ID, author.{firstName || ' ' || lastName, address.{street || ', ' || city}}}  }
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       left outer join booksCalc.Authors   as author  on author.ID = Books.author_ID
       left outer join booksCalc.Addresses as address on address.ID = author.address_ID
       {
@@ -382,8 +382,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('in expand (to-one)', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author {name, IBAN } }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author {name, IBAN } }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       {
         Books.ID,
         (
@@ -397,8 +397,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('in expand (to-one), 2 assocs', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, author {name, addressText } }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, author {name, addressText } }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
       {
         Books.ID,
         (
@@ -414,10 +414,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
   it('expand and inline target same calc element', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books { ID, author.{name, addressText }, author {name, addressText } }`,
+      cds.ql`SELECT from booksCalc.Books { ID, author.{name, addressText }, author {name, addressText } }`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
           left outer join booksCalc.Authors   as author  on author.ID = Books.author_ID
           left outer join booksCalc.Addresses as address on address.ID = author.address_ID
       {
@@ -437,10 +437,10 @@ describe('Unfolding calculated elements in select list', () => {
   })
   it('expand and inline target same calc element inverted', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books { ID, author {name, addressText }, author.{name, addressText } }`,
+      cds.ql`SELECT from booksCalc.Books { ID, author {name, addressText }, author.{name, addressText } }`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
           left outer join booksCalc.Authors   as author  on author.ID = Books.author_ID
           left outer join booksCalc.Addresses as address on address.ID = author.address_ID
       {
@@ -460,9 +460,9 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('in expand (to-many)', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID, books { ID, area, volume } }`, model)
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors { ID, books { ID, area, volume } }`, model)
 
-    const expected = CQL`SELECT from booksCalc.Authors as Authors {
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors {
       Authors.ID,
       (
         SELECT from booksCalc.Books as books
@@ -482,10 +482,10 @@ describe('Unfolding calculated elements in select list', () => {
 
   it('via wildcard without columns', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books excluding { length, width, height, stock, price, youngAuthorName }`,
+      cds.ql`SELECT from booksCalc.Books excluding { length, width, height, stock, price, youngAuthorName }`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
           left outer join booksCalc.Authors as author on author.ID = Books.author_ID
           left outer join booksCalc.Addresses as address on address.ID = author.address_ID
         {
@@ -517,10 +517,10 @@ describe('Unfolding calculated elements in select list', () => {
 
   it('via wildcard', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books { * } excluding { length, width, height, stock, price, youngAuthorName}`,
+      cds.ql`SELECT from booksCalc.Books { * } excluding { length, width, height, stock, price, youngAuthorName}`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
           left outer join booksCalc.Authors as author on author.ID = Books.author_ID
           left outer join booksCalc.Addresses as address on address.ID = author.address_ID
         {
@@ -551,8 +551,8 @@ describe('Unfolding calculated elements in select list', () => {
   })
 
   it('wildcard select from subquery', () => {
-    let query = cqn4sql(CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } )`, model)
-    const expected = CQL`
+    let query = cqn4sql(cds.ql`SELECT from ( SELECT FROM booksCalc.Simple { * } )`, model)
+    const expected = cds.ql`
     SELECT from (
       SELECT from booksCalc.Simple as Simple
       left join booksCalc.Simple as my on my.ID = Simple.my_ID
@@ -574,12 +574,12 @@ describe('Unfolding calculated elements in select list', () => {
 
   it('wildcard select from subquery + join relevant path expression', () => {
     let query = cqn4sql(
-      CQL`SELECT from ( SELECT FROM booksCalc.Simple { * } ) {
+      cds.ql`SELECT from ( SELECT FROM booksCalc.Simple { * } ) {
         my.name as otherName
       }`,
       model,
     )
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from (
       SELECT from booksCalc.Simple as Simple
       left join booksCalc.Simple as my2 on my2.ID = Simple.my_ID
@@ -598,10 +598,10 @@ describe('Unfolding calculated elements in select list', () => {
 
   it('replacement for calculated element is considered for wildcard expansion', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books { *, volume as ctitle } excluding { length, width, height, stock, price, youngAuthorName }`,
+      cds.ql`SELECT from booksCalc.Books { *, volume as ctitle } excluding { length, width, height, stock, price, youngAuthorName }`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books
+    const expected = cds.ql`SELECT from booksCalc.Books as Books
           left outer join booksCalc.Authors as author on author.ID = Books.author_ID
           left outer join booksCalc.Addresses as address on address.ID = author.address_ID
         {
@@ -637,7 +637,7 @@ describe('Unfolding calculated elements in select list', () => {
     // their table aliases properly rewritten to the already
     // existing join node
     let query = cqn4sql(
-      CQL`
+      cds.ql`
     SELECT from booksCalc.Books {
       youngAuthorName,
       authorLastName,
@@ -649,7 +649,7 @@ describe('Unfolding calculated elements in select list', () => {
       model,
     )
 
-    const expected = CQL`
+    const expected = cds.ql`
         SELECT from booksCalc.Books as Books
         left outer join booksCalc.Authors as author on author.ID = Books.author_ID
                         and years_between(author.dateOfBirth, author.dateOfDeath) < 50
@@ -670,7 +670,7 @@ describe('Unfolding calculated elements in select list', () => {
     // their table aliases properly rewritten to the already
     // existing join node
     let query = cqn4sql(
-      CQL`
+      cds.ql`
     SELECT from booksCalc.Authors {
       books.youngAuthorName,
       books.authorLastName,
@@ -682,7 +682,7 @@ describe('Unfolding calculated elements in select list', () => {
       model,
     )
 
-    const expected = CQL`
+    const expected = cds.ql`
         SELECT from booksCalc.Authors as Authors
         left outer join booksCalc.Books as books on books.author_ID = Authors.ID
         left outer join booksCalc.Authors as author on author.ID = books.author_ID
@@ -704,7 +704,7 @@ describe('Unfolding calculated elements in select list', () => {
     // their table aliases properly rewritten to the already
     // existing join node
     let query = cqn4sql(
-      CQL`
+      cds.ql`
     SELECT from booksCalc.Authors {
       books.author.books.youngAuthorName,
       books.author.books.authorLastName,
@@ -716,7 +716,7 @@ describe('Unfolding calculated elements in select list', () => {
       model,
     )
 
-    const expected = CQL`
+    const expected = cds.ql`
         SELECT from booksCalc.Authors as Authors
         left outer join booksCalc.Books as books on books.author_ID = Authors.ID
         left outer join booksCalc.Authors as author on author.ID = books.author_ID
@@ -736,27 +736,27 @@ describe('Unfolding calculated elements in select list', () => {
 
   it('exists cannot leverage calculated elements which ends in string', () => {
     // at the leaf of a where exists path, there must be an association
-    expect(() => cqn4sql(CQL`SELECT from booksCalc.Books { ID } where exists youngAuthorName`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from booksCalc.Books { ID } where exists youngAuthorName`, model)).to.throw(
       `Expecting path “youngAuthorName” following “EXISTS” predicate to end with association/composition, found “cds.String”`,
     )
   })
   it('exists cannot leverage calculated elements which is an expression', () => {
     // at the leaf of a where exists path, there must be an association
-    expect(() => cqn4sql(CQL`SELECT from booksCalc.Books { ID } where exists authorFullName`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from booksCalc.Books { ID } where exists authorFullName`, model)).to.throw(
       `Expecting path “authorFullName” following “EXISTS” predicate to end with association/composition, found “expression”`,
     )
   })
   it('exists cannot leverage calculated elements w/ path expressions', () => {
     // at the leaf of a where exists path, there must be an association
     expect(() =>
-      cqn4sql(CQL`SELECT from booksCalc.Books { ID } where exists author.books.youngAuthorName`, model),
+      cqn4sql(cds.ql`SELECT from booksCalc.Books { ID } where exists author.books.youngAuthorName`, model),
     ).to.throw('Expecting path “author.books.youngAuthorName” following “EXISTS” predicate to end with association/composition, found “cds.String”')
   })
 
   it('exists cannot leverage calculated elements in CASE', () => {
     expect(() =>
       cqn4sql(
-        CQL`SELECT from booksCalc.Books {
+        cds.ql`SELECT from booksCalc.Books {
       ID,
       case when exists youngAuthorName then 'yes'
            else 'no'
@@ -769,14 +769,14 @@ describe('Unfolding calculated elements in select list', () => {
 
   it('scoped query cannot leverage calculated elements', () => {
     // at the leaf of a where exists path, there must be an association
-    expect(() => cqn4sql(CQL`SELECT from booksCalc.Books:youngAuthorName { ID }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from booksCalc.Books:youngAuthorName { ID }`, model)).to.throw(
       'Query source must be a an entity or an association',
     )
   })
 
   it('via wildcard in expand subquery include complex calc element', () => {
     let query = cqn4sql(
-      CQL`
+      cds.ql`
     SELECT from booksCalc.Authors {
       books { * } excluding { length, width, height, stock, price}
     }
@@ -784,7 +784,7 @@ describe('Unfolding calculated elements in select list', () => {
       model,
     )
 
-    const expected = CQL`SELECT from booksCalc.Authors as Authors {
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors {
       (
         SELECT from booksCalc.Books as books
         left outer join booksCalc.Authors as author on author.ID = books.author_ID
@@ -823,7 +823,7 @@ describe('Unfolding calculated elements in select list', () => {
   })
   it('via wildcard in expand subquery', () => {
     let query = cqn4sql(
-      CQL`
+      cds.ql`
     SELECT from booksCalc.Authors {
       books { * } excluding { length, width, height, stock, price, youngAuthorName}
     }
@@ -831,7 +831,7 @@ describe('Unfolding calculated elements in select list', () => {
       model,
     )
 
-    const expected = CQL`SELECT from booksCalc.Authors as Authors {
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors {
       (
         SELECT from booksCalc.Books as books
           left outer join booksCalc.Authors as author on author.ID = books.author_ID
@@ -874,16 +874,16 @@ describe('Unfolding calculated elements in other places', () => {
   })
 
   it('in where', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID } where area < 13`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books { Books.ID }
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID } where area < 13`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books { Books.ID }
       where (Books.length * Books.width) < 13
     `
     expect(query).to.deep.equal(expected)
   })
 
   it('in filter in where exists', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors { ID } where exists books[area < 13]`, model)
-    const expected = CQL`SELECT from booksCalc.Authors as Authors { Authors.ID }
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors { ID } where exists books[area < 13]`, model)
+    const expected = cds.ql`SELECT from booksCalc.Authors as Authors { Authors.ID }
       where exists (
         select 1 from booksCalc.Books as books where books.author_ID = Authors.ID
           and (books.length * books.width) < 13
@@ -894,11 +894,11 @@ describe('Unfolding calculated elements in other places', () => {
 
   it('in group by & having', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books { ID, sum(price) as tprice }
+      cds.ql`SELECT from booksCalc.Books { ID, sum(price) as tprice }
       group by ctitle having ctitle like 'A%'`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID, sum(Books.price) as tprice
       } group by substring(Books.title, 3, Books.stock)
         having substring(Books.title, 3, Books.stock) like 'A%'
@@ -907,8 +907,8 @@ describe('Unfolding calculated elements in other places', () => {
   })
 
   it('in order by', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, title } order by ctitle`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, title } order by ctitle`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID, Books.title
       } order by substring(Books.title, 3, Books.stock)
     `
@@ -916,8 +916,8 @@ describe('Unfolding calculated elements in other places', () => {
   })
 
   it('in filter in path in FROM', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Authors[name like 'A%'].books[storageVolume < 4] { ID }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as books {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Authors[name like 'A%'].books[storageVolume < 4] { ID }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as books {
       books.ID
     } where exists (select 1 from booksCalc.Authors as Authors
                       where Authors.ID = books.author_ID
@@ -929,14 +929,14 @@ describe('Unfolding calculated elements in other places', () => {
 
   it('in a subquery', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books {
+      cds.ql`SELECT from booksCalc.Books {
         ID,
         (select from booksCalc.Authors as A { name }
            where A.ID = Books.author.ID and A.IBAN = Books.area + Books.ctitle) as f
       }`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         (select from booksCalc.Authors as A { A.firstName || ' ' || A.lastName as name }
             where A.ID = Books.author_ID
@@ -948,13 +948,13 @@ describe('Unfolding calculated elements in other places', () => {
   })
   it('in a function, args are join relevant', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books {
+      cds.ql`SELECT from booksCalc.Books {
       ID,
       authorAge
     }`,
       model,
     )
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from booksCalc.Books as Books
       left join booksCalc.Authors as author on author.ID = Books.author_ID
       {
@@ -966,13 +966,13 @@ describe('Unfolding calculated elements in other places', () => {
   })
   it('calculated element has other calc element in infix filter', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books {
+      cds.ql`SELECT from booksCalc.Books {
       ID,
       youngAuthorName
     }`,
       model,
     )
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from booksCalc.Books as Books
       left join booksCalc.Authors as author on author.ID = Books.author_ID
                 and years_between(author.dateOfBirth, author.dateOfDeath) < 50
@@ -985,14 +985,14 @@ describe('Unfolding calculated elements in other places', () => {
   })
   it('in a subquery calc element is join relevant', () => {
     let query = cqn4sql(
-      CQL`SELECT from booksCalc.Books {
+      cds.ql`SELECT from booksCalc.Books {
         ID,
         (select from booksCalc.Authors as A { books.title }
            where A.ID = Books.author.ID and A.IBAN = Books.area + Books.ctitle) as f
       }`,
       model,
     )
-    const expected = CQL`SELECT from booksCalc.Books as Books {
+    const expected = cds.ql`SELECT from booksCalc.Books as Books {
         Books.ID,
         (select from booksCalc.Authors as A
           left join booksCalc.Books as books2 on books2.author_ID = A.ID
@@ -1005,8 +1005,8 @@ describe('Unfolding calculated elements in other places', () => {
     expect(query).to.deep.equal(expected)
   })
   it('variable replacements are left untouched in calc element navigation', () => {
-    const q = CQL`SELECT from booksCalc.VariableReplacements { ID, authorAlive.firstName }`
-    const expected = CQL`SELECT from booksCalc.VariableReplacements as VariableReplacements
+    const q = cds.ql`SELECT from booksCalc.VariableReplacements { ID, authorAlive.firstName }`
+    const expected = cds.ql`SELECT from booksCalc.VariableReplacements as VariableReplacements
     left join booksCalc.Authors as authorAlive on ( authorAlive.ID = VariableReplacements.author_ID )
     and ( authorAlive.dateOfBirth <= $now and authorAlive.dateOfDeath >= $now and $user.unknown.foo.bar = 'Bob' )
     {
@@ -1016,8 +1016,8 @@ describe('Unfolding calculated elements in other places', () => {
     expect(cqn4sql(q, model)).to.deep.equal(expected)
   })
   it('variable replacements are left untouched in calc elements via wildcard', () => {
-    const q = CQL`SELECT from booksCalc.VariableReplacements { * }`
-    const expected = CQL`SELECT from booksCalc.VariableReplacements as VariableReplacements
+    const q = cds.ql`SELECT from booksCalc.VariableReplacements { * }`
+    const expected = cds.ql`SELECT from booksCalc.VariableReplacements as VariableReplacements
     {
         VariableReplacements.ID,
         VariableReplacements.author_ID
@@ -1026,8 +1026,8 @@ describe('Unfolding calculated elements in other places', () => {
   })
 
   it('with expand', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.VariableReplacements { ID, authorAlive { ID }  }`, model)
-    const expected = CQL`SELECT from booksCalc.VariableReplacements as VariableReplacements {
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.VariableReplacements { ID, authorAlive { ID }  }`, model)
+    const expected = cds.ql`SELECT from booksCalc.VariableReplacements as VariableReplacements {
       VariableReplacements.ID,
       (
         SELECT from booksCalc.Authors as authorAlive
@@ -1048,8 +1048,8 @@ describe('Unfolding calculated elements ... misc', () => {
     model = cds.model = await cds.load(__dirname + '/../bookshop/db/booksWithExpr').then(cds.linked)
   })
   it('calculated element on-write (stored) is not unfolded', () => {
-    let query = cqn4sql(CQL`SELECT from booksCalc.Books { ID, areaS }`, model)
-    const expected = CQL`SELECT from booksCalc.Books as Books { Books.ID, Books.areaS }`
+    let query = cqn4sql(cds.ql`SELECT from booksCalc.Books { ID, areaS }`, model)
+    const expected = cds.ql`SELECT from booksCalc.Books as Books { Books.ID, Books.areaS }`
     expect(query).to.deep.equal(expected)
   })
 })
@@ -1062,10 +1062,10 @@ describe('Unfolding calculated elements and localized', () => {
   })
 
   it('presence of localized element should not affect unfolding', () => {
-    const q = CQL`SELECT from booksCalc.LBooks { ID, title, area }`
+    const q = cds.ql`SELECT from booksCalc.LBooks { ID, title, area }`
     q.SELECT.localized = true
     let query = cqn4sql(q, model)
-    const expected = CQL`SELECT from localized.booksCalc.LBooks as LBooks {
+    const expected = cds.ql`SELECT from localized.booksCalc.LBooks as LBooks {
         LBooks.ID,
         LBooks.title,
         LBooks.length * LBooks.width as area
@@ -1075,10 +1075,10 @@ describe('Unfolding calculated elements and localized', () => {
   })
 
   it('calculated element refers to localized element', () => {
-    const q = CQL`SELECT from booksCalc.LBooks { ID, title, ctitle }`
+    const q = cds.ql`SELECT from booksCalc.LBooks { ID, title, ctitle }`
     q.SELECT.localized = true
     let query = cqn4sql(q, model)
-    const expected = CQL`SELECT from localized.booksCalc.LBooks as LBooks {
+    const expected = cds.ql`SELECT from localized.booksCalc.LBooks as LBooks {
         LBooks.ID,
         LBooks.title,
         substring(LBooks.title, 3, 3) as ctitle

--- a/db-service/test/cqn4sql/column.element.test.js
+++ b/db-service/test/cqn4sql/column.element.test.js
@@ -13,7 +13,7 @@ describe('assign element onto columns', () => {
   })
 
   it('attaches the `element` to simple / structured columns', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.Books {
         ID,
         author,
@@ -21,7 +21,7 @@ describe('assign element onto columns', () => {
         dedication.sub
       }
     `, model)
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.author_ID,
         Books.dedication_addressee_ID,
@@ -40,7 +40,7 @@ describe('assign element onto columns', () => {
       .that.equals(Books.elements.dedication.elements.sub.elements.foo)
   })
   it('attaches the `element` to expand subquery columns', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.Books {
         author { name }
       }
@@ -49,7 +49,7 @@ describe('assign element onto columns', () => {
     expect(query.SELECT.columns[0].SELECT.columns[0]).to.have.property('element').that.equals(Authors.elements['name'])
   })
   it('attaches the `element` to functions, xpr and val', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.Books {
         1 as val,
         1 + 1 as xpr,
@@ -72,13 +72,13 @@ describe('assign element onto columns with flat model', () => {
   })
 
   it('foreign key is adjacent to its association in flat model', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.Books {
         ID,
         author
       }
     `, model)
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.author_ID
     }
@@ -90,7 +90,7 @@ describe('assign element onto columns with flat model', () => {
     expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(Books.elements.author_ID)
   })
   it('within expand, the key in the target is attached, not the foreign key', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.Books {
         ID,
         author {
@@ -98,7 +98,7 @@ describe('assign element onto columns with flat model', () => {
         }
       }
     `, model)
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         (SELECT from bookshop.Authors as author {
           author.ID
@@ -112,13 +112,13 @@ describe('assign element onto columns with flat model', () => {
   })
 
   it('foreign key is adjacent to its association in flat model with multiple foreign keys', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.AssocWithStructuredKey {
         ID,
         toStructuredKey
       }
     `, model)
-    const expected = CQL`SELECT from bookshop.AssocWithStructuredKey as AssocWithStructuredKey {
+    const expected = cds.ql`SELECT from bookshop.AssocWithStructuredKey as AssocWithStructuredKey {
         AssocWithStructuredKey.ID,
         AssocWithStructuredKey.toStructuredKey_struct_mid_leaf,
         AssocWithStructuredKey.toStructuredKey_struct_mid_anotherLeaf,
@@ -143,7 +143,7 @@ describe('assign element onto columns with flat model', () => {
   })
 
   it('foreign key is adjacent to its association in flat model and is renamed', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.TestPublisher {
         ID,
         publisherRenamedKey
@@ -151,7 +151,7 @@ describe('assign element onto columns with flat model', () => {
     `, model)
     // structured key is renamed in model:
     // --> `key publisherRenamedKey : Association to Publisher { structuredKey.ID as notID };`
-    const expected = CQL`SELECT from bookshop.TestPublisher as TestPublisher {
+    const expected = cds.ql`SELECT from bookshop.TestPublisher as TestPublisher {
         TestPublisher.ID,
         TestPublisher.publisherRenamedKey_notID
     }

--- a/db-service/test/cqn4sql/compare-structs.test.js
+++ b/db-service/test/cqn4sql/compare-structs.test.js
@@ -111,18 +111,18 @@ describe('compare structures', () => {
   })
 
   it('list in where', () => {
-    let query = CQL`SELECT from bookshop.Books { ID } where (author.ID, 1) in ('foo', 'bar')`
-    let expected = CQL`SELECT from bookshop.Books as Books { Books.ID } where (Books.author_ID, 1) in ('foo', 'bar')`
+    let query = cds.ql`SELECT from bookshop.Books { ID } where (author.ID, 1) in ('foo', 'bar')`
+    let expected = cds.ql`SELECT from bookshop.Books as Books { Books.ID } where (Books.author_ID, 1) in ('foo', 'bar')`
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('tuple list in where', () => {
-    let query = CQL`SELECT from bookshop.Books { ID } where (author.ID, 1) in (('foo', 1), ('bar', 2))`
-    let expected = CQL`SELECT from bookshop.Books as Books { Books.ID } where (Books.author_ID, 1) in (('foo', 1), ('bar', 2))`
+    let query = cds.ql`SELECT from bookshop.Books { ID } where (author.ID, 1) in (('foo', 1), ('bar', 2))`
+    let expected = cds.ql`SELECT from bookshop.Books as Books { Books.ID } where (Books.author_ID, 1) in (('foo', 1), ('bar', 2))`
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
   it('list in having', () => {
-    let query = CQL`SELECT from bookshop.Books { ID } having (author.ID, 1) in ('foo', 'bar')`
-    let expected = CQL`SELECT from bookshop.Books as Books { Books.ID } having (Books.author_ID, 1) in ('foo', 'bar')`
+    let query = cds.ql`SELECT from bookshop.Books { ID } having (author.ID, 1) in ('foo', 'bar')`
+    let expected = cds.ql`SELECT from bookshop.Books as Books { Books.ID } having (Books.author_ID, 1) in ('foo', 'bar')`
     expect(cqn4sql(query, model)).to.deep.equal(expected)
   })
 
@@ -130,10 +130,10 @@ describe('compare structures', () => {
     // `IS NULL` concat with "and"
     // `<> NULL` concat with "or"
     let query = cqn4sql(
-      CQL`SELECT from bookshop.AssocWithStructuredKey as AWSK { ID } where 1<2 and toStructuredKey is null or 2<3 or toStructuredKey <> null`,
+      cds.ql`SELECT from bookshop.AssocWithStructuredKey as AWSK { ID } where 1<2 and toStructuredKey is null or 2<3 or toStructuredKey <> null`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocWithStructuredKey as AWSK { AWSK.ID }
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocWithStructuredKey as AWSK { AWSK.ID }
         where 1<2
           and (AWSK.toStructuredKey_struct_mid_leaf is null
           and AWSK.toStructuredKey_struct_mid_anotherLeaf is null
@@ -145,8 +145,8 @@ describe('compare structures', () => {
   })
 
   it('IS NULL comparison with a structure', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Bar { ID } where Bar.structure is null`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {Bar.ID}
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } where Bar.structure is null`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {Bar.ID}
           where (Bar.structure_foo is null
             and Bar.structure_baz is null)`)
   })

--- a/db-service/test/cqn4sql/expand.test.js
+++ b/db-service/test/cqn4sql/expand.test.js
@@ -12,29 +12,29 @@ describe('Unfold expands on structure', () => {
     cds.model = await cds.load(__dirname + '/../bookshop/db/schema').then(cds.linked)
   })
   it('supports nested projections for structs', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication { addressee } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication { addressee } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books { Books.ID,
+      cds.ql`SELECT from bookshop.Books as Books { Books.ID,
         Books.dedication_addressee_ID,
       }`,
     )
   })
   it('supports deeply nested projections for structs', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication { addressee, sub { foo } } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication { addressee, sub { foo } } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books { Books.ID,
+      cds.ql`SELECT from bookshop.Books as Books { Books.ID,
         Books.dedication_addressee_ID,
         Books.dedication_sub_foo,
       }`,
     )
   })
   it('supports deeply nested projections for structs w/ wildcard', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication { addressee, sub { * } } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication { addressee, sub { * } } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.dedication_addressee_ID,
         Books.dedication_sub_foo,
@@ -42,10 +42,10 @@ describe('Unfold expands on structure', () => {
     )
   })
   it('supports renaming', () => {
-    let query = CQL`SELECT from bookshop.Books { ID as foo, dedication as bubu { addressee, sub { * } } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID as foo, dedication as bubu { addressee, sub { * } } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
         Books.ID as foo,
         Books.dedication_addressee_ID as bubu_addressee_ID,
         Books.dedication_sub_foo as bubu_sub_foo,
@@ -53,10 +53,10 @@ describe('Unfold expands on structure', () => {
     )
   })
   it('supports nested projections for structs w/ order by', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication as bubu { addressee, sub { * } } } order by bubu.sub.foo`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication as bubu { addressee, sub { * } } } order by bubu.sub.foo`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.dedication_addressee_ID as bubu_addressee_ID,
         Books.dedication_sub_foo as bubu_sub_foo,
@@ -65,10 +65,10 @@ describe('Unfold expands on structure', () => {
   })
 
   it('supports nested projections for structs with wildcard select and respects order', () => {
-    let query = CQL`SELECT from bookshop.Books { dedication {text, * } }`
+    let query = cds.ql`SELECT from bookshop.Books { dedication {text, * } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
         Books.dedication_text,
         Books.dedication_addressee_ID,
         Books.dedication_sub_foo,
@@ -77,10 +77,10 @@ describe('Unfold expands on structure', () => {
     )
   })
   it('supports nested projections for structs with wildcard select', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication { * } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication { * } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books { Books.ID,
+      cds.ql`SELECT from bookshop.Books as Books { Books.ID,
         Books.dedication_addressee_ID,
         Books.dedication_text,
         Books.dedication_sub_foo,
@@ -89,10 +89,10 @@ describe('Unfold expands on structure', () => {
     )
   })
   it('supports nested projections for structs with smart wildcard', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication { *, 5 as text } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication { *, 5 as text } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.dedication_addressee_ID,
         5 as dedication_text,
@@ -103,10 +103,10 @@ describe('Unfold expands on structure', () => {
   })
 
   it('supports nested projections for structs with join relevant path expression', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication { addressee.name } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication { addressee.name } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books
+      cds.ql`SELECT from bookshop.Books as Books
           left outer join bookshop.Person as addressee on addressee.ID = Books.dedication_addressee_ID {
             Books.ID,
             addressee.name as dedication_addressee_name
@@ -114,10 +114,10 @@ describe('Unfold expands on structure', () => {
     )
   })
   it('supports nested projections for structs with join relevant path expression w/ infix filter', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, dedication { addressee[ID=42].name } }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, dedication { addressee[ID=42].name } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books
+      cds.ql`SELECT from bookshop.Books as Books
           left outer join bookshop.Person as addressee on addressee.ID = Books.dedication_addressee_ID and addressee.ID = 42 {
             Books.ID,
             addressee.name as dedication_addressee_name
@@ -125,13 +125,13 @@ describe('Unfold expands on structure', () => {
     )
   })
   it('nested projection of assoc within structured expand', () => {
-    let query = CQL`SELECT from bookshop.Books {
+    let query = cds.ql`SELECT from bookshop.Books {
                     ID,
                     dedication { text, addressee { name } }
                   }`
     let transformed = cqn4sql(query)
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             Books.dedication_text,
             (
@@ -144,10 +144,10 @@ describe('Unfold expands on structure', () => {
   })
 
   it('handles smart wildcard and respects order', () => {
-    let query = CQL`SELECT from bookshop.Books { dedication { 'first' as first, 'second' as sub, *, 5 as ![5], 'Baz' as text } }`
+    let query = cds.ql`SELECT from bookshop.Books { dedication { 'first' as first, 'second' as sub, *, 5 as ![5], 'Baz' as text } }`
     let transformed = cqn4sql(query)
     expect(transformed).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
         'first' as dedication_first,
         'second' as dedication_sub,
         Books.dedication_addressee_ID,
@@ -159,13 +159,13 @@ describe('Unfold expands on structure', () => {
   })
 
   it('structured expand within nested projection of assoc within structured expand', () => {
-    let query = CQL`SELECT from bookshop.Books {
+    let query = cds.ql`SELECT from bookshop.Books {
                     ID,
                     dedication { text, addressee { name, address { * } } }
                   }`
     let transformed = cqn4sql(query)
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books {
+      cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             Books.dedication_text,
             (
@@ -191,23 +191,23 @@ describe('Unfold expands on associations to special subselects', () => {
   // - they can select multiple columns
   // - they can return multiple rows
   it('rejects unmanaged association in infix filter of expand path', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { author[books.title = 'foo'] { name } }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { author[books.title = 'foo'] { name } }`, model)).to.throw(
       /Unexpected unmanaged association “books” in filter expression of “author”/,
     )
   })
   it('rejects non-fk access in infix filter of expand path', () => {
     expect(() =>
-      cqn4sql(CQL`SELECT from bookshop.EStrucSibling { self[sibling.struc1 = 'foo'] { ID } }`, model),
+      cqn4sql(cds.ql`SELECT from bookshop.EStrucSibling { self[sibling.struc1 = 'foo'] { ID } }`, model),
     ).to.throw(/Only foreign keys of “sibling” can be accessed in infix filter/)
   })
   it('unfold expand, one field', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { name }
     }`
     const res = cqn4sql(q)
     expect(res.SELECT.columns[0].SELECT).to.have.property('expand').that.equals(true)
     expect(res.SELECT.columns[0].SELECT).to.have.property('one').that.equals(true)
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
       (
         SELECT from bookshop.Authors as author {
           author.name
@@ -266,7 +266,7 @@ describe('Unfold expands on associations to special subselects', () => {
     }
 
     const res = cqn4sql(q)
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
       (
         SELECT from bookshop.Authors as author {
           author.name
@@ -283,7 +283,7 @@ describe('Unfold expands on associations to special subselects', () => {
   it('do not loose additional properties on expand column if defined in ref', () => {
     const q = cds.ql`SELECT from bookshop.Authors { books[order by price] { title } }`
     const res = cqn4sql(q)
-    const expected = CQL`SELECT from bookshop.Authors as Authors {
+    const expected = cds.ql`SELECT from bookshop.Authors as Authors {
       (
         SELECT from bookshop.Books as books {
           books.title
@@ -330,7 +330,7 @@ describe('Unfold expands on associations to special subselects', () => {
     }
 
     const res = cqn4sql(q)
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
       (
         SELECT from bookshop.Authors as author {
           author.name
@@ -378,7 +378,7 @@ describe('Unfold expands on associations to special subselects', () => {
       },
     }
 
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
       (
         SELECT from bookshop.Authors as author {
           author.name
@@ -402,7 +402,7 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, make sure the prototype of the subquery is not polluted', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { name }
     }`
     const res = cqn4sql(q)
@@ -411,11 +411,11 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('enforce external alias to texts expand', () => {
-    const q = CQL`SELECT from bookshop.Books as NotBooks {
+    const q = cds.ql`SELECT from bookshop.Books as NotBooks {
       ID,
       texts { locale }
     }`
-    const qx = CQL`SELECT from bookshop.Books as NotBooks {
+    const qx = cds.ql`SELECT from bookshop.Books as NotBooks {
       NotBooks.ID,
       (
         SELECT texts.locale
@@ -428,10 +428,10 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, one field w/ infix filter', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author[name='King' or name like '%Sanderson'] { name }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       (SELECT author.name from bookshop.Authors as author
         where Books.author_ID = author.ID and (author.name = 'King' or author.name like '%Sanderson')) as author
     }`
@@ -442,12 +442,12 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('backlink with simple condition AND backlink', () => {
-    let query = cqn4sql(CQL`
+    let query = cqn4sql(cds.ql`
       SELECT from bookshop.SoccerTeams {
         goalKeeper { name }
       }
     `)
-    let expected = CQL`
+    let expected = cds.ql`
       SELECT from bookshop.SoccerTeams as SoccerTeams {
         (
           SELECT from bookshop.SoccerPlayers as goalKeeper {
@@ -462,10 +462,10 @@ describe('Unfold expands on associations to special subselects', () => {
   // TODO: aliases of outer query needs to be considered
   // still valid sql in this case
   it('unfold expand, with subquery in expand', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { name, (select title from bookshop.Books) as book }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       (SELECT
           author.name,
           (select Books2.title from bookshop.Books as Books2) as book
@@ -479,10 +479,10 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('correctly builds correlated subquery if selecting from subquery', () => {
-    const q = CQL`SELECT from (select author from bookshop.Books) as book {
+    const q = cds.ql`SELECT from (select author from bookshop.Books) as book {
       author { name }
     }`
-    const qx = CQL`SELECT from (select Books.author_ID from bookshop.Books as Books) as book {
+    const qx = cds.ql`SELECT from (select Books.author_ID from bookshop.Books as Books) as book {
       (SELECT
           author.name
         from bookshop.Authors as author
@@ -493,10 +493,10 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, several fields with alias', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { name, dateOfBirth as dob, placeOfBirth as pob}
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       (SELECT author.name, author.dateOfBirth as dob, author.placeOfBirth as pob
          from bookshop.Authors as author where Books.author_ID = author.ID) as author
     }`
@@ -507,10 +507,10 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, several fields with expressions', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { name, substring(placeOfBirth, 1, 1) as pob }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       (SELECT author.name, substring(author.placeOfBirth, 1, 1) as pob
          from bookshop.Authors as author where Books.author_ID = author.ID) as author
     }`
@@ -521,10 +521,10 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, structured field', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { name, address }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       ( SELECT
         author.name, author.address_street, author.address_city
         from bookshop.Authors as author where Books.author_ID = author.ID) as author
@@ -535,10 +535,10 @@ describe('Unfold expands on associations to special subselects', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('unfold expand, structured field with alias', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { name, address as BUBU }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       ( SELECT
         author.name, author.address_street as BUBU_street, author.address_city as BUBU_city
         from bookshop.Authors as author where Books.author_ID = author.ID) as author
@@ -550,10 +550,10 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, *', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author { * }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       ( SELECT
         author.createdAt, author.createdBy, author.modifiedAt, author.modifiedBy,
         author.ID, author.name, author.dateOfBirth, author.dateOfDeath, author.placeOfBirth, author.placeOfDeath,
@@ -568,10 +568,10 @@ describe('Unfold expands on associations to special subselects', () => {
 
   // explicit alias for struc name is also used as table alias for subquery
   it('unfold expand, with association alias', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author as a { name }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       (SELECT a.name from bookshop.Authors as a where Books.author_ID  = a.ID) as a
     }`
     const res = cqn4sql(q)
@@ -581,10 +581,10 @@ describe('Unfold expands on associations to special subselects', () => {
   // if the provided alias needs to be renamed when used as table alias, the alias for the element
   // must not change
   it('unfold expand, with duplicate association alias', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author as books { name }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       (SELECT books2.name from bookshop.Authors as books2 where Books.author_ID = books2.ID) as books
     }`
     const res = cqn4sql(q)
@@ -592,11 +592,11 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, two expands', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author as a1 { name },
       author as a2 { name }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       (SELECT a1.name from bookshop.Authors as a1
         where Books.author_ID = a1.ID) as a1,
       (SELECT a2.name from bookshop.Authors as a2
@@ -611,13 +611,13 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, with path expressions in nested projection', () => {
-    const q = CQL`SELECT from bookshop.Authors {
+    const q = cds.ql`SELECT from bookshop.Authors {
       books {
         title,
         genre.name
       }
     }`
-    const qx = CQL`SELECT from bookshop.Authors as Authors {
+    const qx = cds.ql`SELECT from bookshop.Authors as Authors {
       (SELECT books.title, genre.name AS genre_name
         FROM bookshop.Books AS books
         LEFT JOIN bookshop.Genres AS genre ON genre.ID = books.genre_ID
@@ -631,11 +631,11 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, expand after association', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       title,
       author.books { title }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       {
         Books.title,
@@ -649,12 +649,12 @@ describe('Unfold expands on associations to special subselects', () => {
 
   // TODO (SMW) new test
   it('unfold expand, expand after association (2)', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       title,
       author.name,
       author.books { title }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       {
         Books.title,
@@ -668,12 +668,12 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, expand after association (3) with infix filter on last step', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       title,
       author.name,
       author.books[title = 'foo'] { title }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       {
         Books.title,
@@ -687,12 +687,12 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, expand after association (4) with infix filter in intermediate step', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       title,
       author.name,
       Books.author.books.genre[name = 'foo'] { name }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       left outer join bookshop.Books as books2 on books2.author_ID = author.ID
       {
@@ -706,12 +706,12 @@ describe('Unfold expands on associations to special subselects', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('unfold expand, expand after association (5) with infix filter on first step', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       title,
       author[name='Sanderson'].name,
       author[name='Sanderson'].books.genre { name }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID and author.name = 'Sanderson'
       left outer join bookshop.Books as books2 on books2.author_ID = author.ID
       {
@@ -726,11 +726,11 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, expand after association (6) with assoc as key', () => {
-    const q = CQL`SELECT from bookshop.AssocAsKey {
+    const q = cds.ql`SELECT from bookshop.AssocAsKey {
       foo,
       toAuthor.books { title }
     }`
-    const qx = CQL`SELECT from bookshop.AssocAsKey as AssocAsKey
+    const qx = cds.ql`SELECT from bookshop.AssocAsKey as AssocAsKey
     left outer join bookshop.Authors as toAuthor on toAuthor.ID = AssocAsKey.toAuthor_ID
       {
         AssocAsKey.foo,
@@ -748,8 +748,8 @@ describe('Unfold expands on associations to special subselects', () => {
 
   // TODO clarify if it would be okay to only forbid addressing to many expands
   it('unfold expand // reference in order by is NOT referring to expand column', () => {
-    const input = CQL`SELECT from bookshop.Books.twin { author { name } } order by author.name asc`
-    let qx = CQL`SELECT from bookshop.Books.twin as twin
+    const input = cds.ql`SELECT from bookshop.Books.twin { author { name } } order by author.name asc`
+    let qx = cds.ql`SELECT from bookshop.Books.twin as twin
     left outer join bookshop.Authors as author on author.ID = twin.author_ID
     {
       (
@@ -763,11 +763,11 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand within structure', () => {
-    const q = CQL`SELECT from bookshop.DeepRecursiveAssoc {
+    const q = cds.ql`SELECT from bookshop.DeepRecursiveAssoc {
       ID,
       one.two.three.toSelf { ID }
     }`
-    const qx = CQL`SELECT from bookshop.DeepRecursiveAssoc as DeepRecursiveAssoc {
+    const qx = cds.ql`SELECT from bookshop.DeepRecursiveAssoc as DeepRecursiveAssoc {
         DeepRecursiveAssoc.ID,
         (
           SELECT one_two_three_toSelf.ID
@@ -781,11 +781,11 @@ describe('Unfold expands on associations to special subselects', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('unfold expand within structure (2) + joins', () => {
-    const q = CQL`SELECT from bookshop.DeepRecursiveAssoc {
+    const q = cds.ql`SELECT from bookshop.DeepRecursiveAssoc {
       ID,
       one.two.three.toSelf.one.two.three.toSelf { ID }
     }`
-    const qx = CQL`SELECT from bookshop.DeepRecursiveAssoc as DeepRecursiveAssoc
+    const qx = cds.ql`SELECT from bookshop.DeepRecursiveAssoc as DeepRecursiveAssoc
     left outer join bookshop.DeepRecursiveAssoc as toSelf on
       toSelf.ID = DeepRecursiveAssoc.one_two_three_toSelf_ID
     {
@@ -803,7 +803,7 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold nested expands', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       author {
         books {
           genre {
@@ -812,7 +812,7 @@ describe('Unfold expands on associations to special subselects', () => {
         }
       }
     }`
-    const qx = CQL`SELECT from bookshop.Books as Books {
+    const qx = cds.ql`SELECT from bookshop.Books as Books {
       ( SELECT
           ( SELECT
             ( SELECT genre.name
@@ -840,11 +840,11 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('unfold expand, with assoc in FROM', () => {
-    const q = CQL`SELECT from bookshop.Books:author {
+    const q = cds.ql`SELECT from bookshop.Books:author {
       name,
       books { title }
     }`
-    const qx = CQL`SELECT from bookshop.Authors as author {
+    const qx = cds.ql`SELECT from bookshop.Authors as author {
       author.name,
       (SELECT books2.title from bookshop.Books as books2
         where author.ID = books2.author_ID) as books
@@ -855,11 +855,11 @@ describe('Unfold expands on associations to special subselects', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.eql(qx)
   })
   it('expand on assoc respects smart wildcard rules', () => {
-    const q = CQL`SELECT from bookshop.Authors {
+    const q = cds.ql`SELECT from bookshop.Authors {
       name,
       books { 'first' as first, 'second' as ID, *, 'third' as createdAt, 'last' as last }
     }`
-    const qx = CQL`SELECT from bookshop.Authors as Authors {
+    const qx = cds.ql`SELECT from bookshop.Authors as Authors {
       Authors.name,
       (SELECT
         'first' as first,
@@ -894,7 +894,7 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('correctly calculates aliases for refs of on condition within xpr', () => {
-    const q = CQL`SELECT from bookshop.WorklistItems {
+    const q = cds.ql`SELECT from bookshop.WorklistItems {
       ID,
       releaseChecks {
         ID,
@@ -903,7 +903,7 @@ describe('Unfold expands on associations to special subselects', () => {
         }
       }
     }`
-    const expected = CQL`SELECT from bookshop.WorklistItems as WorklistItems {
+    const expected = cds.ql`SELECT from bookshop.WorklistItems as WorklistItems {
       WorklistItems.ID,
       (
         SELECT from bookshop.WorklistItem_ReleaseChecks as releaseChecks {
@@ -927,20 +927,20 @@ describe('Unfold expands on associations to special subselects', () => {
   })
 
   it('ignores expands which target ”@cds.persistence.skip”', () => {
-    const q = CQL`SELECT from bookshop.NotSkipped {
+    const q = cds.ql`SELECT from bookshop.NotSkipped {
       ID, skipped { text }
     }`
-    const qx = CQL`SELECT from bookshop.NotSkipped as NotSkipped {
+    const qx = cds.ql`SELECT from bookshop.NotSkipped as NotSkipped {
       NotSkipped.ID
     }`
     const res = cqn4sql(q)
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('ignores expand if assoc in path expression has target ”@cds.persistence.skip”', () => {
-    const q = CQL`SELECT from bookshop.NotSkipped {
+    const q = cds.ql`SELECT from bookshop.NotSkipped {
       ID, skipped.notSkipped { text }
     }`
-    const qx = CQL`SELECT from bookshop.NotSkipped as NotSkipped {
+    const qx = cds.ql`SELECT from bookshop.NotSkipped as NotSkipped {
       NotSkipped.ID
     }`
     const res = cqn4sql(q)
@@ -948,7 +948,7 @@ describe('Unfold expands on associations to special subselects', () => {
   })
   describe('anonymous expand', () => {
     it('scalar elements', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
         ID,
         {
           title,
@@ -956,7 +956,7 @@ describe('Unfold expands on associations to special subselects', () => {
           price
         } as bookInfos
       }`
-      const qx = CQL`SELECT from bookshop.Books as Books {
+      const qx = cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.title as bookInfos_title,
         Books.descr as bookInfos_descr,
@@ -966,7 +966,7 @@ describe('Unfold expands on associations to special subselects', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
     })
     it('scalar elements, structure with renaming and association', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
         ID,
         {
           title,
@@ -975,7 +975,7 @@ describe('Unfold expands on associations to special subselects', () => {
           dedication.sub as deep
         } as bookInfos
       }`
-      const qx = CQL`SELECT from bookshop.Books as Books {
+      const qx = cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.title as bookInfos_title,
         Books.author_ID as bookInfos_author_ID,
@@ -986,7 +986,7 @@ describe('Unfold expands on associations to special subselects', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
     })
     it('mixed with inline', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
         ID,
         {
           dedication.{
@@ -994,7 +994,7 @@ describe('Unfold expands on associations to special subselects', () => {
           }
         } as bookInfos
       }`
-      const qx = CQL`SELECT from bookshop.Books as Books {
+      const qx = cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.dedication_addressee_ID as bookInfos_dedication_addressee_ID,
         Books.dedication_text as bookInfos_dedication_text,
@@ -1005,13 +1005,13 @@ describe('Unfold expands on associations to special subselects', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
     })
     it('join relevant association', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
         ID,
         {
           author.name
         } as bookInfos
       }`
-      const qx = CQL`SELECT from bookshop.Books as Books
+      const qx = cds.ql`SELECT from bookshop.Books as Books
         left join bookshop.Authors as author on author.ID = Books.author_ID
       {
         Books.ID,
@@ -1028,8 +1028,8 @@ describe('Unfold expands on associations to special subselects', () => {
     })
 
     it('assoc comparison needs to be expanded in on condition calculation', () => {
-      const query = cqn4sql(CQL`SELECT from a2j.Foo { ID, buz { foo } }`, model)
-      const expected = CQL`
+      const query = cqn4sql(cds.ql`SELECT from a2j.Foo { ID, buz { foo } }`, model)
+      const expected = cds.ql`
         SELECT from a2j.Foo as Foo {
           Foo.ID,
           (
@@ -1040,8 +1040,8 @@ describe('Unfold expands on associations to special subselects', () => {
       expect(JSON.parse(JSON.stringify(query))).to.eql(expected)
     })
     it('unmanaged association path traversal in on condition needs to be flattened', () => {
-      const query = cqn4sql(CQL`SELECT from a2j.Foo { ID, buzUnmanaged { foo } }`, model)
-      const expected = CQL`
+      const query = cqn4sql(cds.ql`SELECT from a2j.Foo { ID, buzUnmanaged { foo } }`, model)
+      const expected = cds.ql`
         SELECT from a2j.Foo as Foo {
           Foo.ID,
           (
@@ -1056,7 +1056,7 @@ describe('Unfold expands on associations to special subselects', () => {
     // innermost expand on association with backlink plus additional condition
     // must be properly linked
     const model = await cds.load(__dirname + '/model/collaborations').then(cds.linked)
-    const q = CQL`
+    const q = cds.ql`
       SELECT from Collaborations {
         id,
         leads {
@@ -1071,7 +1071,7 @@ describe('Unfold expands on associations to special subselects', () => {
       }
     `
     let transformed = cqn4sql(q, cds.compile.for.nodejs(JSON.parse(JSON.stringify(model))))
-    expect(JSON.parse(JSON.stringify(transformed))).to.deep.eql(CQL`
+    expect(JSON.parse(JSON.stringify(transformed))).to.deep.eql(cds.ql`
       SELECT from Collaborations as Collaborations {
         Collaborations.id,
         (
@@ -1101,12 +1101,12 @@ describe('Expands with aggregations are special', () => {
   })
 
   it('simple aggregation', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { name }
     } group by author.name`
 
-    const qx = CQL`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
+    const qx = cds.ql`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
       Books.ID,
       (SELECT from DUMMY { author.name as name }) as author
     } group by author.name`
@@ -1116,12 +1116,12 @@ describe('Expands with aggregations are special', () => {
   })
 
   it('aggregation with mulitple path steps', () => {
-    const q = CQL`SELECT from bookshop.Intermediate {
+    const q = cds.ql`SELECT from bookshop.Intermediate {
       ID,
       toAssocWithStructuredKey { toStructuredKey { second } }
     } group by toAssocWithStructuredKey.toStructuredKey.second`
 
-    const qx = CQL`SELECT from bookshop.Intermediate as Intermediate
+    const qx = cds.ql`SELECT from bookshop.Intermediate as Intermediate
     left join bookshop.AssocWithStructuredKey as toAssocWithStructuredKey
       on toAssocWithStructuredKey.ID = Intermediate.toAssocWithStructuredKey_ID
     {
@@ -1139,12 +1139,12 @@ describe('Expands with aggregations are special', () => {
   })
   it.skip('simple aggregation expand ref wrapped in func', () => {
     // TODO: how to detect the nested ref?
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { toLower(name) as lower }
     } group by author.name`
 
-    const qx = CQL`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
+    const qx = cds.ql`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
       Books.ID,
       (SELECT from DUMMY { toLower(author.name) as name }) as author
     } group by author.name`
@@ -1155,12 +1155,12 @@ describe('Expands with aggregations are special', () => {
   })
 
   it('wildcard expand vanishes for aggregations', () => {
-    const q = CQL`SELECT from bookshop.TestPublisher {
+    const q = cds.ql`SELECT from bookshop.TestPublisher {
       ID,
       texts { publisher {*} }
     } group by ID, publisher.structuredKey_ID, publisher.title`
 
-    const qx = CQL`SELECT from bookshop.TestPublisher as TestPublisher
+    const qx = cds.ql`SELECT from bookshop.TestPublisher as TestPublisher
     left join bookshop.Publisher as publisher on publisher.structuredKey_ID = TestPublisher.publisher_structuredKey_ID {
       TestPublisher.ID
     } group by TestPublisher.ID, TestPublisher.publisher_structuredKey_ID, publisher.title`
@@ -1170,12 +1170,12 @@ describe('Expands with aggregations are special', () => {
   })
 
   it('aggregation with structure', () => {
-    const q = CQL`SELECT from bookshop.Authors as Authors {
+    const q = cds.ql`SELECT from bookshop.Authors as Authors {
       ID,
       books { dedication }
     } group by books.dedication`
 
-    const qx = CQL`SELECT from bookshop.Authors as Authors left join bookshop.Books as books on books.author_ID = Authors.ID {
+    const qx = cds.ql`SELECT from bookshop.Authors as Authors left join bookshop.Books as books on books.author_ID = Authors.ID {
       Authors.ID,
       (SELECT from DUMMY { 
         books.dedication_addressee_ID as dedication_addressee_ID,
@@ -1189,12 +1189,12 @@ describe('Expands with aggregations are special', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('optimized foreign key access', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { name, ID }
     } group by author.name, author.ID`
 
-    const qx = CQL`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
+    const qx = cds.ql`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
       Books.ID,
       (SELECT from DUMMY { author.name as name, Books.author_ID as ID }) as author
     } group by author.name, Books.author_ID`
@@ -1203,12 +1203,12 @@ describe('Expands with aggregations are special', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('foreign key access renamed', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { name, ID as foo }
     } group by author.name, author.ID`
 
-    const qx = CQL`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
+    const qx = cds.ql`SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID {
       Books.ID,
       (SELECT from DUMMY { author.name as name, Books.author_ID as foo }) as author
     } group by author.name, Books.author_ID`
@@ -1217,12 +1217,12 @@ describe('Expands with aggregations are special', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('non optimized foreign key access with filters', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author[ID = 201] { name, ID }
     } group by author[ID = 201].name, author[ID = 201].ID`
 
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
       left join bookshop.Authors as author on author.ID = Books.author_ID and author.ID = 201
     {
       Books.ID,
@@ -1233,12 +1233,12 @@ describe('Expands with aggregations are special', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('expand path with filter must be an exact match in group by', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       Books.ID,
       author[name='King'] { name }
     } group by author[name='King'].name`
 
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
     left join bookshop.Authors as author on author.ID = Books.author_ID and author.name = 'King' {
       Books.ID,
       (SELECT from DUMMY { author.name as name }) as author
@@ -1249,13 +1249,13 @@ describe('Expands with aggregations are special', () => {
   })
 
   it('with multiple expands', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { name },
       genre { name }
     } group by author.name, genre.name`
 
-    const qx = CQL`SELECT from bookshop.Books as Books
+    const qx = cds.ql`SELECT from bookshop.Books as Books
     left join bookshop.Authors as author on author.ID = Books.author_ID
     left join bookshop.Genres as genre on genre.ID = Books.genre_ID
     {
@@ -1269,12 +1269,12 @@ describe('Expands with aggregations are special', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('with nested expands', () => {
-    const q = CQL`SELECT from bookshop.Genres {
+    const q = cds.ql`SELECT from bookshop.Genres {
       ID,
       Genres.parent { parent { name } },
     } group by parent.parent.name`
 
-    const qx = CQL`SELECT from bookshop.Genres as Genres
+    const qx = cds.ql`SELECT from bookshop.Genres as Genres
     left join bookshop.Genres as parent on parent.ID = Genres.parent_ID
     left join bookshop.Genres as parent2 on parent2.ID = parent.parent_ID
     {
@@ -1291,12 +1291,12 @@ describe('Expands with aggregations are special', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
   })
   it('with nested expands and non-nested sibling', () => {
-    const q = CQL`SELECT from bookshop.Genres {
+    const q = cds.ql`SELECT from bookshop.Genres {
       ID,
       Genres.parent { parent { name }, name },
     } group by parent.parent.name, parent.name`
 
-    const qx = CQL`SELECT from bookshop.Genres as Genres
+    const qx = cds.ql`SELECT from bookshop.Genres as Genres
     left join bookshop.Genres as parent on parent.ID = Genres.parent_ID
     left join bookshop.Genres as parent2 on parent2.ID = parent.parent_ID
     {
@@ -1316,7 +1316,7 @@ describe('Expands with aggregations are special', () => {
 
   // negative tests
   it('simple path not part of group by', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { name, ID }
     } group by author.name`
@@ -1324,7 +1324,7 @@ describe('Expands with aggregations are special', () => {
     expect(() => cqn4sql(q, model)).to.throw(/The expanded column "author.ID" must be part of the group by clause/)
   })
   it('nested path not part of group by', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { books {title}, ID }
     } group by author.ID`
@@ -1334,7 +1334,7 @@ describe('Expands with aggregations are special', () => {
     )
   })
   it('deeply nested path not part of group by', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       ID,
       Books.author { books { author { name } } , ID }
     } group by author.ID`
@@ -1345,7 +1345,7 @@ describe('Expands with aggregations are special', () => {
   })
 
   it('expand path with filter must be an exact match in group by', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       Books.ID,
       author[name='King'] { name }
     } group by author.name`
@@ -1355,7 +1355,7 @@ describe('Expands with aggregations are special', () => {
     )
   })
   it('expand path with filter must be an exact match in group by (2)', () => {
-    const q = CQL`SELECT from bookshop.Books {
+    const q = cds.ql`SELECT from bookshop.Books {
       Books.ID,
       author { name }
     } group by author[name='King'].name`
@@ -1373,27 +1373,27 @@ describe('expand on structure part II', () => {
   })
 
   it('simple structural expansion', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
       office {
         floor,
         room
       }
     }`
 
-    let expected = CQL`select from Employee as Employee {
+    let expected = cds.ql`select from Employee as Employee {
       Employee.office_floor,
       Employee.office_room
     }`
     expect(cqn4sql(expandQuery, model)).to.eql(expected)
   })
   it('structural expansion with path expression', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
       office {
         floor,
         building.name
       }
     }`
-    let expected = CQL`select from Employee as Employee
+    let expected = cds.ql`select from Employee as Employee
     left join Building as building on building.id = Employee.office_building_id
     {
       Employee.office_floor,
@@ -1403,7 +1403,7 @@ describe('expand on structure part II', () => {
   })
 
   it('deep expand', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
           office {
             floor,
             address {
@@ -1412,7 +1412,7 @@ describe('expand on structure part II', () => {
             }
           }
     }`
-    let expected = CQL`SELECT from Employee as Employee {
+    let expected = cds.ql`SELECT from Employee as Employee {
         Employee.office_floor,
         Employee.office_address_city,
         Employee.office_address_street
@@ -1421,7 +1421,7 @@ describe('expand on structure part II', () => {
   })
 
   it('multi expand with star - foreign key must survive in flat mode', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
         *,
         department {
           id,
@@ -1432,7 +1432,7 @@ describe('expand on structure part II', () => {
           descr
         }
     } excluding { office_floor, office_address_country, office_building, office_room, office_building_id, office_address_city, office_building_id, office_address_street, office_address_country_code, office_address_country_code, office_furniture_chairs,office_furniture_desks }`
-    let expected = CQL`SELECT from Employee as Employee {
+    let expected = cds.ql`SELECT from Employee as Employee {
         Employee.id,
         Employee.name,
         Employee.job,
@@ -1446,7 +1446,7 @@ describe('expand on structure part II', () => {
   })
 
   it('multi expand with star but foreign key does not survive in structured mode', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
         *,
         department {
           id,
@@ -1457,7 +1457,7 @@ describe('expand on structure part II', () => {
           descr
         }
     } excluding { office }`
-    let expected = CQL`SELECT from Employee as Employee {
+    let expected = cds.ql`SELECT from Employee as Employee {
         Employee.id,
         Employee.name,
         Employee.job,
@@ -1468,7 +1468,7 @@ describe('expand on structure part II', () => {
   })
 
   it('structured expand with deep assoc expand', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
       office {
         floor,
         address {
@@ -1478,7 +1478,7 @@ describe('expand on structure part II', () => {
         }
       }
     }`
-    let expected = CQL`select from Employee as Employee {
+    let expected = cds.ql`select from Employee as Employee {
       Employee.office_floor,
       Employee.office_address_city,
       Employee.office_address_street,
@@ -1491,7 +1491,7 @@ describe('expand on structure part II', () => {
     expect(JSON.parse(JSON.stringify(cqn4sql(expandQuery, model)))).to.eql(expected)
   })
   it('deep, structured expand', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
       office {
         floor,
         address {
@@ -1500,7 +1500,7 @@ describe('expand on structure part II', () => {
         }
       }
     }`
-    let expected = CQL`select from Employee as Employee{
+    let expected = cds.ql`select from Employee as Employee{
       Employee.office_floor,
       Employee.office_address_city,
       Employee.office_address_street,
@@ -1508,7 +1508,7 @@ describe('expand on structure part II', () => {
     expect(cqn4sql(expandQuery, model)).to.eql(expected)
   })
   it('deep expand on assoc within structure expand', () => {
-    let expandQuery = CQL`select from Employee {
+    let expandQuery = cds.ql`select from Employee {
       office {
         floor,
         building {
@@ -1516,7 +1516,7 @@ describe('expand on structure part II', () => {
         }
       }
     }`
-    let expected = CQL`select from Employee as Employee {
+    let expected = cds.ql`select from Employee as Employee {
       Employee.office_floor,
       (
         select office_building.id from Building as office_building
@@ -1528,10 +1528,10 @@ describe('expand on structure part II', () => {
   })
 
   it('wildcard expand toplevel', () => {
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office { * }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.floor,
       office.room,
       office.building,
@@ -1539,7 +1539,7 @@ describe('expand on structure part II', () => {
       office.furniture
     }`
 
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
       EmployeeNoUnmanaged.office_floor,
       EmployeeNoUnmanaged.office_room,
       EmployeeNoUnmanaged.office_building_id,
@@ -1554,10 +1554,10 @@ describe('expand on structure part II', () => {
     expect(wildcard).to.eql(absolute).to.eql(expected)
   })
   it('wildcard on expand deep', () => {
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office { address {*} }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
       EmployeeNoUnmanaged.office_address_city,
       EmployeeNoUnmanaged.office_address_street,
       EmployeeNoUnmanaged.office_address_country_code,
@@ -1568,10 +1568,10 @@ describe('expand on structure part II', () => {
 
   it('smart wildcard - assoc overwrite after *', () => {
     // office.address.city replaces office.floor
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office { *, furniture as building, address.city as floor, building.id as room }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
       EmployeeNoUnmanaged.office_address_city as office_floor,
       EmployeeNoUnmanaged.office_building_id as office_room,
       EmployeeNoUnmanaged.office_furniture_chairs as office_building_chairs,
@@ -1588,10 +1588,10 @@ describe('expand on structure part II', () => {
 
   it('smart wildcard - structure overwritten by assoc before *', () => {
     // intermediate structures are overwritten
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office.{ building as furniture, * }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_building_id as office_furniture_id,
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
@@ -1604,10 +1604,10 @@ describe('expand on structure part II', () => {
   })
   it('smart wildcard - structure overwritten by join relevant assoc before *', () => {
     // intermediate structures are overwritten
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office { building[name='mega tower'].name as furniture, * }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
       left join Building as building on building.id = EmployeeNoUnmanaged.office_building_id and building.name = 'mega tower'
     {
      building.name as office_furniture,
@@ -1622,10 +1622,10 @@ describe('expand on structure part II', () => {
   })
   it('wildcard - no overwrite but additional cols', () => {
     // intermediate structures are overwritten
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office { *, 'foo' as last }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
     {
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
@@ -1641,20 +1641,20 @@ describe('expand on structure part II', () => {
   })
   it('assigning alias within expand only influences name of element, prefix still appended', () => {
     // intermediate structures are overwritten
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office { floor as x }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_floor as office_x,
     }`
     expect(cqn4sql(expandQuery, model)).to.eql(expected)
   })
   it('smart wildcard - structured overwrite before *', () => {
     // intermediate structures are overwritten
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office { 'first' as furniture, 'second' as building, * }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      'first' as office_furniture,
      'second' as office_building,
      EmployeeNoUnmanaged.office_floor,
@@ -1667,10 +1667,10 @@ describe('expand on structure part II', () => {
   })
   it('smart wildcard - structured overwrite after *', () => {
     // intermediate structures are overwritten
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office {*, 'third' as building, 'fourth' as address }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
      'third' as office_building,
@@ -1683,10 +1683,10 @@ describe('expand on structure part II', () => {
 
   it('wildcard expansion - exclude association', () => {
     // intermediate structures are overwritten
-    let expandQuery = CQL`select from EmployeeNoUnmanaged {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged {
       office {*} excluding { building, address }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
      EmployeeNoUnmanaged.office_furniture_chairs,
@@ -1696,13 +1696,13 @@ describe('expand on structure part II', () => {
   })
 
   it('wildcard expansion sql style on table alias', () => {
-    let expandQuery = CQL`select from EmployeeNoUnmanaged as E {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged as E {
       E {*}
     }`
-    let regularWildcard = CQL`select from EmployeeNoUnmanaged as E {
+    let regularWildcard = cds.ql`select from EmployeeNoUnmanaged as E {
       *
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as E {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as E {
      E.id,
      E.name,
      E.job,
@@ -1719,13 +1719,13 @@ describe('expand on structure part II', () => {
     expect(cqn4sql(expandQuery)).to.eql(cqn4sql(regularWildcard)).to.eql(expected)
   })
   it('wildcard expansion sql style on table alias - exclude stuff', () => {
-    let expandQuery = CQL`select from EmployeeNoUnmanaged as E {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged as E {
       E {*} excluding { office }
     }`
-    let regularWildcard = CQL`select from EmployeeNoUnmanaged as E {
+    let regularWildcard = cds.ql`select from EmployeeNoUnmanaged as E {
       *
     } excluding { office }`
-    let expected = CQL`select from EmployeeNoUnmanaged as E {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as E {
      E.id,
      E.name,
      E.job,
@@ -1737,10 +1737,10 @@ describe('expand on structure part II', () => {
       .to.eql(JSON.parse(JSON.stringify(cqn4sql(regularWildcard)))) // prototype is different
   })
   it('wildcard expansion sql style on IMPLICIT table alias - exclude stuff', () => {
-    let expandQuery = CQL`select from EmployeeNoUnmanaged as E {
+    let expandQuery = cds.ql`select from EmployeeNoUnmanaged as E {
       {*} excluding { office } as FOO
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as E {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as E {
      E.FOO_id,
      E.FOO_name,
      E.FOO_job,

--- a/db-service/test/cqn4sql/flattening.test.js
+++ b/db-service/test/cqn4sql/flattening.test.js
@@ -14,13 +14,13 @@ describe('Flattening', () => {
   describe('in columns', () => {
     it('unfolds structure', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar {
+        cds.ql`SELECT from bookshop.Bar {
               ID,
               structure
             }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
               Bar.ID,
               Bar.structure_foo,
               Bar.structure_baz
@@ -29,13 +29,13 @@ describe('Flattening', () => {
 
     it('unfolds structure also with table alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar as structure {
+        cds.ql`SELECT from bookshop.Bar as structure {
               structure,
               ID
             }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as structure {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as structure {
               structure.structure_foo,
               structure.structure_baz,
               structure.ID
@@ -44,12 +44,12 @@ describe('Flattening', () => {
 
     it('unfolds structure also with alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar {
+        cds.ql`SELECT from bookshop.Bar {
               structure as ding
             }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
               Bar.structure_foo as ding_foo,
               Bar.structure_baz as ding_baz
             }`)
@@ -57,13 +57,13 @@ describe('Flattening', () => {
 
     it('unfolds structure repeatedly if properly aliased', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar {
+        cds.ql`SELECT from bookshop.Bar {
               structure as ding,
               Bar.structure as bing
             }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
               Bar.structure_foo as ding_foo,
               Bar.structure_baz as ding_baz,
               Bar.structure_foo as bing_foo,
@@ -73,12 +73,12 @@ describe('Flattening', () => {
 
     it('unfolds nested structure', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar {
+        cds.ql`SELECT from bookshop.Bar {
               nested
             }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
               Bar.nested_foo_x,
               Bar.nested_bar_a,
               Bar.nested_bar_b
@@ -87,57 +87,57 @@ describe('Flattening', () => {
     // unmanaged ...
 
     it('ignores unmanaged association in SELECT clause (has no value)', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { author, coAuthorUnmanaged }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Books as Books { Books.author_ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { author, coAuthorUnmanaged }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books { Books.author_ID }`)
     })
 
     it('ignores managed composition in SELECT clause (has no value)', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Orders as src { ID, items }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Orders as src { src.ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Orders as src { ID, items }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Orders as src { src.ID }`)
     })
 
     // why?
     it('ignores managed composition in SELECT clause (has no value) even if it results in an empty select list', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Orders as src { items }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Orders as src { }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Orders as src { items }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Orders as src { }`)
     })
     it('rejects struct fields in expressions in SELECT clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { 2*nested as x }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { 2*nested as x }`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects struct fields in expressions in SELECT clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { sin(nested) as x }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { sin(nested) as x }`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed associations in expressions in SELECT clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { 2*author as x }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { 2*author as x }`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
     it('rejects managed associations in expressions in SELECT clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { sin(author) as x }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { sin(author) as x }`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
     it('rejects unmanaged associations in expressions in SELECT clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { 2*coAuthorUnmanaged as x }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { 2*coAuthorUnmanaged as x }`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects unmanaged associations in expressions in SELECT clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { sin(coAuthorUnmanaged) as x }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { sin(coAuthorUnmanaged) as x }`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('unfolds managed associations in SELECT clause', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             author,
             coAuthor,
@@ -145,7 +145,7 @@ describe('Flattening', () => {
           }`,
         model,
       )
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             Books.author_ID,
             Books.coAuthor_ID,
@@ -155,7 +155,7 @@ describe('Flattening', () => {
 
     it('unfolds managed associations in SELECT clause with foreign keys', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             author,
             author_ID,
@@ -166,7 +166,7 @@ describe('Flattening', () => {
           }`,
         cds.linked(cds.compile.for.nodejs(JSON.parse(JSON.stringify(model)))),
       )
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             Books.author_ID,
             Books.coAuthor_ID,
@@ -176,14 +176,14 @@ describe('Flattening', () => {
 
     it('unfolds managed associations in SELECT clause also with table alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as genre {
+        cds.ql`SELECT from bookshop.Books as genre {
             genre.author,
             genre,
             ID
           }`,
         model,
       )
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Books as genre {
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Books as genre {
             genre.author_ID,
             genre.genre_ID,
             genre.ID
@@ -192,14 +192,14 @@ describe('Flattening', () => {
 
     it('unfolds managed associations in SELECT clause also with alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             author as person,
             Books.genre as topic
           }`,
         model,
       )
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             Books.author_ID as person_ID,
             Books.genre_ID as topic_ID
@@ -207,15 +207,15 @@ describe('Flattening', () => {
     })
 
     it('unfolds implicit up_ association in SELECT clause', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Orders.items as src { up_ }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Orders.items as src {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Orders.items as src { up_ }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Orders.items as src {
             src.up__ID
           }`)
     })
 
     it('unfolds managed associations with structured FKs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocWithStructuredKey as src { toStructuredKey }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocWithStructuredKey as src {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocWithStructuredKey as src { toStructuredKey }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocWithStructuredKey as src {
             src.toStructuredKey_struct_mid_leaf,
             src.toStructuredKey_struct_mid_anotherLeaf,
             src.toStructuredKey_second
@@ -224,8 +224,8 @@ describe('Flattening', () => {
 
     // TODO also relevant for "inferred"?
     it('unfolds managed associations with structured FKs (2)', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_struc }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_struc }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_struc_ID_1_a, AM.a_struc_ID_1_b,
             AM.a_struc_ID_2_a, AM.a_struc_ID_2_b
@@ -234,8 +234,8 @@ describe('Flattening', () => {
 
     // TODO also relevant for "inferred"?
     it('unfolds managed associations with explicit simple FKs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucX }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucX }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_strucX_a, AM.a_strucX_b
           }`)
@@ -243,8 +243,8 @@ describe('Flattening', () => {
 
     // TODO also relevant for "inferred"?
     it('unfolds managed associations with explicit structured FKs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucY }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucY }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_strucY_S_1_a, AM.a_strucY_S_1_b,
             AM.a_strucY_S_2_a, AM.a_strucY_S_2_b
@@ -253,8 +253,8 @@ describe('Flattening', () => {
 
     // TODO also relevant for "inferred"?
     it('unfolds managed associations with explicit structured aliased FKs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucXA }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucXA }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_strucXA_T_1_a, AM.a_strucXA_T_1_b,
             AM.a_strucXA_T_2_a, AM.a_strucXA_T_2_b
@@ -263,8 +263,8 @@ describe('Flattening', () => {
 
     // also relevant for "inferred"?
     it('unfolds managed associations with FKs being managed associations', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_assoc }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_assoc }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_assoc_assoc1_ID_1_a, AM.a_assoc_assoc1_ID_1_b,
             AM.a_assoc_assoc1_ID_2_a, AM.a_assoc_assoc1_ID_2_b,
@@ -275,8 +275,8 @@ describe('Flattening', () => {
 
     // also relevant for "inferred"?
     it('unfolds managed associations with explicit FKs being managed associations', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocY }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocY }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_assocY_A_1_a, AM.a_assocY_A_1_b_ID,
             AM.a_assocY_A_2_a, AM.a_assocY_A_2_b_ID
@@ -285,8 +285,8 @@ describe('Flattening', () => {
 
     // also relevant for "inferred"?
     it('unfolds managed associations with explicit aliased FKs being managed associations', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocYA as asso }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocYA as asso }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_assocYA_B_1_a as asso_B_1_a , AM.a_assocYA_B_1_b_ID as asso_B_1_b_ID,
             AM.a_assocYA_B_2_a as asso_B_2_a,  AM.a_assocYA_B_2_b_ID as asso_B_2_b_ID
@@ -295,8 +295,8 @@ describe('Flattening', () => {
 
     // also relevant for "inferred"?
     it('unfolds managed associations with FKs being mix of struc and managed assoc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_strass }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_strass }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_strass_A_1_a,
             AM.a_strass_A_1_b_assoc1_ID_1_a, AM.a_strass_A_1_b_assoc1_ID_1_b,
@@ -313,8 +313,8 @@ describe('Flattening', () => {
 
     // also relevant for "inferred"?
     it('unfolds managed associations with explicit FKs being path into a struc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_part }`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.AssocMaze1 as AM {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_part }`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.AssocMaze1 as AM {
             AM.ID,
             AM.a_part_a,
             AM.a_part_b
@@ -326,14 +326,14 @@ describe('Flattening', () => {
 
     // TODO move out
     it('does not transform queries with multiple query sources, but just returns the inferred query', () => {
-      const query = CQL`SELECT from bookshop.Books, bookshop.Authors {Books.ID as bid, Authors.ID as aid}`
+      const query = cds.ql`SELECT from bookshop.Books, bookshop.Authors {Books.ID as bid, Authors.ID as aid}`
       expect(cqn4sql(query, model)).to.deep.equal(_inferred(query, model))
     })
 
     // skipped as queries with multiple sources are not supported (at least for now)
     it.skip('unfolds association in SELECT clause, two data sources', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books, bookshop.Authors {
+        cds.ql`SELECT from bookshop.Books, bookshop.Authors {
           Books.ID,
           Books.author,
           genre,
@@ -343,7 +343,7 @@ describe('Flattening', () => {
       )
 
       expect(query).to.deep.eql(
-        CQL`SELECT from bookshop.Books as Books, bookshop.Authors as Authors {
+        cds.ql`SELECT from bookshop.Books as Books, bookshop.Authors as Authors {
           Books.ID,
           Books.author_ID,
           Books.genre_ID
@@ -354,7 +354,7 @@ describe('Flattening', () => {
     // skipped as queries with multiple sources are not supported (at least for now)
     it.skip('unfolds association in SELECT clause also with alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books, bookshop.Authors {
+        cds.ql`SELECT from bookshop.Books, bookshop.Authors {
           Books.ID,
           Books.author as a,
           genre as g,
@@ -364,7 +364,7 @@ describe('Flattening', () => {
       )
 
       expect(query).to.deep.eql(
-        CQL`SELECT from bookshop.Books as Books, bookshop.Authors as Authors {
+        cds.ql`SELECT from bookshop.Books as Books, bookshop.Authors as Authors {
           Books.ID,
           Books.author_ID as a_ID,
           Books.genre_ID as g_ID
@@ -375,60 +375,60 @@ describe('Flattening', () => {
   describe('in where', () => {
     it('unfolds structure in subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID } WHERE exists (
+        cds.ql`SELECT from bookshop.Books { ID } WHERE exists (
               SELECT address from bookshop.Authors where ID > Books.ID
               )`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep
-        .equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE exists (
+        .equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE exists (
               SELECT Authors.address_street, Authors.address_city from bookshop.Authors as Authors where Authors.ID > Books.ID
             )`)
     })
     it('rejects struct fields in expressions in WHERE clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } WHERE 2 = nested`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } WHERE 2 = nested`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects struct fields in expressions in WHERE clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } WHERE sin(nested) < 0`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } WHERE sin(nested) < 0`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed association in WHERE clause', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE author`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE author`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed associations in expressions in WHERE clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE 2 = author`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE 2 = author`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed associations in expressions in WHERE clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE sin(author) < 0`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE sin(author) < 0`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
     // (PB) TODO align error message with the examples below
     it('rejects unmanaged associations in WHERE clause', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE coAuthorUnmanaged`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE coAuthorUnmanaged`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects unmanaged associations in expressions in WHERE clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE 2 = coAuthorUnmanaged`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE 2 = coAuthorUnmanaged`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects unmanaged associations in expressions in WHERE clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE sin(coAuthorUnmanaged) > 0`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE sin(coAuthorUnmanaged) > 0`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
@@ -441,13 +441,13 @@ describe('Flattening', () => {
 
     it('unfolds structure in value subquery (result is invalid SQL)', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
           ID,
           (SELECT from bookshop.Person { address }) as foo
         }`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
           Books.ID,
           (SELECT from bookshop.Person as Person { Person.address_street, Person.address_city}) as foo
         }`)
@@ -455,7 +455,7 @@ describe('Flattening', () => {
 
     it('unfolds structure in value subquery (result is invalid SQL), access outer table alias in inner query', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
           (SELECT address from bookshop.Authors where ID > Books.ID) as authorColumn,
 
           (SELECT from bookshop.Genres as G {
@@ -464,7 +464,7 @@ describe('Flattening', () => {
         }`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
           (SELECT Authors.address_street, Authors.address_city from bookshop.Authors as Authors where Authors.ID > Books.ID) as authorColumn,
           (SELECT from bookshop.Genres as G {
             (SELECT genreAuthor.address_street, genreAuthor.address_city from bookshop.Authors as genreAuthor
@@ -474,13 +474,13 @@ describe('Flattening', () => {
     })
     it('unfolds managed association in value subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             (SELECT from bookshop.Books { author }) as foo
           }`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             (SELECT from bookshop.Books as Books2 { Books2.author_ID }) as foo
           }`)
@@ -488,13 +488,13 @@ describe('Flattening', () => {
 
     it('unfolds managed association in value subquery (result is invalid SQL)', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             (SELECT from bookshop.AssocMaze1 as AM { a_struc as a }) as foo
           }`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.eql(CQL`SELECT from bookshop.Books as Books {
+      expect(JSON.parse(JSON.stringify(query))).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             (SELECT from bookshop.AssocMaze1 as AM {
               AM.a_struc_ID_1_a as a_ID_1_a, AM.a_struc_ID_1_b as a_ID_1_b,
@@ -505,26 +505,26 @@ describe('Flattening', () => {
 
     it('unfolds managed association in EXISTS subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE exists (
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE exists (
             SELECT author from bookshop.Books as Books where Books.ID > Authors.ID
             )`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep
-        .equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE exists (
+        .equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE exists (
             SELECT Books.author_ID from bookshop.Books as Books where Books.ID > Authors.ID
           )`)
     })
 
     it('unfolds managed association in FROM subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from (select from bookshop.Books { author, coAuthor as co}) as Q {
+        cds.ql`SELECT from (select from bookshop.Books { author, coAuthor as co}) as Q {
         author,
         co
       }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from (select from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from (select from bookshop.Books as Books {
         Books.author_ID,
         Books.coAuthor_ID as co_ID
        } ) as Q {
@@ -536,41 +536,41 @@ describe('Flattening', () => {
 
   describe('in order by', () => {
     it('unfolds struct field with a single element in ORDER BY clause', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Bar { stock } ORDER BY struct1`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar { Bar.stock }
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Bar { stock } ORDER BY struct1`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar { Bar.stock }
             ORDER BY Bar.struct1_foo
           `)
     })
     it('unfolds nested struct field with a single leaf element in ORDER BY clause', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Bar { stock } ORDER BY nested1`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar { Bar.stock }
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Bar { stock } ORDER BY nested1`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar { Bar.stock }
               ORDER BY Bar.nested1_foo_x
             `)
     })
     it('rejects struct field with multiple elements in ORDER BY', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { stock } ORDER BY structure`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { stock } ORDER BY structure`, model)).to.throw(
         /"structure" can't be used in order by as it expands to multiple fields/,
       )
     })
     it('rejects nested struct field with multiple leafs elements in ORDER BY', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { stock } ORDER BY nested`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { stock } ORDER BY nested`, model)).to.throw(
         /"nested" can't be used in order by as it expands to multiple fields/,
       )
     })
 
     it('fails for structures with multiple leafs in ORDER BY, accessing a deep element', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.WithStructuredKey { second } order by struct.mid`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.WithStructuredKey { second } order by struct.mid`, model)).to.throw(
         /"struct.mid" can't be used in order by as it expands to multiple fields/,
       )
     })
 
     it('unfolds structured access to a single element in ORDER BY, select list alias shadows table alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar as structure { structure.structure as structure }
+        cds.ql`SELECT from bookshop.Bar as structure { structure.structure as structure }
       ORDER BY structure.foo, structure.baz`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as structure {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as structure {
         structure.structure_foo as structure_foo,
         structure.structure_baz as structure_baz
       } ORDER BY
@@ -581,11 +581,11 @@ describe('Flattening', () => {
 
     it('unfolds structured access to a single element in ORDER BY, table alias shadows data source element', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar as ID { stock }
+        cds.ql`SELECT from bookshop.Bar as ID { stock }
       ORDER BY ID.structure.foo, ID.structure.baz`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as ID { ID.stock } ORDER BY
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as ID { ID.stock } ORDER BY
       ID.structure_foo,
       ID.structure_baz
       `)
@@ -593,10 +593,10 @@ describe('Flattening', () => {
 
     it('xy unfolds structured access to a single element in ORDER BY clause', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar { structure as out } ORDER BY out.foo, out.baz, Bar.nested.foo, Bar.nested.bar.a, Bar.nested.bar.b`,
+        cds.ql`SELECT from bookshop.Bar { structure as out } ORDER BY out.foo, out.baz, Bar.nested.foo, Bar.nested.bar.a, Bar.nested.bar.b`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.structure_foo as out_foo,
         Bar.structure_baz as out_baz,
       } ORDER BY
@@ -610,10 +610,10 @@ describe('Flattening', () => {
 
     it('unfolds structured access to a single element in ORDER BY clause', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar { structure as out } ORDER BY out.foo, out.baz, Bar.nested.foo, Bar.nested.bar.a, Bar.nested.bar.b`,
+        cds.ql`SELECT from bookshop.Bar { structure as out } ORDER BY out.foo, out.baz, Bar.nested.foo, Bar.nested.bar.a, Bar.nested.bar.b`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.structure_foo as out_foo,
         Bar.structure_baz as out_baz,
       } ORDER BY
@@ -626,23 +626,23 @@ describe('Flattening', () => {
     })
 
     it('rejects struct fields in expressions in ORDER BY clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } ORDER BY 2*nested`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } ORDER BY 2*nested`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects struct fields in expressions in ORDER BY clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } ORDER BY sin(nested)`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } ORDER BY sin(nested)`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
     it('unfolds managed association with one FK in ORDER BY clause', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books  { ID, author, coAuthor as co }
+        cds.ql`SELECT from bookshop.Books  { ID, author, coAuthor as co }
         order by Books.author, co`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.author_ID,
         Books.coAuthor_ID as co_ID
@@ -653,7 +653,7 @@ describe('Flattening', () => {
     })
     it('same as above but navigation to foreign key in order by', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books  {
+        cds.ql`SELECT from bookshop.Books  {
           ID,
           author,
           coAuthor as co
@@ -663,7 +663,7 @@ describe('Flattening', () => {
           co.ID`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         Books.author_ID,
         Books.coAuthor_ID as co_ID
@@ -675,33 +675,33 @@ describe('Flattening', () => {
 
     it('rejects managed association with multiple FKs in ORDER BY clause', () => {
       expect(() =>
-        cqn4sql(CQL`SELECT from bookshop.AssocWithStructuredKey { ID } order by toStructuredKey`, model),
+        cqn4sql(cds.ql`SELECT from bookshop.AssocWithStructuredKey { ID } order by toStructuredKey`, model),
       ).to.throw(/"toStructuredKey" can't be used in order by as it expands to multiple fields/)
     })
 
     it('rejects managed associations in expressions in ORDER BY clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } ORDER BY 2*author`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } ORDER BY 2*author`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed associations in expressions in ORDER BY clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } ORDER BY sin(author)`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } ORDER BY sin(author)`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
     it('ignores unmanaged associations in ORDER BY clause', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } ORDER BY ID, coAuthorUnmanaged`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Books as Books { Books.ID } order by ID`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } ORDER BY ID, coAuthorUnmanaged`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books { Books.ID } order by ID`)
     })
     it('rejects unmanaged associations in expressions in ORDER BY clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } ORDER BY 2*coAuthorUnmanaged`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } ORDER BY 2*coAuthorUnmanaged`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects unmanaged associations in expressions in ORDER BY clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } ORDER BY sin(coAuthorUnmanaged)`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } ORDER BY sin(coAuthorUnmanaged)`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
@@ -709,8 +709,8 @@ describe('Flattening', () => {
 
   describe('in group by', () => {
     it('unfolds struct field in GROUP BY clause', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Bar { ID } group by Bar.structure, nested`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar { Bar.ID } group by
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } group by Bar.structure, nested`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar { Bar.ID } group by
             Bar.structure_foo,
             Bar.structure_baz,
             Bar.nested_foo_x,
@@ -721,11 +721,11 @@ describe('Flattening', () => {
 
     it('unfolds managed association in GROUP BY clause', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID, author, coAuthor as co }
+        cds.ql`SELECT from bookshop.Books { ID, author, coAuthor as co }
             group by author, Books.coAuthor`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             Books.author_ID,
             Books.coAuthor_ID as co_ID
@@ -736,11 +736,11 @@ describe('Flattening', () => {
     })
 
     it('if only partial foreign key is accessed, only the requested key is flattened', () => {
-      const q = CQL`SELECT from bookshop.Intermediate {
+      const q = cds.ql`SELECT from bookshop.Intermediate {
         ID
       } group by toAssocWithStructuredKey.toStructuredKey.second`
   
-      const qx = CQL`SELECT from bookshop.Intermediate as Intermediate
+      const qx = cds.ql`SELECT from bookshop.Intermediate as Intermediate
       left join bookshop.AssocWithStructuredKey as toAssocWithStructuredKey
         on toAssocWithStructuredKey.ID = Intermediate.toAssocWithStructuredKey_ID
       {
@@ -751,11 +751,11 @@ describe('Flattening', () => {
     })
     // TODO: currently no-op in runtime (those structured elements are flat), however this should work
     it.skip('if only partial, structured foreign key is accessed, only the requested key is flattened', () => {
-      const q = CQL`SELECT from bookshop.Intermediate {
+      const q = cds.ql`SELECT from bookshop.Intermediate {
         ID
       } group by toAssocWithStructuredKey.toStructuredKey.struct.mid.leaf`
   
-      const qx = CQL`SELECT from bookshop.Intermediate as Intermediate
+      const qx = cds.ql`SELECT from bookshop.Intermediate as Intermediate
       left join bookshop.AssocWithStructuredKey as toAssocWithStructuredKey
         on toAssocWithStructuredKey.ID = Intermediate.toAssocWithStructuredKey_ID
       {
@@ -766,50 +766,50 @@ describe('Flattening', () => {
     })
 
     it('rejects managed associations in expressions in GROUP BY clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } GROUP BY 2*author`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } GROUP BY 2*author`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed associations in expressions in GROUP BY clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } GROUP BY sin(author)`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } GROUP BY sin(author)`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
     it('rejects struct fields in expressions in GROUP BY clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } GROUP BY 2*nested`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } GROUP BY 2*nested`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects struct fields in expressions in GROUP BY clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } GROUP BY sin(nested)`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } GROUP BY sin(nested)`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('ignores unmanaged associations in GROUP BY clause', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } GROUP BY ID, coAuthorUnmanaged`, model)
-      expect(query).to.deep.eql(CQL`SELECT from bookshop.Books as Books { Books.ID } GROUP BY Books.ID`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } GROUP BY ID, coAuthorUnmanaged`, model)
+      expect(query).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books { Books.ID } GROUP BY Books.ID`)
     })
 
     it('ignores unmanaged associations in GROUP BY and deletes the clause if it is the only GROUP BY column', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } GROUP BY coAuthorUnmanaged`, model)
-      expect(JSON.parse(JSON.stringify(query))).to.deep.eql(CQL`SELECT from bookshop.Books as Books { Books.ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } GROUP BY coAuthorUnmanaged`, model)
+      expect(JSON.parse(JSON.stringify(query))).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books { Books.ID }`)
     })
     it('ignores unmanaged associations in ORDER BY and deletes the clause if it is the only ORDER BY column', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } ORDER BY coAuthorUnmanaged`, model)
-      expect(JSON.parse(JSON.stringify(query))).to.deep.eql(CQL`SELECT from bookshop.Books as Books { Books.ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } ORDER BY coAuthorUnmanaged`, model)
+      expect(JSON.parse(JSON.stringify(query))).to.deep.eql(cds.ql`SELECT from bookshop.Books as Books { Books.ID }`)
     })
 
     it('rejects unmanaged associations in expressions in GROUP BY clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } GROUP BY 2*coAuthorUnmanaged`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } GROUP BY 2*coAuthorUnmanaged`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects unmanaged associations in expressions in GROUP BY clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } GROUP BY sin(coAuthorUnmanaged)`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } GROUP BY sin(coAuthorUnmanaged)`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
@@ -817,7 +817,7 @@ describe('Flattening', () => {
 
   describe('in having', () => {
     it('rejects struct field in HAVING clause', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } HAVING nested`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } HAVING nested`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
@@ -834,19 +834,19 @@ describe('Flattening', () => {
     //   relax for certain patterns -> see "Expressions in where clauses"
 
     it('rejects struct fields in expressions in HAVING clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } HAVING 2 = nested`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } HAVING 2 = nested`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects struct fields in expressions in HAVING clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Bar { ID } HAVING sin(nested) < 0`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } HAVING sin(nested) < 0`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed association in HAVING clause', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } HAVING author`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } HAVING author`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
@@ -857,30 +857,30 @@ describe('Flattening', () => {
     //   relax for certain patterns -> see "Expressions in where clauses"
 
     it('rejects managed associations in expressions in HAVING clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } HAVING 2 = author`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } HAVING 2 = author`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects managed associations in expressions in HAVING clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } HAVING sin(author) < 0`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } HAVING sin(author) < 0`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects unmanaged associations in HAVING clause', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } HAVING coAuthorUnmanaged`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } HAVING coAuthorUnmanaged`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
     it('rejects unmanaged associations in expressions in HAVING clause (1)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } HAVING 2 = coAuthorUnmanaged`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } HAVING 2 = coAuthorUnmanaged`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })
 
     it('rejects unmanaged associations in expressions in HAVING clause (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } HAVING sin(coAuthorUnmanaged) < 0`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } HAVING sin(coAuthorUnmanaged) < 0`, model)).to.throw(
         /An association can't be used as a value in an expression/,
       )
     })

--- a/db-service/test/cqn4sql/functions.test.js
+++ b/db-service/test/cqn4sql/functions.test.js
@@ -10,10 +10,10 @@ describe('functions', () => {
   })
   describe('general', () => {
     it('function in filter of expand', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
           author[substring(placeOfBirth, 0, 2) = 'DE'] { name }
         }`
-      const qx = CQL`SELECT from bookshop.Books as Books {
+      const qx = cds.ql`SELECT from bookshop.Books as Books {
           (
             SELECT author.name
              from bookshop.Authors as author
@@ -28,10 +28,10 @@ describe('functions', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
     })
     it('function val in func.args must not be expanded to fk comparison', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          1
         } where not exists author[contains(toLower('foo'))]`
-      const qx = CQL`SELECT from bookshop.Books as Books {
+      const qx = cds.ql`SELECT from bookshop.Books as Books {
           1
         } where not exists (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and contains(toLower('foo'))
@@ -40,10 +40,10 @@ describe('functions', () => {
       expect(res).to.deep.equal(qx)
     })
     it('function with dot operator', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          func1(ID, 'bar').func2(author.name, 'foo') as dotOperator
         } `
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID
         {
           func1(Books.ID, 'bar').func2(author.name, 'foo') as dotOperator
@@ -55,10 +55,10 @@ describe('functions', () => {
 
   describe('with named parameters', () => {
     it('in column', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          getAuthorsName( author => author.name, book => title ) as foo
         } `
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books left join bookshop.Authors as author on author.ID = Books.author_ID
         {
           getAuthorsName( author => author.name, book => Books.title ) as foo
@@ -67,10 +67,10 @@ describe('functions', () => {
       expect(res).to.deep.equal(qx)
     })
     it('in infix filter', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          author[ 'King' = getAuthorsName( author => ID ) ].ID as foo
         } `
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books
           left join bookshop.Authors as author on author.ID = Books.author_ID and
           'King' = getAuthorsName( author => author.ID )
@@ -81,10 +81,10 @@ describe('functions', () => {
       expect(res).to.deep.equal(qx)
     })
     it('in where', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          ID
         } where getAuthorsName( author => author.name ) = 'King'`
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books
           left join bookshop.Authors as author on author.ID = Books.author_ID
         {
@@ -95,10 +95,10 @@ describe('functions', () => {
     })
 
     it('in order by', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          ID
         } order by getAuthorsName( author => author.name )`
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books
           left join bookshop.Authors as author on author.ID = Books.author_ID
         {
@@ -109,10 +109,10 @@ describe('functions', () => {
     })
 
     it('in group by', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          ID
         } group by getAuthorsName( author => author.name )`
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books
           left join bookshop.Authors as author on author.ID = Books.author_ID
         {
@@ -123,10 +123,10 @@ describe('functions', () => {
     })
 
     it('in having', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          ID
         } having getAuthorsName( author => author.name ) = 'King'`
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books
           left join bookshop.Authors as author on author.ID = Books.author_ID
         {
@@ -137,10 +137,10 @@ describe('functions', () => {
     })
 
     it('in xpr', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
          ID
         } where ('Stephen ' + getAuthorsName( author => author.name )) = 'Stephen King'`
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books
           left join bookshop.Authors as author on author.ID = Books.author_ID
         {
@@ -150,10 +150,10 @@ describe('functions', () => {
       expect(res).to.deep.equal(qx)
     })
     it('in from', () => {
-      const q = CQL`SELECT from bookshop.Books[getAuthorsName( author => author.ID ) = 1] {
+      const q = cds.ql`SELECT from bookshop.Books[getAuthorsName( author => author.ID ) = 1] {
          ID
         }`
-      const qx = CQL`
+      const qx = cds.ql`
         SELECT from bookshop.Books as Books
         {
           Books.ID
@@ -172,7 +172,7 @@ describe('functions', () => {
           where: [{ func: 'current_date' }, '=', { val: 'today' }],
         },
       }
-      let expected = CQL`
+      let expected = cds.ql`
         SELECT Books.ID from bookshop.Books as Books
        where current_date = 'today'
       `

--- a/db-service/test/cqn4sql/inline.test.js
+++ b/db-service/test/cqn4sql/inline.test.js
@@ -13,34 +13,34 @@ describe('inline', () => {
   })
 
   it('simple structural inline expansion', () => {
-    let inlineQuery = CQL`select from Employee {
+    let inlineQuery = cds.ql`select from Employee {
       office.{
         floor,
         room
       }
     }`
-    let longVersion = CQL`select from Employee {
+    let longVersion = cds.ql`select from Employee {
       office.floor,
       office.room
     }`
-    let expected = CQL`select from Employee as Employee {
+    let expected = cds.ql`select from Employee as Employee {
       Employee.office_floor,
       Employee.office_room
     }`
     expect(cqn4sql(inlineQuery, model)).to.eql(cqn4sql(longVersion, model)).to.eql(expected)
   })
   it('structural inline expansion with path expression', () => {
-    let inlineQuery = CQL`select from Employee {
+    let inlineQuery = cds.ql`select from Employee {
       office.{
         floor,
         building.name
       }
     }`
-    let longVersion = CQL`select from Employee {
+    let longVersion = cds.ql`select from Employee {
       office.floor,
       office.building.name
     }`
-    let expected = CQL`select from Employee as Employee
+    let expected = cds.ql`select from Employee as Employee
     left join Building as building on building.id = Employee.office_building_id
     {
       Employee.office_floor,
@@ -50,12 +50,12 @@ describe('inline', () => {
     expect(cqn4sql(inlineQuery, model)).to.eql(longResult).to.eql(expected)
   })
   it('inline expansion with path expression', () => {
-    let inlineQuery = CQL`select from Employee {
+    let inlineQuery = cds.ql`select from Employee {
       department.{
         name
       }
     }`
-    let expected = CQL`select from Employee as Employee
+    let expected = cds.ql`select from Employee as Employee
     left join Department as department on department.id = Employee.department_id
     {
       department.name as department_name
@@ -63,12 +63,12 @@ describe('inline', () => {
     expect(cqn4sql(inlineQuery, model)).to.eql(expected)
   })
   it('structural inline expansion with path expression and infix filter', () => {
-    let inlineQuery = CQL`select from Department {
+    let inlineQuery = cds.ql`select from Department {
       head[job = 'boss'].office.{
         floor
       }
     }`
-    let expected = CQL`select from Department as Department
+    let expected = cds.ql`select from Department as Department
     left join Employee as head on head.id = Department.head_id
         and head.job = 'boss'
     {
@@ -77,12 +77,12 @@ describe('inline', () => {
     expect(cqn4sql(inlineQuery, model)).to.eql(expected)
   })
   it('structural inline expansion with path expression and infix filter at leaf', () => {
-    let inlineQuery = CQL`select from Department {
+    let inlineQuery = cds.ql`select from Department {
       head[job = 'boss'].{
         name
       }
     }`
-    let expected = CQL`select from Department as Department
+    let expected = cds.ql`select from Department as Department
     left join Employee as head on head.id = Department.head_id
         and head.job = 'boss'
     {
@@ -92,12 +92,12 @@ describe('inline', () => {
   })
 
   it('structural inline expansion back and forth', () => {
-    let inlineQuery = CQL`select from Department {
+    let inlineQuery = cds.ql`select from Department {
       head.department.{
         costCenter
       }
     }`
-    let expected = CQL`select from Department as Department
+    let expected = cds.ql`select from Department as Department
     left join Employee as head on head.id = Department.head_id
     left join Department as department2 on department2.id = head.department_id
     {
@@ -108,12 +108,12 @@ describe('inline', () => {
   })
 
   it('structural inline expansion back and forth', () => {
-    let inlineQuery = CQL`select from Department {
+    let inlineQuery = cds.ql`select from Department {
       head.department.{
         costCenter
       }
     }`
-    let expected = CQL`select from Department as Department
+    let expected = cds.ql`select from Department as Department
     left join Employee as head on head.id = Department.head_id
     left join Department as department2 on department2.id = head.department_id
     {
@@ -124,7 +124,7 @@ describe('inline', () => {
   })
 
   it('mixed with expand', () => {
-    let queryInlineNotation = CQL`select from Employee {
+    let queryInlineNotation = cds.ql`select from Employee {
           office {
             floor,
             address.{
@@ -133,14 +133,14 @@ describe('inline', () => {
             }
           }
     }`
-    let variantWithoutInline = CQL`select from Employee {
+    let variantWithoutInline = cds.ql`select from Employee {
       office {
         floor,
         address.city,
         address.street
       }
     }`
-    let expected = CQL`SELECT from Employee as Employee {
+    let expected = cds.ql`SELECT from Employee as Employee {
         Employee.office_floor,
         Employee.office_address_city,
         Employee.office_address_street
@@ -150,7 +150,7 @@ describe('inline', () => {
   })
 
   it('deep inline', () => {
-    let queryInlineNotation = CQL`select from Employee {
+    let queryInlineNotation = cds.ql`select from Employee {
       office.{
         floor,
         address.{
@@ -160,13 +160,13 @@ describe('inline', () => {
         }
       }
     }`
-    let variantWithoutInline = CQL`select from Employee {
+    let variantWithoutInline = cds.ql`select from Employee {
       office.floor,
       office.address.city,
       office.address.street,
       office.address.country.code
     }`
-    let expected = CQL`select from Employee as Employee {
+    let expected = cds.ql`select from Employee as Employee {
       Employee.office_floor,
       Employee.office_address_city,
       Employee.office_address_street,
@@ -175,7 +175,7 @@ describe('inline', () => {
     expect(cqn4sql(queryInlineNotation, model)).to.eql(cqn4sql(variantWithoutInline, model)).to.eql(expected)
   })
   it('deep expand in inline', () => {
-    let queryInlineNotation = CQL`select from Employee {
+    let queryInlineNotation = cds.ql`select from Employee {
       office.{
         floor,
         address {
@@ -184,14 +184,14 @@ describe('inline', () => {
         }
       }
     }`
-    let variantWithoutInline = CQL`select from Employee {
+    let variantWithoutInline = cds.ql`select from Employee {
       office.floor,
       office.address {
           city,
           street
       }
     }`
-    let expected = CQL`select from Employee as Employee{
+    let expected = cds.ql`select from Employee as Employee{
       Employee.office_floor,
       Employee.office_address_city,
       Employee.office_address_street,
@@ -199,7 +199,7 @@ describe('inline', () => {
     expect(cqn4sql(queryInlineNotation, model)).to.eql(cqn4sql(variantWithoutInline, model)).to.eql(expected)
   })
   it('deep expand on assoc in inline', () => {
-    let queryInlineNotation = CQL`select from Employee {
+    let queryInlineNotation = cds.ql`select from Employee {
       office.{
         floor,
         building {
@@ -207,13 +207,13 @@ describe('inline', () => {
         }
       }
     }`
-    let variantWithoutInline = CQL`select from Employee {
+    let variantWithoutInline = cds.ql`select from Employee {
       office.floor,
       office.building {
           id
       }
     }`
-    let expected = CQL`select from Employee as Employee {
+    let expected = cds.ql`select from Employee as Employee {
       Employee.office_floor,
       (
         select office_building.id from Building as office_building
@@ -227,10 +227,10 @@ describe('inline', () => {
   })
 
   it('wildcard inline toplevel', () => {
-    let inlineWildcard = CQL`select from EmployeeNoUnmanaged {
+    let inlineWildcard = cds.ql`select from EmployeeNoUnmanaged {
       office.{ * }
     }`
-    let inlineExplicit = CQL`select from EmployeeNoUnmanaged {
+    let inlineExplicit = cds.ql`select from EmployeeNoUnmanaged {
       office.{
         floor,
         room,
@@ -239,7 +239,7 @@ describe('inline', () => {
         furniture
       }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.floor,
       office.room,
       office.building,
@@ -247,7 +247,7 @@ describe('inline', () => {
       office.furniture
     }`
 
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
       EmployeeNoUnmanaged.office_floor,
       EmployeeNoUnmanaged.office_room,
       EmployeeNoUnmanaged.office_building_id,
@@ -263,15 +263,15 @@ describe('inline', () => {
     expect(wildcard).to.eql(explicit).to.eql(absolute).to.eql(expected)
   })
   it('wildcard inline deep w/o brackets', () => {
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{ address.* }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.address.city,
       office.address.street,
       office.address.country,
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
       EmployeeNoUnmanaged.office_address_city,
       EmployeeNoUnmanaged.office_address_street,
       EmployeeNoUnmanaged.office_address_country_code,
@@ -282,17 +282,17 @@ describe('inline', () => {
 
   it('smart wildcard - assoc overwrite after *', () => {
     // office.address.city replaces office.floor
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{ *, furniture as building, address.city as floor, building.id as room }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.address.city as office_floor,
       office.building.id as office_room,
       office.furniture as office_building,
       office.address,
       office.furniture
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
       EmployeeNoUnmanaged.office_address_city as office_floor,
       EmployeeNoUnmanaged.office_building_id as office_room,
       EmployeeNoUnmanaged.office_furniture_chairs as office_building_chairs,
@@ -310,17 +310,17 @@ describe('inline', () => {
 
   it('smart wildcard - structure overwritten by assoc before *', () => {
     // intermediate structures are overwritten
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{ building as furniture, * }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.building as office_furniture,
       office.floor,
       office.room,
       office.building,
       office.address
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_building_id as office_furniture_id,
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
@@ -334,17 +334,17 @@ describe('inline', () => {
   })
   it('smart wildcard - structure overwritten by join relevant assoc before *', () => {
     // intermediate structures are overwritten
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{ building[name='mega tower'].name as furniture, * }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.building[name='mega tower'].name as office_furniture,
       office.floor,
       office.room,
       office.building,
       office.address
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
       left join Building as building on building.id = EmployeeNoUnmanaged.office_building_id and building.name = 'mega tower'
     {
      building.name as office_furniture,
@@ -361,10 +361,10 @@ describe('inline', () => {
   })
   it('wildcard - no overwrite but additional cols', () => {
     // intermediate structures are overwritten
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{ *, 'foo' as last }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.floor,
       office.room,
       office.building,
@@ -372,7 +372,7 @@ describe('inline', () => {
       office.furniture,
       'foo' as office_last
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged
     {
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
@@ -390,10 +390,10 @@ describe('inline', () => {
   })
   it('assigning alias within inline only influences name of element, prefix still appended', () => {
     // intermediate structures are overwritten
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{ floor as x }
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_floor as office_x,
     }`
     const inlineRes = cqn4sql(inline, model)
@@ -401,17 +401,17 @@ describe('inline', () => {
   })
   it('smart wildcard - structured overwrite before *', () => {
     // intermediate structures are overwritten
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{ 'first' as furniture, 'second' as building, * }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
      'first' as office_furniture,
      'second' as office_building,
       office.floor,
       office.room,
       office.address
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      'first' as office_furniture,
      'second' as office_building,
      EmployeeNoUnmanaged.office_floor,
@@ -425,17 +425,17 @@ describe('inline', () => {
   })
   it('smart wildcard - structured overwrite after *', () => {
     // intermediate structures are overwritten
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{*, 'third' as building, 'fourth' as address }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.floor,
       office.room,
       'third' as office_building,
       'fourth' as office_address,
       office.furniture
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
      'third' as office_building,
@@ -449,15 +449,15 @@ describe('inline', () => {
 
   it('wildcard expansion - exclude association', () => {
     // intermediate structures are overwritten
-    let inline = CQL`select from EmployeeNoUnmanaged {
+    let inline = cds.ql`select from EmployeeNoUnmanaged {
       office.{*} excluding { building, address }
     }`
-    let absolutePaths = CQL`select from EmployeeNoUnmanaged {
+    let absolutePaths = cds.ql`select from EmployeeNoUnmanaged {
       office.floor,
       office.room,
       office.furniture
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as EmployeeNoUnmanaged {
      EmployeeNoUnmanaged.office_floor,
      EmployeeNoUnmanaged.office_room,
      EmployeeNoUnmanaged.office_furniture_chairs,
@@ -468,16 +468,16 @@ describe('inline', () => {
   })
 
   it('wildcard expansion sql style on table alias', () => {
-    let inline = CQL`select from EmployeeNoUnmanaged as E {
+    let inline = cds.ql`select from EmployeeNoUnmanaged as E {
       E.*
     }`
-    let inlineWithBrackets = CQL`select from EmployeeNoUnmanaged as E {
+    let inlineWithBrackets = cds.ql`select from EmployeeNoUnmanaged as E {
       E.{*}
     }`
-    let regularWildcard = CQL`select from EmployeeNoUnmanaged as E {
+    let regularWildcard = cds.ql`select from EmployeeNoUnmanaged as E {
       *
     }`
-    let expected = CQL`select from EmployeeNoUnmanaged as E {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as E {
      E.id,
      E.name,
      E.job,
@@ -496,13 +496,13 @@ describe('inline', () => {
     expect(inlineRes).to.eql(cqn4sql(inlineWithBrackets)).to.eql(cqn4sql(regularWildcard)).to.eql(expected)
   })
   it('wildcard expansion sql style on table alias - exclude stuff', () => {
-    let inlineWithBrackets = CQL`select from EmployeeNoUnmanaged as E {
+    let inlineWithBrackets = cds.ql`select from EmployeeNoUnmanaged as E {
       E.{*} excluding { office }
     }`
-    let regularWildcard = CQL`select from EmployeeNoUnmanaged as E {
+    let regularWildcard = cds.ql`select from EmployeeNoUnmanaged as E {
       *
     } excluding { office }`
-    let expected = CQL`select from EmployeeNoUnmanaged as E {
+    let expected = cds.ql`select from EmployeeNoUnmanaged as E {
      E.id,
      E.name,
      E.job,

--- a/db-service/test/cqn4sql/keyless.test.js
+++ b/db-service/test/cqn4sql/keyless.test.js
@@ -22,7 +22,7 @@ describe('keyless entities', () => {
       // ok if explicit foreign key is used
       const qOk = SELECT.columns('ID').from(Books).where(`authorWithExplicitForeignKey[ID = 42].name LIKE 'King'`)
       expect(cqn4sql(qOk, model)).to.eql(
-        CQL`SELECT Books.ID FROM Books as Books 
+        cds.ql`SELECT Books.ID FROM Books as Books 
         left join Authors as authorWithExplicitForeignKey
           on authorWithExplicitForeignKey.ID = Books.authorWithExplicitForeignKey_ID
           and authorWithExplicitForeignKey.ID = 42
@@ -43,7 +43,7 @@ describe('keyless entities', () => {
       // ok if explicit foreign key is used
       const qOk = SELECT.from('Books:authorWithExplicitForeignKey').columns('ID')
       expect(cqn4sql(qOk, model)).to.eql(
-        CQL`SELECT authorWithExplicitForeignKey.ID FROM Authors as authorWithExplicitForeignKey 
+        cds.ql`SELECT authorWithExplicitForeignKey.ID FROM Authors as authorWithExplicitForeignKey 
         where exists (
           SELECT 1 from Books as Books where Books.authorWithExplicitForeignKey_ID = authorWithExplicitForeignKey.ID
         )`,
@@ -55,19 +55,19 @@ describe('keyless entities', () => {
       // ok if explicit foreign key is used
       const qOk = SELECT.from('Books').columns('ID').where('exists authorWithExplicitForeignKey')
       expect(cqn4sql(qOk, model)).to.eql(
-        CQL`SELECT Books.ID FROM Books as Books 
+        cds.ql`SELECT Books.ID FROM Books as Books 
         where exists (
           SELECT 1 from Authors as authorWithExplicitForeignKey where authorWithExplicitForeignKey.ID = Books.authorWithExplicitForeignKey_ID
         )`,
       )
     })
     it('correlated subquery for expand cant be constructed', () => {
-      const q = CQL`SELECT author { name } from Books`
+      const q = cds.ql`SELECT author { name } from Books`
       expect(() => cqn4sql(q, model)).to.throw(`Can't expand “author” as it has no foreign keys`)
       // ok if explicit foreign key is used
-      const qOk = CQL`SELECT authorWithExplicitForeignKey { name } from Books`
+      const qOk = cds.ql`SELECT authorWithExplicitForeignKey { name } from Books`
       expect(JSON.parse(JSON.stringify(cqn4sql(qOk, model)))).to.eql(
-        CQL`
+        cds.ql`
       SELECT
         (
           SELECT authorWithExplicitForeignKey.name from Authors as authorWithExplicitForeignKey
@@ -103,7 +103,7 @@ describe('keyless entities', () => {
       )
     })
     it('backlink has no foreign keys for expand subquery', () => {
-      const q = CQL`SELECT bookWithBackLink { title } from Authors`
+      const q = cds.ql`SELECT bookWithBackLink { title } from Authors`
       expect(() => cqn4sql(q, model)).to.throw(
         `Path step “bookWithBackLink” is a self comparison with “author” that has no foreign keys`,
       )

--- a/db-service/test/cqn4sql/localized.test.js
+++ b/db-service/test/cqn4sql/localized.test.js
@@ -13,9 +13,9 @@ describe('localized', () => {
     model = await cds.load(__dirname + '/../bookshop/db/schema').then( m => cds.compile.for.nodejs(m, options))
   })
   it('performs no replacement if not requested', () => {
-    const q = CQL`SELECT from bookshop.Books {ID, title}`
+    const q = cds.ql`SELECT from bookshop.Books {ID, title}`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from bookshop.Books as Books
                     {
                       Books.ID,
@@ -25,7 +25,7 @@ describe('localized', () => {
   it('performs simple replacement of ref', () => {
     const q = SELECT.localized `from bookshop.Books {ID, title}`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from localized.bookshop.Books as Books
                     {
                       Books.ID,
@@ -57,7 +57,7 @@ describe('localized', () => {
   it('performs no replacement of ref if ”@cds.localized: false”', () => {
     const q = SELECT.localized `from bookshop.BP {ID, title}`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from bookshop.BP as BP
                     {
                       BP.ID,
@@ -67,7 +67,7 @@ describe('localized', () => {
   it('performs no replacement of ref if ”@cds.localized: false” and does not yield localized results for expand', () => {
     const q = SELECT.localized `from bookshop.BP {ID, title, currency { code } }`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from bookshop.BP as BP
                     {
                       BP.ID,
@@ -113,7 +113,7 @@ describe('localized', () => {
   it('performs replacement of ref if ”@cds.localized: true” and localized is set', () => {
     const q = SELECT.localized `from bookshop.BPLocalized {ID, title}`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from localized.bookshop.BPLocalized as BPLocalized
                     {
                       BPLocalized.ID,
@@ -123,7 +123,7 @@ describe('localized', () => {
   it('performs simple replacement of ref within subquery', () => {
     const q = SELECT.localized `from bookshop.Books {ID, title, (SELECT title from bookshop.Books) as foo}`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from localized.bookshop.Books as Books
                     {
                       Books.ID,
@@ -134,7 +134,7 @@ describe('localized', () => {
   it('performs simple replacement of ref within subquery in from', () => {
     const q = SELECT.localized `from (SELECT Books.title from bookshop.Books) as foo { foo.title }`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from (
             SELECT Books.title from localized.bookshop.Books as Books
           ) as foo
@@ -146,7 +146,7 @@ describe('localized', () => {
   it('performs no replacement of ref within subquery if main query has ”@cds.localized: false”', () => {
     const q = SELECT.localized `from bookshop.BP {ID, title, (SELECT title from bookshop.Books) as foo}`
     let query = cqn4sql(q, model)
-    expect(cds.clone(query)).to.deep.equal(CQL`
+    expect(cds.clone(query)).to.deep.equal(cds.ql`
         SELECT from bookshop.BP as BP
                     {
                       BP.ID,

--- a/db-service/test/cqn4sql/not-persisted.test.js
+++ b/db-service/test/cqn4sql/not-persisted.test.js
@@ -23,20 +23,20 @@ describe('not persisted', () => {
 
   describe('virtual fields', () => {
     it('remove from columns', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Foo { ID, virtualField }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo { Foo.ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Foo { ID, virtualField }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo { Foo.ID }`)
     })
 
     // If select list is empty already in input, we produce corresponding SQL.
     // But if empty select list results from removing virtual fields, we throw an error.
     it('error out if removal of virtual element leads to empty columns', () => {
-      let query = CQL`SELECT from bookshop.Foo { virtualField as x, stru.v }`
+      let query = cds.ql`SELECT from bookshop.Foo { virtualField as x, stru.v }`
       expect(() => cqn4sql(query, model)).to.throw('Queries must have at least one non-virtual column')
     })
 
     it('remove from columns in struc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Foo { ID, stru }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Foo { ID, stru }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo {
         Foo.ID,
         Foo.stru_u,
         Foo.stru_nested_nu
@@ -45,7 +45,7 @@ describe('not persisted', () => {
 
     it('remove from columns with path into struc', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Foo {
+        cds.ql`SELECT from bookshop.Foo {
         ID,
         stru.u,
         stru.v,
@@ -54,7 +54,7 @@ describe('not persisted', () => {
       }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo {
         Foo.ID,
         Foo.stru_u,
         Foo.stru_nested_nu
@@ -62,8 +62,8 @@ describe('not persisted', () => {
     })
 
     it('remove from columns via wildcard', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Foo`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo {
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Foo`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo {
         Foo.ID,
         Foo.toFoo_ID,
         Foo.stru_u,
@@ -72,30 +72,30 @@ describe('not persisted', () => {
     })
 
     it('remove from GROUP BY', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Foo { ID } group by ID, virtualField`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo { Foo.ID } group by Foo.ID`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Foo { ID } group by ID, virtualField`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo { Foo.ID } group by Foo.ID`)
     })
 
     it('remove from ORDER BY', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Foo { ID, virtualField as x }
+        cds.ql`SELECT from bookshop.Foo { ID, virtualField as x }
         order by ID, x, Foo.virtualField`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo { Foo.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo { Foo.ID }
         order by ID`)
     })
 
 
     it('Navigation to virtual field does not cause join', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Foo {
+        cds.ql`SELECT from bookshop.Foo {
         ID,
         toFoo.virtualField,
       }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo {
         Foo.ID,
       }`)
     })
@@ -104,14 +104,14 @@ describe('not persisted', () => {
     // The idea to replace conditions involving virtual fields by "1=1" doesn't work, as we
     // are not able to detect where the conditions start/end (-> we don't understand xpr)
     it('reject virtual elements in expressions', () => {
-      let query = CQL`SELECT from bookshop.Foo {
+      let query = cds.ql`SELECT from bookshop.Foo {
         ID
       } where virtualField = 2 * stru.v + stru.nested.nv and virtualField`;
       expect(() => cqn4sql(query, model)).to.throw('Virtual elements are not allowed in expressions')
     })
 
     it('reject virtual elements in column expressions', () => {
-      let query = CQL`SELECT from bookshop.Foo {
+      let query = cds.ql`SELECT from bookshop.Foo {
         ID,
         toFoo.virtualField + 42 / 20 as virtualField,
       }`
@@ -119,12 +119,12 @@ describe('not persisted', () => {
     })
 
     it('reject virtual elements in simple conditions', () => {
-      let query = CQL`SELECT from bookshop.Foo { ID } where ID = 5 and virtualField = 6`
+      let query = cds.ql`SELECT from bookshop.Foo { ID } where ID = 5 and virtualField = 6`
       expect(() => cqn4sql(query, model)).to.throw('Virtual elements are not allowed in expressions')
     })
 
     it('reject virtual elements in order by', () => {
-      let query =  CQL`SELECT from bookshop.Foo { ID, virtualField as x }
+      let query =  cds.ql`SELECT from bookshop.Foo { ID, virtualField as x }
         order by ID, x, (Foo.toFoo.virtualField * 42)`
       expect(() => cqn4sql(query, model)).to.throw('Virtual elements are not allowed in expressions')
     })
@@ -132,10 +132,10 @@ describe('not persisted', () => {
 
   describe('paths with @cds.persistence.skip', () => {
     it('ignores column if assoc in path expression has target ”@cds.persistence.skip”', () => {
-      const q = CQL`SELECT from bookshop.NotSkipped {
+      const q = cds.ql`SELECT from bookshop.NotSkipped {
       ID, skipped.notSkipped.text
     }`
-      const qx = CQL`SELECT from bookshop.NotSkipped as NotSkipped
+      const qx = cds.ql`SELECT from bookshop.NotSkipped as NotSkipped
     {
       NotSkipped.ID,
     }`
@@ -143,11 +143,11 @@ describe('not persisted', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
     })
     it('ignores column if assoc in path expression has target ”@cds.persistence.skip” in order by / group by', () => {
-      const q = CQL`SELECT from bookshop.NotSkipped {
+      const q = cds.ql`SELECT from bookshop.NotSkipped {
       ID
     } group by skipped.notSkipped.text
       order by skipped.notSkipped.text`
-      const qx = CQL`SELECT from bookshop.NotSkipped as NotSkipped
+      const qx = cds.ql`SELECT from bookshop.NotSkipped as NotSkipped
     {
       NotSkipped.ID,
     }`
@@ -157,16 +157,16 @@ describe('not persisted', () => {
 
     // same as for virtual
     it('error out if removal of element leads to empty columns', () => {
-      let query = CQL`SELECT from bookshop.NotSkipped { skipped.notSkipped.text }`
+      let query = cds.ql`SELECT from bookshop.NotSkipped { skipped.notSkipped.text }`
       expect(() => cqn4sql(query, model)).to.throw('Queries must have at least one non-virtual column')
     })
 
     // same as for virtual
     it('does not touch expression but renders the potentially wrong SQL', () => {
-      const q = CQL`SELECT from bookshop.NotSkipped {
+      const q = cds.ql`SELECT from bookshop.NotSkipped {
       ID, skipped.notSkipped.text * 2 + 5 as bar
     } where (skipped.notSkipped.text / 2 + 5) = 42`
-      const qx = CQL`SELECT from bookshop.NotSkipped as NotSkipped
+      const qx = cds.ql`SELECT from bookshop.NotSkipped as NotSkipped
                   left outer join bookshop.Skip as skipped on skipped.ID = NotSkipped.skipped_ID
                   left outer join bookshop.NotSkipped as notSkipped2 on notSkipped2.ID = skipped.notSkipped_ID
     {
@@ -177,10 +177,10 @@ describe('not persisted', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
     })
     it('No join for a skip path within filter if outer path is not persisted', () => {
-      const q = CQL`SELECT from bookshop.NotSkipped {
+      const q = cds.ql`SELECT from bookshop.NotSkipped {
       ID, skipped[notSkipped.ID = 42].notSkipped.text
     }`
-      const qx = CQL`SELECT from bookshop.NotSkipped as NotSkipped
+      const qx = cds.ql`SELECT from bookshop.NotSkipped as NotSkipped
     {
       NotSkipped.ID,
     }`
@@ -189,10 +189,10 @@ describe('not persisted', () => {
     })
 
     it('Join for a skip path within filter if outer path is persisted', () => {
-      const q = CQL`SELECT from bookshop.SkippedAndNotSkipped {
+      const q = cds.ql`SELECT from bookshop.SkippedAndNotSkipped {
       ID, self[skipped.ID = 42].ID
     }`
-      const qx = CQL`SELECT from bookshop.SkippedAndNotSkipped as SkippedAndNotSkipped
+      const qx = cds.ql`SELECT from bookshop.SkippedAndNotSkipped as SkippedAndNotSkipped
       left join bookshop.SkippedAndNotSkipped as self on self.ID = SkippedAndNotSkipped.self_ID and self.skipped_ID = 42
     {
       SkippedAndNotSkipped.ID,
@@ -202,10 +202,10 @@ describe('not persisted', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(qx)
     })
     it('Join for a skip path within filter if outer path is persisted in order by', () => {
-      const q = CQL`SELECT from bookshop.SkippedAndNotSkipped {
+      const q = cds.ql`SELECT from bookshop.SkippedAndNotSkipped {
       ID
     } order by self[skipped.ID = 42].ID`
-      const qx = CQL`SELECT from bookshop.SkippedAndNotSkipped as SkippedAndNotSkipped
+      const qx = cds.ql`SELECT from bookshop.SkippedAndNotSkipped as SkippedAndNotSkipped
       left join bookshop.SkippedAndNotSkipped as self on self.ID = SkippedAndNotSkipped.self_ID and self.skipped_ID = 42
     {
       SkippedAndNotSkipped.ID,
@@ -215,9 +215,9 @@ describe('not persisted', () => {
     })
 
     it('do not remove from simple conditions', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.NotSkipped { ID } where skipped.notSkipped.text`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.NotSkipped { ID } where skipped.notSkipped.text`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.NotSkipped as NotSkipped
+        cds.ql`SELECT from bookshop.NotSkipped as NotSkipped
           left outer join bookshop.Skip as skipped on skipped.ID = NotSkipped.skipped_ID
           left outer join bookshop.NotSkipped as notSkipped2 on notSkipped2.ID = skipped.notSkipped_ID
       { NotSkipped.ID } where notSkipped2.text`,

--- a/db-service/test/cqn4sql/not-supported.test.js
+++ b/db-service/test/cqn4sql/not-supported.test.js
@@ -12,7 +12,7 @@ describe('not supported features', () => {
   })
 
   it('does not transform queries with multiple query sources, but just returns the inferred query', () => {
-    let query = CQL`SELECT from bookshop.Books, bookshop.Receipt`
+    let query = cds.ql`SELECT from bookshop.Books, bookshop.Receipt`
     expect(cqn4sql(query, model)).to.deep.equal(_inferred(query, model))
     // .to.throw(/Queries with multiple query sources are not supported/)
   })

--- a/db-service/test/cqn4sql/path-in-from.test.js
+++ b/db-service/test/cqn4sql/path-in-from.test.js
@@ -10,38 +10,38 @@ describe('infix filter on entities', () => {
   // (SMW) TODO: assoc path in FROM in subquery
   it('fail for infix filter at namespace', () => {
     // cds infer takes care of this
-    expect(() => cqn4sql(CQL`SELECT from bookshop[Books.price < 12.13].Books`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop[Books.price < 12.13].Books`, model)).to.throw(
       /"bookshop" not found in the definitions of your model/,
     )
   })
 
   it('handles simple infix filter at entity', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[price < 12.13] {ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE Books.price < 12.13`)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[price < 12.13] {ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE Books.price < 12.13`)
   })
 
   it('handles multiple simple infix filters at entity', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[price < 12.13 or 12.14 < price] {ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[price < 12.13 or 12.14 < price] {ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.price < 12.13 or 12.14 < Books.price)`,
+      cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.price < 12.13 or 12.14 < Books.price)`,
     )
   })
 
   it('fails when using table alias in infix filter at entity', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books[Books.price < 12.13] {ID}`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books[Books.price < 12.13] {ID}`, model)).to.throw(
       /"Books" not found in "bookshop.Books"/,
     )
   })
 
   it('handles infix filter with struct access at entity', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[dedication.text = 'foo'] {Books.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE Books.dedication_text = 'foo'`)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[dedication.text = 'foo'] {Books.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE Books.dedication_text = 'foo'`)
   })
 
   // TODO belongs to flattening
   it('handles infix filter at entity with association if it accesses FK', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[author.ID = 22] {Books.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE Books.author_ID = 22`)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[author.ID = 22] {Books.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE Books.author_ID = 22`)
   })
   it('handles query modifiers defined in infix filter at leaf', () => {
     let query = cqn4sql(

--- a/db-service/test/cqn4sql/pseudo-variable-replacement.test.js
+++ b/db-service/test/cqn4sql/pseudo-variable-replacement.test.js
@@ -20,7 +20,7 @@ describe('Pseudo Variables', () => {
 
   it('stay untouched in SELECT', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
       ID,
       $user,
       $user.id,
@@ -38,7 +38,7 @@ describe('Pseudo Variables', () => {
       model,
     )
 
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
       Books.ID,
       $user,
       $user.id,
@@ -57,7 +57,7 @@ describe('Pseudo Variables', () => {
 
   it('stay untouched in WHERE/GROUP BY/ORDER BY', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
       ID
     } WHERE $user = 'karl' and $user.locale = 'DE' and $user.unknown.foo.bar = 'foo'
       GROUP BY $user.id, $to
@@ -66,7 +66,7 @@ describe('Pseudo Variables', () => {
       model,
     )
 
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
       Books.ID,
     } WHERE $user = 'karl' and $user.locale = 'DE' and $user.unknown.foo.bar = 'foo'
       GROUP BY $user.id, $to
@@ -76,14 +76,14 @@ describe('Pseudo Variables', () => {
 
   it('stay untouched in filter', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
       ID,
       author[name = $user.name or dateOfDeath < $now].dateOfBirth
     }`,
       model,
     )
 
-    const expected = CQL`SELECT from bookshop.Books as Books
+    const expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
                                                  and ( author.name = $user.name or author.dateOfDeath < $now )
       { Books.ID, author.dateOfBirth as author_dateOfBirth }
@@ -93,13 +93,13 @@ describe('Pseudo Variables', () => {
 
   it('stay untouched in generated join', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.SimpleBook {
+      cds.ql`SELECT from bookshop.SimpleBook {
       ID
     } where activeAuthors.name = $user.name`,
       model,
     )
 
-    const expected = CQL`SELECT from bookshop.SimpleBook as SimpleBook
+    const expected = cds.ql`SELECT from bookshop.SimpleBook as SimpleBook
       left outer join bookshop.Authors as activeAuthors on activeAuthors.ID = SimpleBook.author_ID and $now = $now and $user.id = $user.tenant
       { SimpleBook.ID }
       where activeAuthors.name = $user.name
@@ -109,13 +109,13 @@ describe('Pseudo Variables', () => {
 
   it('stay untouched in where exists', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {
+      cds.ql`SELECT from bookshop.Books {
       ID
     } where exists author[$user.name = 'towald'] `,
       model,
     )
 
-    const expected = CQL`SELECT from bookshop.Books as Books
+    const expected = cds.ql`SELECT from bookshop.Books as Books
       { Books.ID } where exists (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and $user.name = 'towald'
         )
@@ -124,18 +124,18 @@ describe('Pseudo Variables', () => {
   })
 
   it('must not be prefixed by table alias', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, Books.$now }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID, Books.$now }`, model)).to.throw(
       '"$now" not found in "bookshop.Books"',
     )
   })
 
   it('must not be prefixed by struc or assoc', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author.$user }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author.$user }`, model)).to.throw(
       '"$user" not found in "author"',
     )
   })
   it('only well defined pseudo variables are allowed', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, $whatever }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID, $whatever }`, model)).to.throw(
       '"$whatever" not found in the elements of "bookshop.Books"',
     )
   })

--- a/db-service/test/cqn4sql/replacements.test.js
+++ b/db-service/test/cqn4sql/replacements.test.js
@@ -18,7 +18,7 @@ describe('in where', () => {
       .where({ ID: { in: [] } })
 
     expect(cqn4sql(original, model)).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books { Books.ID } where Books.ID = null
      `,
     )
@@ -28,7 +28,7 @@ describe('in where', () => {
     original.SELECT.where = [{ ref: ['ID'] }, 'not', 'in', { list: [] }]
 
     expect(cqn4sql(original, model)).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books { Books.ID } where Books.ID is not null
      `,
     )
@@ -39,7 +39,7 @@ describe('in where', () => {
     })
 
     expect(cqn4sql(query, model)).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books
         left join bookshop.Authors as author
           on author.ID = Books.author_ID and author.name is not null
@@ -55,7 +55,7 @@ describe('in where', () => {
     })
 
     expect(cqn4sql(query, model)).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Authors as author
        { author.ID }
        where exists (

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -11,55 +11,55 @@ describe('Replace attribute search by search predicate', () => {
 
   it('one string element with one search element', () => {
     // WithStructuredKey is the only entity with only one string element in the model ...
-    let query = CQL`SELECT from bookshop.WithStructuredKey as wsk { second }`
+    let query = cds.ql`SELECT from bookshop.WithStructuredKey as wsk { second }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
     // single val is stored as val directly, not as expr with val
-    const expected = CQL`SELECT from bookshop.WithStructuredKey as wsk { wsk.second }`
+    const expected = cds.ql`SELECT from bookshop.WithStructuredKey as wsk { wsk.second }`
     expected.SELECT.where = [ {func: 'search', args: [{ list: [{ ref: ['wsk', 'second']}] }, {val: 'x'}]}]
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
   it('one string element', () => {
     // WithStructuredKey is the only entity with only one string element in the model ...
-    let query = CQL`SELECT from bookshop.WithStructuredKey as wsk { second }`
+    let query = cds.ql`SELECT from bookshop.WithStructuredKey as wsk { second }`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`SELECT from bookshop.WithStructuredKey as wsk { wsk.second }`
+    const expected = cds.ql`SELECT from bookshop.WithStructuredKey as wsk { wsk.second }`
     expected.SELECT.where = [ {func: 'search', args: [{ list: [{ ref: ['wsk', 'second']}] }, {xpr: [{val: 'x'}, 'or', {val: 'y'}]}]}]
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
   it('multiple string elements', () => {
-    let query = CQL`SELECT from bookshop.Genres { ID }`
+    let query = cds.ql`SELECT from bookshop.Genres { ID }`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`SELECT from bookshop.Genres as Genres {
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`SELECT from bookshop.Genres as Genres {
       Genres.ID
     } where search((Genres.name, Genres.descr, Genres.code), ('x' OR 'y'))`)
   })
 
   it('with existing WHERE clause', () => {
-    let query = CQL`SELECT from bookshop.Genres { ID } where ID < 4 or ID > 5`
+    let query = cds.ql`SELECT from bookshop.Genres { ID } where ID < 4 or ID > 5`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`SELECT from bookshop.Genres as Genres {
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`SELECT from bookshop.Genres as Genres {
       Genres.ID
     } where (Genres.ID < 4 or Genres.ID > 5)
         and search((Genres.name, Genres.descr, Genres.code), ('x' OR 'y'))`)
   })
 
   it('with filter on data source', () => {
-    let query = CQL`SELECT from bookshop.Genres[ID < 4 or ID > 5] { ID }`
+    let query = cds.ql`SELECT from bookshop.Genres[ID < 4 or ID > 5] { ID }`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
     // todo, not necessary to add the search predicate as xpr
-    const expected = CQL`SELECT from bookshop.Genres as Genres {
+    const expected = cds.ql`SELECT from bookshop.Genres as Genres {
       Genres.ID
     } where search((Genres.name, Genres.descr, Genres.code), ('x' OR 'y')) and (Genres.ID < 4 or Genres.ID > 5)`
     expected.SELECT.where[0] = { xpr: [expected.SELECT.where[0]] }
@@ -67,31 +67,31 @@ describe('Replace attribute search by search predicate', () => {
   })
 
   it('string fields inside struct', () => {
-    let query = CQL`SELECT from bookshop.Person { ID }`
+    let query = cds.ql`SELECT from bookshop.Person { ID }`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`SELECT from bookshop.Person as Person {
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`SELECT from bookshop.Person as Person {
       Person.ID
     } where search((Person.name, Person.placeOfBirth, Person.placeOfDeath, Person.address_street, Person.address_city), ('x' OR 'y'))`)
   })
 
   it('ignores virtual string elements', () => {
-    let query = CQL`SELECT from bookshop.Foo { ID }`
+    let query = cds.ql`SELECT from bookshop.Foo { ID }`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`SELECT from bookshop.Foo as Foo {
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo {
       Foo.ID
     }`)
   })
   it('Uses primary query source in case of joins', () => {
-    let query = CQL`SELECT from bookshop.Books { ID, author.books.title as authorsBook }`
+    let query = cds.ql`SELECT from bookshop.Books { ID, author.books.title as authorsBook }`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books as Books
         left join bookshop.Authors as author on author.ID = Books.author_ID
         left join bookshop.Books as books2 on  books2.author_ID = author.ID
@@ -103,11 +103,11 @@ describe('Replace attribute search by search predicate', () => {
   })
   it('Search columns if result is grouped', () => {
     // in this case, we actually search the "title" which comes from the join
-    let query = CQL`SELECT from bookshop.Books { ID, author.books.title as authorsBook } group by title`
+    let query = cds.ql`SELECT from bookshop.Books { ID, author.books.title as authorsBook } group by title`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    const expected =       CQL`
+    const expected =       cds.ql`
     SELECT from bookshop.Books as Books
       left join bookshop.Authors as author on author.ID = Books.author_ID
       left join bookshop.Books as books2 on  books2.author_ID = author.ID
@@ -119,11 +119,11 @@ describe('Replace attribute search by search predicate', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
   it('Search on navigation', () => {
-    let query = CQL`SELECT from bookshop.Authors:books { ID }`
+    let query = cds.ql`SELECT from bookshop.Authors:books { ID }`
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
       SELECT from bookshop.Books as books
       {
         books.ID,
@@ -145,7 +145,7 @@ describe('Replace attribute search by search predicate', () => {
       .columns({ args: [{ ref: ['title'] }], as: 'firstInAlphabet', func: 'MIN' })
       .groupBy('title')
       .search('Cat')
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from bookshop.Books as Books {
       MIN(Books.title) as firstInAlphabet
     } group by Books.title having search(MIN(Books.title), 'Cat')`
@@ -154,7 +154,7 @@ describe('Replace attribute search by search predicate', () => {
   })
 
   it('Ignore non string aggregates from being searched', () => {
-    const query = CQL`
+    const query = cds.ql`
       SELECT from bookshop.Books {
         title,
         AVG(Books.stock) as searchRelevant,
@@ -162,7 +162,7 @@ describe('Replace attribute search by search predicate', () => {
       `
 
     query.SELECT.search = [{ val: 'x' }]
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from bookshop.Books as Books {
       Books.title,
       AVG(Books.stock) as searchRelevant,
@@ -171,7 +171,7 @@ describe('Replace attribute search by search predicate', () => {
     expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(expected)
   })
   it('aggregations which are not of type string are not searched', () => {
-    const query = CQL`
+    const query = cds.ql`
       SELECT from bookshop.Books {
         ID,
         SUM(Books.stock) as notSearchRelevant,
@@ -180,7 +180,7 @@ describe('Replace attribute search by search predicate', () => {
 
     query.SELECT.search = [{ val: 'x' }]
 
-    expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(CQL`
+    expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(cds.ql`
       SELECT from bookshop.Books as Books {
         Books.ID,
         SUM(Books.stock) as notSearchRelevant,
@@ -189,7 +189,7 @@ describe('Replace attribute search by search predicate', () => {
   it('func is search relevant via cast', () => {
     // this aggregation is not relevant for search per default
     // but due to the cast to string, we search
-    const query = CQL`
+    const query = cds.ql`
       SELECT from bookshop.Books {
         ID,
         substring(Books.stock) as searchRelevantViaCast: cds.String,
@@ -197,7 +197,7 @@ describe('Replace attribute search by search predicate', () => {
       `
 
     query.SELECT.search = [{ val: 'x' }]
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from bookshop.Books as Books {
       Books.ID,
       substring(Books.stock) as searchRelevantViaCast: cds.String,
@@ -211,7 +211,7 @@ describe('Replace attribute search by search predicate', () => {
   it('xpr is search relevant via cast', () => {
     // this aggregation is not relevant for search per default
     // but due to the cast to string, we search
-    const query = CQL`
+    const query = cds.ql`
       SELECT from bookshop.Books {
         ID,
         ('very' + 'useful' + 'string') as searchRelevantViaCast: cds.String,
@@ -220,7 +220,7 @@ describe('Replace attribute search by search predicate', () => {
       `
 
     query.SELECT.search = [{ val: 'x' }]
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from bookshop.Books as Books {
       Books.ID,
       ('very' + 'useful' + 'string') as searchRelevantViaCast: cds.String,
@@ -245,11 +245,11 @@ describe('search w/ path expressions', () => {
   })
 
   it('one string element with one search element', () => {
-    let query = CQL`SELECT from search.BooksSearchAuthorName { ID, title }`
+    let query = cds.ql`SELECT from search.BooksSearchAuthorName { ID, title }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from search.BooksSearchAuthorName as BooksSearchAuthorName left join search.Authors as author on author.ID = BooksSearchAuthorName.author_ID
     {
       BooksSearchAuthorName.ID,
@@ -260,11 +260,11 @@ describe('search w/ path expressions', () => {
   })
 
   it('search all searchable fields in target', () => {
-    let query = CQL`SELECT from search.BooksSearchAuthor as Books { ID, title }`
+    let query = cds.ql`SELECT from search.BooksSearchAuthor as Books { ID, title }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from search.BooksSearchAuthor as Books left join search.Authors as author on author.ID = Books.author_ID
     {
       Books.ID,
@@ -274,11 +274,11 @@ describe('search w/ path expressions', () => {
   })
 
   it('search only some searchable fields via multiple association paths', () => {
-    let query = CQL`SELECT from search.BooksSearchAuthorAndAddress as Books { ID, title }`
+    let query = cds.ql`SELECT from search.BooksSearchAuthorAndAddress as Books { ID, title }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from search.BooksSearchAuthorAndAddress as Books
       left join search.AuthorsSearchAddresses as authorWithAddress on authorWithAddress.ID = Books.authorWithAddress_ID
       left join search.Addresses as address on address.ID = authorWithAddress.address_ID
@@ -290,11 +290,11 @@ describe('search w/ path expressions', () => {
   })
 
   it('dont dump for non existing search paths, but ignore the path', () => {
-    let query = CQL`SELECT from search.BookShelf { ID, genre }`
+    let query = cds.ql`SELECT from search.BookShelf { ID, genre }`
     query.SELECT.search = [{ val: 'Harry Plotter' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from search.BookShelf as BookShelf
     {
       BookShelf.ID,
@@ -312,11 +312,11 @@ describe('calculated elements', () => {
   })
 
   it('search calculated element via path expression', () => {
-    let query = CQL`SELECT from search.AuthorsSearchCalculatedAddress as Authors { lastName }`
+    let query = cds.ql`SELECT from search.AuthorsSearchCalculatedAddress as Authors { lastName }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from search.AuthorsSearchCalculatedAddress as Authors
         left join search.CalculatedAddresses as address on address.ID = Authors.address_ID
     {
@@ -326,11 +326,11 @@ describe('calculated elements', () => {
   })
 
   it('search calculated element only if explicitly requested', () => {
-    let query = CQL`SELECT from search.CalculatedAddressesWithoutAnno as Address { Address.ID }`
+    let query = cds.ql`SELECT from search.CalculatedAddressesWithoutAnno as Address { Address.ID }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`SELECT from search.CalculatedAddressesWithoutAnno as Address { Address.ID }`
+    const expected = cds.ql`SELECT from search.CalculatedAddressesWithoutAnno as Address { Address.ID }`
     expected.SELECT.where = [ {func: 'search', args: [{ list: [{ref: ['Address', 'city']}]}, {val: 'x'}]}]
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
@@ -343,11 +343,11 @@ describe('caching searchable fields', () => {
   })
 
   it('should cache searchable fields for entity', () => {
-    let query = CQL`SELECT from search.BooksSearchAuthor as Books { ID, title }`
+    let query = cds.ql`SELECT from search.BooksSearchAuthor as Books { ID, title }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from search.BooksSearchAuthor as Books left join search.Authors as author on author.ID = Books.author_ID
     {
       Books.ID,
@@ -367,11 +367,11 @@ describe('caching searchable fields', () => {
   // it is not required to set the searchable fields dynamically
   it.skip('should be possible to define new search criteria during runtime', () => {
     const { BooksSearchAuthor } = cds.entities
-    let query = CQL`SELECT from search.BooksSearchAuthor as Books { ID, title }`
+    let query = cds.ql`SELECT from search.BooksSearchAuthor as Books { ID, title }`
     query.SELECT.search = [{ val: 'x' }]
 
     let res = cqn4sql(query, model)
-    const expected = CQL`
+    const expected = cds.ql`
     SELECT from search.BooksSearchAuthor as Books left join search.Authors as author on author.ID = Books.author_ID
     {
       Books.ID,

--- a/db-service/test/cqn4sql/structure-access.test.js
+++ b/db-service/test/cqn4sql/structure-access.test.js
@@ -16,73 +16,73 @@ describe('Structured Access', () => {
     // see "±" there we must address the flat name
     // of the column in the order by clause
     it('resolves struct path to flat field', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { dedication.text }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.dedication_text }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { dedication.text }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.dedication_text }`)
     })
 
     it.skip('WOULD BE CORRECT to use the last segment as implicit alias, but we MUST NOT change current behavior', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { dedication.text }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.dedication_text as text }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { dedication.text }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.dedication_text as text }`)
     })
 
     // First path step is resolved as table alias, even if subsequent path steps cannot be resolved
     it('resolves first path step as table alias, if possible', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books as dedication { dedication.text }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books as dedication { dedication.text }`, model)).to.throw(
         /"text" not found in "bookshop.Books"/,
       )
     })
     it('resolves first path step as element of data source if it cannot be resolved as table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { dedication.text }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.dedication_text }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { dedication.text }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.dedication_text }`)
     })
     it('cannot access flat names of structure elements', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { dedication_text }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { dedication_text }`, model)).to.throw(
         /"dedication_text" not found in the elements of "bookshop.Books"/,
       )
     })
     it('cannot access flat names of FKs', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { author_ID }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { author_ID }`, model)).to.throw(
         /"author_ID" not found in the elements of "bookshop.Books"/,
       )
     })
     it('deeply structured access', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, dedication.sub.foo }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID, Books.dedication_sub_foo }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, dedication.sub.foo }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.dedication_sub_foo }`)
     })
     // mess around with table alias
     it('using implicit table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { Books.dedication.text }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.dedication_text }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { Books.dedication.text }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.dedication_text }`)
     })
 
     it('with explicit table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books as Bar { ID, dedication.text }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Bar { Bar.ID, Bar.dedication_text }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books as Bar { ID, dedication.text }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Bar { Bar.ID, Bar.dedication_text }`)
     })
 
     it('table alias equals field name', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as dedication {
+        cds.ql`SELECT from bookshop.Books as dedication {
             dedication.stock,
             dedication.dedication.text,
             dedication.dedication.dedication
           }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as dedication {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as dedication {
             dedication.stock,
             dedication.dedication_text,
             dedication.dedication_dedication,
           }`)
     })
     it('table alias has precedence over struct name', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books as dedication { dedication.text }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books as dedication { dedication.text }`, model)).to.throw(
         /"text" not found in "bookshop.Books"/,
       )
     })
     it('unfolds all leafs of sub structure', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             dedication.text,
             Books.dedication.sub,
@@ -90,7 +90,7 @@ describe('Structured Access', () => {
           }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             Books.dedication_text,
             Books.dedication_sub_foo,
@@ -99,7 +99,7 @@ describe('Structured Access', () => {
     })
     it('unfolds all leafs of sub structure also if table alias equals a field name', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as dedication {
+        cds.ql`SELECT from bookshop.Books as dedication {
             dedication.stock,
             dedication.dedication.text,
             dedication.dedication.dedication,
@@ -107,7 +107,7 @@ describe('Structured Access', () => {
           }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as dedication {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as dedication {
             dedication.stock,
             dedication.dedication_text,
             dedication.dedication_dedication,
@@ -121,11 +121,11 @@ describe('Structured Access', () => {
   describe('in Where', () => {
     it('simple access of sub element', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             WHERE dedication.text = 'For Mummy'`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             WHERE Books.dedication_text = 'For Mummy'`)
     })
   })
@@ -137,35 +137,35 @@ describe('Structured Access', () => {
     // flat, implicit alias of column must be used
     it('±', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { dedication.sub }
+        cds.ql`SELECT from bookshop.Books { dedication.sub }
             ORDER BY dedication_sub.foo, Books.dedication.text, dedication.text`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.dedication_sub_foo }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.dedication_sub_foo }
             ORDER BY dedication_sub_foo, Books.dedication_text, Books.dedication_text`)
     })
 
     it('table alias shadows data source element', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as dedication { dedication.dedication.sub }
+        cds.ql`SELECT from bookshop.Books as dedication { dedication.dedication.sub }
             ORDER BY dedication_sub.foo, dedication.dedication.text, dedication.stock`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as dedication { dedication.dedication_sub_foo }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as dedication { dedication.dedication_sub_foo }
             ORDER BY dedication_sub_foo, dedication.dedication_text, dedication.stock`)
     })
     it('table alias shadows data source element (2)', () => {
       expect(() =>
-        cqn4sql(CQL`SELECT from bookshop.Books as dedication { ID } ORDER BY dedication.text`, model),
+        cqn4sql(cds.ql`SELECT from bookshop.Books as dedication { ID } ORDER BY dedication.text`, model),
       ).to.throw(/"text" not found in "bookshop.Books"/)
     })
     it('explicit column alias shadows explicit table alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Bar as structure { structure.nested as structure }
+        cds.ql`SELECT from bookshop.Bar as structure { structure.nested as structure }
             ORDER BY structure.foo, structure.bar.a, structure.bar.b`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as structure {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as structure {
             structure.nested_foo_x as structure_foo_x,
             structure.nested_bar_a as structure_bar_a,
             structure.nested_bar_b as structure_bar_b
@@ -177,17 +177,17 @@ describe('Structured Access', () => {
     })
     it('explicit column alias shadows explicit table alias (2)', () => {
       expect(() =>
-        cqn4sql(CQL`SELECT from bookshop.Books as dedication { ID as dedication } ORDER BY dedication.text`, model),
+        cqn4sql(cds.ql`SELECT from bookshop.Books as dedication { ID as dedication } ORDER BY dedication.text`, model),
       ).to.throw(/"text" not found in "dedication"/)
     })
     // new, TODO
     it.skip('functions in ORDER BY have same scope', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID, dedication.sub  }
+        cds.ql`SELECT from bookshop.Books { ID, dedication.sub  }
                   ORDER BY power(2*dedication_sub.foo), Books.dedication.dedication+2`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID, Books.dedication_sub_foo }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.dedication_sub_foo }
                   ORDER BY power(2*dedication_sub_foo), Books.dedication_dedication+2`)
     })
   })
@@ -195,47 +195,47 @@ describe('Structured Access', () => {
   describe('in expressions', () => {
     it('access leaf of structured function argument in column', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             power(Books.dedication.text, 2*dedication.sub.foo) as path
           }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             power(Books.dedication_text, 2*Books.dedication_sub_foo) as path
           }`)
     })
     it('functions in WHERE', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             WHERE power(Books.dedication.text, 2*dedication.sub.foo) > dedication.dedication+2`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             WHERE power(Books.dedication_text, 2*Books.dedication_sub_foo)  > Books.dedication_dedication+2`)
     })
     it('functions in GROUP BY/HAVING', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             GROUP BY power(Books.dedication.text, 2*dedication.sub.foo), dedication.dedication+2
             HAVING power(Books.dedication.text, 2*dedication.sub.foo) > dedication.dedication+2`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             GROUP BY power(Books.dedication_text, 2*Books.dedication_sub_foo), Books.dedication_dedication+2
             HAVING power(Books.dedication_text, 2*Books.dedication_sub_foo)  > Books.dedication_dedication+2`)
     })
     it('functions in ORDER BY', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             ORDER BY power(dedication.text, 2*dedication.sub.foo), dedication.dedication+2`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             ORDER BY power(Books.dedication_text, 2*Books.dedication_sub_foo), Books.dedication_dedication+2`)
     })
 
     it('denies path ending on struct field in expression', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { 2*dedication.sub as foo }`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { 2*dedication.sub as foo }`, model)).to.throw(
         /A structured element can't be used as a value in an expression/,
       )
     })
@@ -244,13 +244,13 @@ describe('Structured Access', () => {
   describe('in subqueries', () => {
     it('subquery in from with alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from (select from bookshop.Books {
+        cds.ql`SELECT from (select from bookshop.Books {
             ID,
             dedication.sub.foo as foo
           }) as Bar { ID, foo }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from (select from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from (select from bookshop.Books as Books {
             Books.ID,
             Books.dedication_sub_foo as foo
           }) as Bar { Bar.ID, Bar.foo }`)
@@ -258,7 +258,7 @@ describe('Structured Access', () => {
     // skipped as queries with multiple sources are not supported (at least for now)
     it.skip('MUST resolve struct paths to flat fields also with multiple query targets', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as Bar, bookshop.Books as BarTwo {
+        cds.ql`SELECT from bookshop.Books as Bar, bookshop.Books as BarTwo {
           BarTwo.ID,
           Bar.dedication.text as barText,
           BarTwo.dedication.text as barTwoText
@@ -266,7 +266,7 @@ describe('Structured Access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Bar, bookshop.Books as BarTwo {
+        cds.ql`SELECT from bookshop.Books as Bar, bookshop.Books as BarTwo {
           BarTwo.ID,
           Bar.dedication_text as barText,
           BarTwo.dedication_text as barTwoText
@@ -279,66 +279,66 @@ describe('Structured Access', () => {
     //   a path along a managed association to a target field that is used as FK of the association
     //   is not translated into a join (or subquery), but as struct access to the local FK element
     it('access fk in column', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, Books.currency.code }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID, Books.currency_code }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, Books.currency.code }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.currency_code }`)
     })
 
     it('structured fk', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID, Books.dedication.addressee.ID as dedicationAddressee }`,
+        cds.ql`SELECT from bookshop.Books { ID, Books.dedication.addressee.ID as dedicationAddressee }`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books { Books.ID, Books.dedication_addressee_ID as dedicationAddressee }`,
+        cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.dedication_addressee_ID as dedicationAddressee }`,
       )
     })
     it('optimizes assoc.assoc.fk path', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_assoc.assoc2.ID_2.b }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_assoc_assoc2_ID_2_b }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_assoc.assoc2.ID_2.b }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_assoc_assoc2_ID_2_b }`)
     })
 
     it('optimizes assoc.fk path, with drilling into structured FK', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_struc.ID_1.a, a_strass.A_1.b.assoc2.ID_2.b }`,
+        cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_struc.ID_1.a, a_strass.A_1.b.assoc2.ID_2.b }`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_struc_ID_1_a, AM.a_strass_A_1_b_assoc2_ID_2_b }`,
+        cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_struc_ID_1_a, AM.a_strass_A_1_b_assoc2_ID_2_b }`,
       )
     })
 
     it('optimizes assoc.fk path, with drilling into structured, explicit, aliased FK', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucXA.S_1.a, a_assocYA.A_2.b.ID }`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_strucXA.S_1.a, a_assocYA.A_2.b.ID }`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_strucXA_T_1_a as a_strucXA_S_1_a, AM.a_assocYA_B_2_b_ID as a_assocYA_A_2_b_ID }`,
+        cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_strucXA_T_1_a as a_strucXA_S_1_a, AM.a_assocYA_B_2_b_ID as a_assocYA_A_2_b_ID }`,
       )
     })
 
     it('optimizes assoc.fk path, with fk being managed assoc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocYA.A_2 }`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID, a_assocYA.A_2 }`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_assocYA_B_2_a as a_assocYA_A_2_a, AM.a_assocYA_B_2_b_ID as a_assocYA_A_2_b_ID }`,
+        cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID, AM.a_assocYA_B_2_a as a_assocYA_A_2_a, AM.a_assocYA_B_2_b_ID as a_assocYA_A_2_b_ID }`,
       )
     })
 
     it('optimizes assoc.fk path in expression', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             power(author.ID, 2*dedication.addressee.ID) as path
           }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             power(Books.author_ID, 2*Books.dedication_addressee_ID) as path
           }`)
     })
     it('resolves struct paths into FROM subquery mix with assoc FK access', () => {
       let query = cqn4sql(
-        CQL`SELECT from (select from bookshop.Books {Books.ID, Books.dedication as dedi}) as Bar { ID, dedi.addressee.ID}`,
+        cds.ql`SELECT from (select from bookshop.Books {Books.ID, Books.dedication as dedi}) as Bar { ID, dedi.addressee.ID}`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from (select from bookshop.Books as Books {
+        cds.ql`SELECT from (select from bookshop.Books as Books {
               Books.ID,
               Books.dedication_addressee_ID as dedi_addressee_ID,
               Books.dedication_text as dedi_text,
@@ -352,21 +352,21 @@ describe('Structured Access', () => {
   describe('in GROUP BY/HAVING', () => {
     it('uses query source elements and not column alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { dedication.text }
+        cds.ql`SELECT from bookshop.Books { dedication.text }
           GROUP BY dedication.text HAVING dedication.text = 'For Mummy'`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.dedication_text }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.dedication_text }
           GROUP BY Books.dedication_text HAVING Books.dedication_text = 'For Mummy'`)
     })
 
     it('resolves and unfolds struct paths ending on struct', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { dedication.sub }
+        cds.ql`SELECT from bookshop.Books { dedication.sub }
           GROUP BY dedication.sub`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.dedication_sub_foo }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.dedication_sub_foo }
           GROUP BY Books.dedication_sub_foo`)
     })
   })

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -14,29 +14,29 @@ describe('table alias access', () => {
     // On DB, the table name is bookshop_Books rather than Books
     // -> if Books is used as table alias, we need to explicitly define this alias
     it('makes implicit table alias explicit and uses it for access', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }`)
     })
 
     it('creates unique alias for anonymous query which selects from other query', () => {
-      let query = cqn4sql(CQL`SELECT from (SELECT from bookshop.Books { ID } )`, model)
+      let query = cqn4sql(cds.ql`SELECT from (SELECT from bookshop.Books { ID } )`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from (SELECT from bookshop.Books as Books { Books.ID }) as __select__ { __select__.ID }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books as Books { Books.ID }) as __select__ { __select__.ID }`,
       )
     })
 
     it('the unique alias for anonymous query does not collide with user provided aliases', () => {
-      let query = cqn4sql(CQL`SELECT from (SELECT from bookshop.Books as __select__ { ID } )`, model)
+      let query = cqn4sql(cds.ql`SELECT from (SELECT from bookshop.Books as __select__ { ID } )`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from (SELECT from bookshop.Books as __select__ { __select__.ID }) as __select__2 { __select__2.ID }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books as __select__ { __select__.ID }) as __select__2 { __select__2.ID }`,
       )
     })
     it('the unique alias for anonymous query does not collide with user provided aliases in case of joins', () => {
       let query = cqn4sql(
-        CQL`SELECT from (SELECT from bookshop.Books as __select__ { ID, author } ) { author.name }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books as __select__ { ID, author } ) { author.name }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`
+      expect(query).to.deep.equal(cds.ql`
       SELECT from (
         SELECT from bookshop.Books as __select__ { __select__.ID, __select__.author_ID }
       ) as __select__2 left join bookshop.Authors as author on author.ID = __select__2.author_ID
@@ -49,7 +49,7 @@ describe('table alias access', () => {
       // author association bubbles up to the top query where the join finally is done
       // --> note that the most outer query uses user defined __select__ alias
       let query = cqn4sql(
-        CQL`
+        cds.ql`
       SELECT from (
         SELECT from (
           SELECT from bookshop.Books { ID, author }
@@ -61,7 +61,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`
+        cds.ql`
         SELECT from (
           SELECT from (
             SELECT from bookshop.Books as Books { Books.ID, Books.author_ID }
@@ -74,36 +74,36 @@ describe('table alias access', () => {
     })
 
     it('preserves table alias at field access', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { Books.ID }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { Books.ID }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }`)
     })
 
     it('handles field access with and without table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, Books.stock }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID, Books.stock }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, Books.stock }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.stock }`)
     })
 
     it('supports user defined table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books as A { A.ID, stock }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as A { A.ID, A.stock }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books as A { A.ID, stock }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as A { A.ID, A.stock }`)
     })
 
     it('user defined table alias equals field name', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books as stock { stock.ID, stock, stock.stock as s2 }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as stock { stock.ID, stock.stock, stock.stock as s2 }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books as stock { stock.ID, stock, stock.stock as s2 }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as stock { stock.ID, stock.stock, stock.stock as s2 }`)
     })
 
     it('supports scoped entity names', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books.twin { ID }`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books.twin as twin { twin.ID }`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books.twin { ID }`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books.twin as twin { twin.ID }`)
     })
   })
 
   describe('in WHERE, GROUP BY, HAVING', () => {
     it('WHERE with implicit table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE ID = 1 and Books.stock <> 1`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE ID = 1 and Books.stock <> 1`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE Books.ID = 1 and Books.stock <> 1`,
+        cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE Books.ID = 1 and Books.stock <> 1`,
       )
     })
 
@@ -116,42 +116,42 @@ describe('table alias access', () => {
         },
       }
       expect(cqn4sql(query, model)).to.deep.equal(
-        CQL`SELECT Books.ID, ? as discount from bookshop.Books as Books WHERE Books.ID = ?`,
+        cds.ql`SELECT Books.ID, ? as discount from bookshop.Books as Books WHERE Books.ID = ?`,
       )
     })
 
     it('WHERE with explicit table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books as Bar { ID } WHERE ID = 1 and Bar.stock <> 1`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Bar { Bar.ID } WHERE Bar.ID = 1 and Bar.stock <> 1`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books as Bar { ID } WHERE ID = 1 and Bar.stock <> 1`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Bar { Bar.ID } WHERE Bar.ID = 1 and Bar.stock <> 1`)
     })
 
     it('WHERE with explicit table alias that equals field name', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books as stock { ID } WHERE stock.ID = 1 and stock <> 1`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books as stock { ID } WHERE stock.ID = 1 and stock <> 1`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as stock { stock.ID } WHERE stock.ID = 1 and stock.stock <> 1`,
+        cds.ql`SELECT from bookshop.Books as stock { stock.ID } WHERE stock.ID = 1 and stock.stock <> 1`,
       )
     })
 
     it('allows access to and prepends table alias in GROUP BY/HAVING clause', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { stock }
+        cds.ql`SELECT from bookshop.Books { stock }
             group by stock, Books.title having stock > 5 and Books.title = 'foo'`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.stock }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.stock }
             group by Books.stock, Books.title having Books.stock > 5 and Books.title = 'foo'`)
     })
 
     it('xpr in filter within where exists shortcut', () => {
       // the `not` in front of `(name = 'King')` makes it an xpr
       // --> make sure we cover this path and prepend aliases
-      let query = CQL`
+      let query = cds.ql`
         SELECT ID
           from bookshop.Books
           where not exists coAuthorUnmanaged[not (name = 'King')]
           order by ID asc
       `
-      let expected = CQL`
+      let expected = cds.ql`
         SELECT Books.ID from bookshop.Books as Books
           where not exists (
             SELECT 1 from bookshop.Authors as coAuthorUnmanaged
@@ -167,13 +167,13 @@ describe('table alias access', () => {
     it('xpr in filter in having', () => {
       // the `not` in front of `(name = 'King')` makes it an xpr
       // --> make sure we cover this path and prepend aliases
-      let query = CQL`
+      let query = cds.ql`
         SELECT ID
           from bookshop.Books
           having coAuthorUnmanaged[not (name = 'King')].name
           order by ID asc
       `
-      let expected = CQL`
+      let expected = cds.ql`
         SELECT Books.ID from bookshop.Books as Books
           left join bookshop.Authors as coAuthorUnmanaged
             on coAuthorUnmanaged.ID = Books.coAuthor_ID_unmanaged and not (coAuthorUnmanaged.name = 'King')
@@ -188,13 +188,13 @@ describe('table alias access', () => {
     it('xpr in filter in group by', () => {
       // the `not` in front of `(name = 'King')` makes it an xpr
       // --> make sure we cover this path and prepend aliases
-      let query = CQL`
+      let query = cds.ql`
         SELECT ID
           from bookshop.Books
           group by coAuthorUnmanaged[not (name = 'King')].name
           order by ID asc
       `
-      let expected = CQL`
+      let expected = cds.ql`
         SELECT Books.ID from bookshop.Books as Books
           left join bookshop.Authors as coAuthorUnmanaged
             on coAuthorUnmanaged.ID = Books.coAuthor_ID_unmanaged and not (coAuthorUnmanaged.name = 'King')
@@ -208,12 +208,12 @@ describe('table alias access', () => {
     it('xpr in filter in order by', () => {
       // the `not` in front of `(name = 'King')` makes it an xpr
       // --> make sure we cover this path and prepend aliases
-      let query = CQL`
+      let query = cds.ql`
         SELECT ID
           from bookshop.Books
           order by coAuthorUnmanaged[not (name = 'King')].name
       `
-      let expected = CQL`
+      let expected = cds.ql`
         SELECT Books.ID from bookshop.Books as Books
           left join bookshop.Authors as coAuthorUnmanaged
             on coAuthorUnmanaged.ID = Books.coAuthor_ID_unmanaged and not (coAuthorUnmanaged.name = 'King')
@@ -227,12 +227,12 @@ describe('table alias access', () => {
 
   describe('in function args', () => {
     it('function in filter in order by', () => {
-      let query = CQL`
+      let query = cds.ql`
         SELECT ID
           from bookshop.Books
           order by coAuthorUnmanaged[not (calculateName(ID) = 'King')].name
       `
-      let expected = CQL`
+      let expected = cds.ql`
         SELECT Books.ID from bookshop.Books as Books
           left join bookshop.Authors as coAuthorUnmanaged
             on coAuthorUnmanaged.ID = Books.coAuthor_ID_unmanaged and not (calculateName(coAuthorUnmanaged.ID) = 'King')
@@ -245,13 +245,13 @@ describe('table alias access', () => {
     it('function in filter along path traversal', () => {
       // the `not` in front of `(name = 'King')` makes it an xpr
       // --> make sure we cover this path and prepend aliases
-      let query = CQL`
+      let query = cds.ql`
         SELECT
             ID,
             coAuthorUnmanaged[not (calculateName(ID) = 'King')].name
           from bookshop.Books
       `
-      let expected = CQL`
+      let expected = cds.ql`
         SELECT
             Books.ID,
             coAuthorUnmanaged.name as coAuthorUnmanaged_name
@@ -265,13 +265,13 @@ describe('table alias access', () => {
     })
 
     it('refs in function args in on condition are aliased', () => {
-      let query = CQL`
+      let query = cds.ql`
         SELECT
           ID,
           iSimilar { name }
         from bookshop.Posts`
 
-      const expected = CQL`
+      const expected = cds.ql`
         SELECT
           Posts.ID,
           (
@@ -286,13 +286,13 @@ describe('table alias access', () => {
       expect(JSON.parse(JSON.stringify(result))).to.deep.equal(expected)
     })
     it('refs in nested function args in on condition are aliased', () => {
-      let query = CQL`
+      let query = cds.ql`
         SELECT
           ID,
           iSimilarNested { name }
         from bookshop.Posts`
 
-      const expected = CQL`
+      const expected = cds.ql`
         SELECT
           Posts.ID,
           (
@@ -311,7 +311,7 @@ describe('table alias access', () => {
   describe('replace $self references', () => {
     it('escaped identifier does not hurt', () => {
       let query = cqn4sql(
-        CQL`
+        cds.ql`
       SELECT FROM bookshop.Books as ![FROM]
       {
         ![FROM].title as group,
@@ -323,7 +323,7 @@ describe('table alias access', () => {
       `,
         model,
       )
-      expect(query).to.deep.equal(CQL`
+      expect(query).to.deep.equal(cds.ql`
       SELECT from bookshop.Books as ![FROM]
       {
         ![FROM].title as group,
@@ -335,7 +335,7 @@ describe('table alias access', () => {
       `)
     })
     it('refer to other query element', () => {
-      const q = CQL`SELECT from bookshop.Books {
+      const q = cds.ql`SELECT from bookshop.Books {
       Books.title,
       title as title2,
       dedication as struct,
@@ -350,7 +350,7 @@ describe('table alias access', () => {
     }`
       const transformed = cqn4sql(q, model)
 
-      expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
       Books.title,
       Books.title as title2,
       Books.dedication_addressee_ID as struct_addressee_ID,
@@ -369,7 +369,7 @@ describe('table alias access', () => {
     })
     it('late replace join relevant paths', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors {
+        cds.ql`SELECT from bookshop.Authors {
             Authors.name as author,
             $self.book as dollarSelfBook,
             books.title as book,
@@ -378,7 +378,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Authors as Authors left join bookshop.Books as books on books.author_ID = Authors.ID {
+        cds.ql`SELECT from bookshop.Authors as Authors left join bookshop.Books as books on books.author_ID = Authors.ID {
           Authors.name as author,
           books.title as dollarSelfBook,
           books.title as book
@@ -388,7 +388,7 @@ describe('table alias access', () => {
     })
     it('in aggregation', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors {
+        cds.ql`SELECT from bookshop.Authors {
             name as author,
             1+1 as xpr,
             years_between(dateOfBirth, dateOfDeath) as age
@@ -399,7 +399,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Authors as Authors {
+        cds.ql`SELECT from bookshop.Authors as Authors {
           Authors.name as author,
           1+1 as xpr,
           years_between(Authors.dateOfBirth, Authors.dateOfDeath) as age
@@ -411,7 +411,7 @@ describe('table alias access', () => {
     })
     it('in having', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors {
+        cds.ql`SELECT from bookshop.Authors {
             name as author,
             1+1 as xpr,
           }
@@ -420,7 +420,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Authors as Authors {
+        cds.ql`SELECT from bookshop.Authors as Authors {
           Authors.name as author,
           1+1 as xpr,
         }
@@ -430,7 +430,7 @@ describe('table alias access', () => {
     })
     it('in where', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors {
+        cds.ql`SELECT from bookshop.Authors {
             name as author,
             1+1 as xpr,
           }
@@ -439,7 +439,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Authors as Authors {
+        cds.ql`SELECT from bookshop.Authors as Authors {
           Authors.name as author,
           1+1 as xpr,
         }
@@ -518,31 +518,31 @@ describe('table alias access', () => {
     // Note: elements of data source can be used in ORDER BY w/o table alias (-> price)
     it('prefer query elements over elements of data source', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID, ID as stock, ID as x }
+        cds.ql`SELECT from bookshop.Books { ID, ID as stock, ID as x }
         order by ID, stock, Books.stock, price, x`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID, Books.ID as stock, Books.ID as x }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.ID as stock, Books.ID as x }
         order by ID, stock, Books.stock, Books.price, x`)
     })
 
     it('prefers to resolve name in ORDER BY as select item (1)', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID as Books } ORDER BY Books`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID as Books } ORDER BY Books`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID as Books } ORDER BY Books`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID as Books } ORDER BY Books`)
     })
 
     it('prefers to resolve name in ORDER BY as select item (2)', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID as Books } ORDER BY Books.price`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID as Books } ORDER BY Books.price`, model)).to.throw(
         /"price" not found in "Books"/,
       )
     })
 
     it('respects sort property also for expressions/functions', () => {
-      const original = CQL`SELECT from (
+      const original = cds.ql`SELECT from (
                                 select from bookshop.Books { ID as Books } ORDER BY Books desc, sum(1+1) asc
                             ) as sub ORDER BY Books asc, 1+1 asc`
 
-      const expected = CQL`SELECT sub.Books from (
+      const expected = cds.ql`SELECT sub.Books from (
                                     select from bookshop.Books as Books { Books.ID as Books } order by Books desc, sum(1+1) asc
                                 ) as sub ORDER BY Books asc, 1+1 asc`
 
@@ -552,8 +552,8 @@ describe('table alias access', () => {
     })
 
     it('resolves single name in ORDER BY as data source element even if it equals table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books as stock { ID } ORDER BY stock`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as stock { stock.ID } ORDER BY stock.stock`)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books as stock { ID } ORDER BY stock`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as stock { stock.ID } ORDER BY stock.stock`)
     })
 
     it('for localized sorting, we must append the table alias for column refs', () => {
@@ -566,7 +566,7 @@ describe('table alias access', () => {
         .columns('title', 'title as foo', 'author.name as author')
         .orderBy('title', 'foo')
       let res = cqn4sql(query, model)
-      expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`
+      expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`
       SELECT from bookshop.Books as Books
       left join bookshop.Authors as author on author.ID = Books.author_ID
       {
@@ -584,7 +584,7 @@ describe('table alias access', () => {
 
       const res = cqn4sql(query, model)
 
-      const expected = CQL`
+      const expected = cds.ql`
         SELECT from
           (SELECT
             SimpleBook.ID,
@@ -604,14 +604,14 @@ describe('table alias access', () => {
       expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
     })
     it('same as above but descriptors like "asc", "desc" etc. must be kept', () => {
-      const query = CQL`SELECT from bookshop.Books {
+      const query = cds.ql`SELECT from bookshop.Books {
         title,
         title as foo,
         author.name as author
       } order by title asc nulls first, foo desc nulls last`
       query.SELECT.localized = true
       let res = cqn4sql(query, model)
-      expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`
+      expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`
       SELECT from bookshop.Books as Books
       left join bookshop.Authors as author on author.ID = Books.author_ID
       {
@@ -630,7 +630,7 @@ describe('table alias access', () => {
       } order by foo, bar, baz`)
       query.SELECT.localized = true
       let res = cqn4sql(query, model)
-      expect(JSON.parse(JSON.stringify(res))).to.deep.equal(CQL`
+      expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`
       SELECT from bookshop.Books as Books
       left join bookshop.Authors as author on author.ID = Books.author_ID
       {
@@ -644,48 +644,48 @@ describe('table alias access', () => {
 
     it('supports ORDER BY clause with expressions', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID, ID as stock, ID as x }
+        cds.ql`SELECT from bookshop.Books { ID, ID as stock, ID as x }
         order by ID + stock + Books.stock + price, stock, x`,
         model,
       )
       expect(query).to.deep
-        .equal(CQL`SELECT from bookshop.Books as Books { Books.ID, Books.ID as stock, Books.ID as x  }
+        .equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID, Books.ID as stock, Books.ID as x  }
         order by Books.ID + Books.stock + Books.stock + Books.price, stock, x`)
     })
 
     it('fails for select items in expressions in ORDER BY', () => {
-      expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, ID as x } order by ID + x`, model)).to.throw(
+      expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID, ID as x } order by ID + x`, model)).to.throw(
         /"x" not found in the elements of "bookshop.Books"/,
       )
     })
     it('should be possible to address alias of function', () => {
-      let input = CQL`SELECT from bookshop.Books { func() as bubu } order by bubu`
+      let input = cds.ql`SELECT from bookshop.Books { func() as bubu } order by bubu`
       let query = cqn4sql(input, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { func() as bubu } order by bubu`)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { func() as bubu } order by bubu`)
     })
     it('anonymous function gets proper alias', () => {
-      let input = CQL`SELECT from bookshop.Books { func() }`
+      let input = cds.ql`SELECT from bookshop.Books { func() }`
       let query = cqn4sql(input, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { func() as func }`)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { func() as func }`)
     })
     it('anonymous function gets proper alias and can be addressed in order by', () => {
-      let input = CQL`SELECT from bookshop.Books { func() } order by func`
+      let input = cds.ql`SELECT from bookshop.Books { func() } order by func`
       let query = cqn4sql(input, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { func() as func } order by func`)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { func() as func } order by func`)
     })
 
     it('do not try to resolve ref in columns if columns consists of star', () => {
-      let input = CQL`SELECT from bookshop.SimpleBook { * } order by author.name`
+      let input = cds.ql`SELECT from bookshop.SimpleBook { * } order by author.name`
       let query = cqn4sql(input, model)
-      const expected = CQL`SELECT from bookshop.SimpleBook as SimpleBook left join bookshop.Authors as author on author.ID = SimpleBook.author_ID
+      const expected = cds.ql`SELECT from bookshop.SimpleBook as SimpleBook left join bookshop.Authors as author on author.ID = SimpleBook.author_ID
       { SimpleBook.ID, SimpleBook.title, SimpleBook.author_ID } order by author.name`
       expect(query).to.deep.equal(expected)
     })
     // doesnt work, can't join with the query source itself
     it.skip('same as above but author is explicit column', () => {
-      let input = CQL`SELECT from bookshop.SimpleBook { *, author } order by author.name`
+      let input = cds.ql`SELECT from bookshop.SimpleBook { *, author } order by author.name`
       let query = cqn4sql(input, model)
-      const expected = CQL`SELECT from bookshop.SimpleBook as SimpleBook left join bookshop.Authors as author on author.ID = SimpleBook.author_ID
+      const expected = cds.ql`SELECT from bookshop.SimpleBook as SimpleBook left join bookshop.Authors as author on author.ID = SimpleBook.author_ID
       { SimpleBook.ID, SimpleBook.title, SimpleBook.author_ID } order by author.name`
       expect(query).to.deep.equal(expected)
     })
@@ -694,7 +694,7 @@ describe('table alias access', () => {
   describe('replace usage of implicit aliases in subqueries', () => {
     it('in columns', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
                   ID,
                   (
                     SELECT from bookshop.Books {
@@ -706,7 +706,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books {
+        cds.ql`SELECT from bookshop.Books as Books {
               Books.ID,
               (
                 SELECT from bookshop.Books as Books2 {
@@ -717,9 +717,9 @@ describe('table alias access', () => {
       )
     })
     it('in a scoped subquery, always assign unique subquery aliases', () => {
-      const query = CQL`SELECT ID from bookshop.Item where exists (select ID from bookshop.Item:item)`
+      const query = cds.ql`SELECT ID from bookshop.Item where exists (select ID from bookshop.Item:item)`
       const res = cqn4sql(query, model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT Item.ID from bookshop.Item as Item where exists (
         SELECT item2.ID from bookshop.Item as item2 where exists (
           SELECT 1 from bookshop.Item as Item3 where Item3.item_ID = item2.ID
@@ -730,7 +730,7 @@ describe('table alias access', () => {
     })
     it('in expand subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
                   ID,
                   (
                     SELECT from bookshop.Books {
@@ -745,7 +745,7 @@ describe('table alias access', () => {
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books {
+        cds.ql`SELECT from bookshop.Books as Books {
               Books.ID,
               (
                 SELECT from bookshop.Books as Books2
@@ -762,7 +762,7 @@ describe('table alias access', () => {
     })
     it('in join relevant columns', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
                   ID,
                   (
                     SELECT from bookshop.Books {
@@ -775,7 +775,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books {
+        cds.ql`SELECT from bookshop.Books as Books {
               Books.ID,
               (
                 SELECT from bookshop.Books as Books2
@@ -790,7 +790,7 @@ describe('table alias access', () => {
     })
     it('in group by and order by', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
                   ID,
                   (
                     SELECT from bookshop.Books {
@@ -804,7 +804,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books {
+        cds.ql`SELECT from bookshop.Books as Books {
               Books.ID,
               (
                 SELECT from bookshop.Books as Books2 {
@@ -821,7 +821,7 @@ describe('table alias access', () => {
   describe('in expressions', () => {
     it('expressions and functions in select list', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             stock * price as foo,
             power(price, stock) as bar,
             stock * power(sin(2*price),
@@ -830,7 +830,7 @@ describe('table alias access', () => {
           }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             Books.stock * Books.price as foo,
             power(Books.price, Books.stock) as bar,
             Books.stock * power(sin(2*Books.price), 2*(Books.stock+3*Books.stock)) as nested,
@@ -840,22 +840,22 @@ describe('table alias access', () => {
 
     it('expressions and functions in WHERE', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             where stock * price < power(price, stock) or stock * power(sin(2*price), 2*(stock+3*stock)) < 7`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             where Books.stock * Books.price < power(Books.price, Books.stock) or Books.stock * power(sin(2*Books.price), 2*(Books.stock+3*Books.stock)) < 7`)
     })
 
     it('expressions and functions in GROUP BY/HAVING', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             group by stock * price, power(price, stock), stock * power(sin(2*price), 2*(stock+3*stock))
             having stock * price < power(price, stock) or stock * power(sin(2*price), 2*(stock+3*stock)) < 7`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             group by Books.stock * Books.price, power(Books.price, Books.stock), Books.stock * power(sin(2*Books.price), 2*(Books.stock+3*Books.stock))
             having Books.stock * Books.price < power(Books.price, Books.stock) or Books.stock * power(sin(2*Books.price), 2*(Books.stock+3*Books.stock)) < 7`)
     })
@@ -864,7 +864,7 @@ describe('table alias access', () => {
   describe('in subqueries', () => {
     it('respects aliases of outer queries and does not shadow them', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             (SELECT from bookshop.Books {
               author,
@@ -876,7 +876,7 @@ describe('table alias access', () => {
           }`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             (SELECT from bookshop.Books as Books2 { Books2.author_ID,
               (SELECT from bookshop.Books as Books3 { Books3.author_ID }) as bar
@@ -885,7 +885,7 @@ describe('table alias access', () => {
     })
     it('respects aliases of outer queries and does not shadow them mix of regular subqueries and expands', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
             ID,
             (SELECT from bookshop.Books {
               author,
@@ -899,7 +899,7 @@ describe('table alias access', () => {
           }`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
             Books.ID,
             (SELECT from bookshop.Books as Books2 { Books2.author_ID,
               (SELECT from bookshop.Books as Books3 {
@@ -916,23 +916,23 @@ describe('table alias access', () => {
     // could maybe be relaxed later
     it('applies the same alias handling in subqueries in FROM', () => {
       let query = cqn4sql(
-        CQL`SELECT from (SELECT from bookshop.Books { ID, Books.stock }) as Books { ID, Books.stock }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books { ID, Books.stock }) as Books { ID, Books.stock }`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from (SELECT from bookshop.Books as Books2 { Books2.ID, Books2.stock }) as Books { Books.ID, Books.stock }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books as Books2 { Books2.ID, Books2.stock }) as Books { Books.ID, Books.stock }`,
       )
     })
     it('explicit alias for FROM subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from (
+        cds.ql`SELECT from (
           SELECT from bookshop.Books {
             ID, Books.stock, Books.dedication
           }) as B { ID, B.stock, B.dedication }`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from (
+        cds.ql`SELECT from (
               SELECT from bookshop.Books as Books {
                 Books.ID,
                 Books.stock,
@@ -952,9 +952,9 @@ describe('table alias access', () => {
       )
     })
     it('wildcard expansion of subquery in from ignores assocs', () => {
-      let query = cqn4sql(CQL`SELECT from ( SELECT from bookshop.Orders ) as O`, model)
+      let query = cqn4sql(cds.ql`SELECT from ( SELECT from bookshop.Orders ) as O`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from (
+        cds.ql`SELECT from (
           SELECT from bookshop.Orders as Orders {
             Orders.ID,
           }
@@ -965,14 +965,14 @@ describe('table alias access', () => {
     })
     it('prepends unique alias for function args or expressions on top of anonymous subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from ( SELECT from bookshop.Orders ) {
+        cds.ql`SELECT from ( SELECT from bookshop.Orders ) {
           sum(ID) as foo,
           ID + 42 as anotherFoo
         }`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from (
+        cds.ql`SELECT from (
           SELECT from bookshop.Orders as Orders {
             Orders.ID
           }
@@ -985,7 +985,7 @@ describe('table alias access', () => {
     it('wildcard expansion for subquery in FROM', () => {
       // REVISIT: order not stable, move "ID" to top of columns in subquery in from
       let query = cqn4sql(
-        CQL`SELECT from (
+        cds.ql`SELECT from (
           SELECT from bookshop.Books {
             sum(stock) as totalStock,
             ID,
@@ -997,7 +997,7 @@ describe('table alias access', () => {
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from (
+        cds.ql`SELECT from (
           SELECT from bookshop.Books as Books {
             sum(Books.stock) as totalStock,
             Books.ID,
@@ -1023,33 +1023,33 @@ describe('table alias access', () => {
 
     it('cannot access table name of FROM subquery in outer query', () => {
       expect(() =>
-        cqn4sql(CQL`SELECT from (SELECT from bookshop.Books { ID, Books.stock }) as B { ID, Books.stock }`, model),
+        cqn4sql(cds.ql`SELECT from (SELECT from bookshop.Books { ID, Books.stock }) as B { ID, Books.stock }`, model),
       ).to.throw(/"Books" not found in the elements of "B"/)
     })
 
     it('expose column of inner query in outer query', () => {
       let query = cqn4sql(
-        CQL`SELECT from (SELECT from bookshop.Books { ID, Books.stock as Books }) as B { ID, Books }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books { ID, Books.stock as Books }) as B { ID, Books }`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from (SELECT from bookshop.Books as Books { Books.ID, Books.stock as Books }) as B { B.ID, B.Books }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books as Books { Books.ID, Books.stock as Books }) as B { B.ID, B.Books }`,
       )
     })
     it('preserves explicit table alias in FROM subquery', () => {
       let query = cqn4sql(
-        CQL`SELECT from (SELECT from bookshop.Books as inner { ID, inner.stock }) as Books { ID, Books.stock }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books as inner { ID, inner.stock }) as Books { ID, Books.stock }`,
         model,
       )
       expect(query).to.deep.equal(
-        CQL`SELECT from (SELECT from bookshop.Books as inner { inner.ID, inner.stock }) as Books { Books.ID, Books.stock }`,
+        cds.ql`SELECT from (SELECT from bookshop.Books as inner { inner.ID, inner.stock }) as Books { Books.ID, Books.stock }`,
       )
     })
 
     it('applies the same alias handling in value subqueries', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books { ID }) as foo }`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books { ID }) as foo }`, model)
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books {
+        cds.ql`SELECT from bookshop.Books as Books {
               Books.ID,
               (SELECT from bookshop.Books as Books2 { Books2.ID } ) as foo
             }`,
@@ -1058,31 +1058,31 @@ describe('table alias access', () => {
 
     it('supports correlated value subquery in select list', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books as Q { ID } where Q.ID = Books.ID) as foo }`,
+        cds.ql`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books as Q { ID } where Q.ID = Books.ID) as foo }`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books { Books.ID, (SELECT from bookshop.Books as Q { Q.ID } where Q.ID = Books.ID) as foo }`,
+        cds.ql`SELECT from bookshop.Books as Books { Books.ID, (SELECT from bookshop.Books as Q { Q.ID } where Q.ID = Books.ID) as foo }`,
       )
     })
 
     it('supports correlated value subquery in select list, explicit table alias for outer query', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as O { ID, (SELECT from bookshop.Books as Q { ID } where Q.ID = O.ID) as foo }`,
+        cds.ql`SELECT from bookshop.Books as O { ID, (SELECT from bookshop.Books as Q { ID } where Q.ID = O.ID) as foo }`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as O { O.ID, (SELECT from bookshop.Books as Q { Q.ID } where Q.ID = O.ID) as foo }`,
+        cds.ql`SELECT from bookshop.Books as O { O.ID, (SELECT from bookshop.Books as Q { Q.ID } where Q.ID = O.ID) as foo }`,
       )
     })
 
     it('in correlated subquery, allows access to fields of inner query without explicit table alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books as Q { ID } where ID = Books.ID) as foo }`,
+        cds.ql`SELECT from bookshop.Books { ID, (SELECT from bookshop.Books as Q { ID } where ID = Books.ID) as foo }`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books { Books.ID, (SELECT from bookshop.Books as Q { Q.ID } where Q.ID = Books.ID) as foo }`,
+        cds.ql`SELECT from bookshop.Books as Books { Books.ID, (SELECT from bookshop.Books as Q { Q.ID } where Q.ID = Books.ID) as foo }`,
       )
     })
 
@@ -1095,7 +1095,7 @@ describe('table alias access', () => {
     it('in correlated subquery, denies access to fields of outer query without explicit table alias', () => {
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Books { ID, (SELECT from bookshop.Authors { ID } where name = title) as foo }`,
+          cds.ql`SELECT from bookshop.Books { ID, (SELECT from bookshop.Authors { ID } where name = title) as foo }`,
           model,
         ),
       ).to.throw(/"title" not found in the elements of "bookshop.Authors"/)
@@ -1103,7 +1103,7 @@ describe('table alias access', () => {
 
     it('in nested correlated subqueries, allows access to fields of all outer queries', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as B {
+        cds.ql`SELECT from bookshop.Books as B {
               (SELECT from bookshop.Authors as A {
                 (SELECT from bookshop.Genres as G { ID } where descr = A.name and descr = B.title) as foo
               } where A.name = B.title) as foo
@@ -1111,7 +1111,7 @@ describe('table alias access', () => {
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as B {
+        cds.ql`SELECT from bookshop.Books as B {
               (SELECT from bookshop.Authors as A {
                 (SELECT from bookshop.Genres as G { G.ID } where G.descr = A.name and G.descr = B.title) as foo
               } where A.name = B.title) as foo
@@ -1121,7 +1121,7 @@ describe('table alias access', () => {
 
     it('in nested correlated subqueries, table alias may be shadowed', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books as B {
+        cds.ql`SELECT from bookshop.Books as B {
               (SELECT from bookshop.Authors as A {
                 (SELECT from bookshop.Genres as B { ID } where A.name = B.descr) as foo
               } where A.name = B.title) as foo
@@ -1129,7 +1129,7 @@ describe('table alias access', () => {
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as B {
+        cds.ql`SELECT from bookshop.Books as B {
               (SELECT from bookshop.Authors as A {
                 (SELECT from bookshop.Genres as B { B.ID } where A.name = B.descr) as foo
               } where A.name = B.title) as foo
@@ -1138,7 +1138,7 @@ describe('table alias access', () => {
     })
     it('in nested correlated subqueries, table alias may be shadowed', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
               (SELECT from bookshop.Authors {
                 books.title
               } where name = Books.title) as foo
@@ -1146,7 +1146,7 @@ describe('table alias access', () => {
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books {
+        cds.ql`SELECT from bookshop.Books as Books {
               (SELECT from bookshop.Authors as Authors
                   left join bookshop.Books as books2  on books2.author_ID = Authors.ID {
                 books2.title as books_title
@@ -1158,7 +1158,7 @@ describe('table alias access', () => {
     it('in nested correlated subqueries, table alias may be shadowed (2)', () => {
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Books as B {
+          cds.ql`SELECT from bookshop.Books as B {
             (SELECT from bookshop.Authors as A {
               (SELECT from bookshop.Genres as B { ID } where A.name = B.title) as foo
             } where A.name = B.title) as foo
@@ -1176,7 +1176,7 @@ describe('table alias access', () => {
             where: [
               { list: [{ ref: ['dedication', 'addressee', 'ID'] }] },
               'in',
-              CQL`SELECT ID from bookshop.Books where ID = 5`,
+              cds.ql`SELECT ID from bookshop.Books where ID = 5`,
             ],
           },
         ],
@@ -1189,7 +1189,7 @@ describe('table alias access', () => {
             list: [{ ref: ['Books', 'dedication_addressee_ID'] }],
           },
           'in',
-          CQL`SELECT Books2.ID from bookshop.Books as Books2 where Books2.ID = 5`,
+          cds.ql`SELECT Books2.ID from bookshop.Books as Books2 where Books2.ID = 5`,
         ])
 
       const res = cqn4sql(query, model)
@@ -1204,7 +1204,7 @@ describe('table alias access', () => {
             where: [
               { list: [{ ref: ['dedication', 'addressee', 'ID'] }] },
               'in',
-              CQL`SELECT Books.ID from bookshop.Books as Books where Books.ID = 5`,
+              cds.ql`SELECT Books.ID from bookshop.Books as Books where Books.ID = 5`,
             ],
           },
           'coAuthorUnmanaged',
@@ -1216,7 +1216,7 @@ describe('table alias access', () => {
           list: [{ ref: ['Books', 'dedication_addressee_ID'] }],
         },
         'in',
-        CQL`SELECT Books.ID from bookshop.Books as Books where Books.ID = 5`,
+        cds.ql`SELECT Books.ID from bookshop.Books as Books where Books.ID = 5`,
       ]
 
       const expected = SELECT.from('bookshop.Authors as coAuthorUnmanaged').columns('coAuthorUnmanaged.ID').where(`
@@ -1233,59 +1233,59 @@ describe('table alias access', () => {
 
     it('handles value subquery in WHERE', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             WHERE (SELECT from bookshop.Books as qInWhere { ID }) = 5`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             WHERE (SELECT from bookshop.Books as qInWhere { qInWhere.ID }) = 5`)
     })
 
     it('handles correlated value subquery in WHERE', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID }
+        cds.ql`SELECT from bookshop.Books { ID }
             WHERE (SELECT from bookshop.Books as qInWhere { ID } where ID = Books.ID) = 5`,
         model,
       )
-      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
             WHERE (SELECT from bookshop.Books as qInWhere { qInWhere.ID } where qInWhere.ID = Books.ID) = 5`)
     })
 
     it('handles EXISTS subquery in WHERE', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE exists (
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE exists (
             SELECT 1 from bookshop.Books where ID = Authors.ID
             )`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep
-        .equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE exists (
+        .equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE exists (
             SELECT 1 from bookshop.Books as Books where Books.ID = Authors.ID
           )`)
     })
 
     it('handles EXISTS subquery in WHERE, explicit table alias', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors as Books { ID } WHERE exists (
+        cds.ql`SELECT from bookshop.Authors as Books { ID } WHERE exists (
             SELECT 1 from bookshop.Books as Authors where ID > Books.ID
             )`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep
-        .equal(CQL`SELECT from bookshop.Authors as Books { Books.ID } WHERE exists (
+        .equal(cds.ql`SELECT from bookshop.Authors as Books { Books.ID } WHERE exists (
             SELECT 1 from bookshop.Books as Authors where Authors.ID > Books.ID
           )`)
     })
 
     it('handles the select list of an exists subquery like any other select list', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE exists (
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE exists (
             SELECT ID, stock, price from bookshop.Books where ID = Authors.ID
             )`,
         model,
       )
       expect(JSON.parse(JSON.stringify(query))).to.deep
-        .equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE exists (
+        .equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE exists (
             SELECT Books.ID, Books.stock, Books.price from bookshop.Books as Books where Books.ID = Authors.ID
           )`)
     })

--- a/db-service/test/cqn4sql/tupleExpansion.test.js
+++ b/db-service/test/cqn4sql/tupleExpansion.test.js
@@ -403,11 +403,11 @@ describe('Structural comparison', () => {
     })
   })
   it('Struct needs to be unfolded in on-condition of join', () => {
-    const query = CQL`SELECT from bookshop.Unmanaged {
+    const query = cds.ql`SELECT from bookshop.Unmanaged {
       toSelf.field
     }`
 
-    const expected = CQL`SELECT from bookshop.Unmanaged as Unmanaged
+    const expected = cds.ql`SELECT from bookshop.Unmanaged as Unmanaged
     left join bookshop.Unmanaged as toSelf
     on Unmanaged.struct_leaf = toSelf.struct_leaf and Unmanaged.struct_toBook_ID = toSelf.struct_toBook_ID {
       toSelf.field as toSelf_field

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -15,17 +15,17 @@ describe('EXISTS predicate in where', () => {
 
   describe('access association after `exists` predicate', () => {
     it('exists predicate for to-many assoc w/o alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists author`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where exists author`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID
         )`)
     })
     it('exists predicate after having', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } group by ID having exists author`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } group by ID having exists author`, model)
       // having only works on aggregated queries, hence the "group by" to make
       // the example more "real life"
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books { Books.ID }
+        cds.ql`SELECT from bookshop.Books as Books { Books.ID }
          GROUP BY Books.ID
          HAVING EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID
@@ -33,11 +33,11 @@ describe('EXISTS predicate in where', () => {
       )
     })
     it('exists predicate after having with infix filter', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } group by ID having exists author[ID=42]`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } group by ID having exists author[ID=42]`, model)
       // having only works on aggregated queries, hence the "group by" to make
       // the example more "real life"
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books { Books.ID }
+        cds.ql`SELECT from bookshop.Books as Books { Books.ID }
          GROUP BY Books.ID
          HAVING EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and author.ID = 42
@@ -46,10 +46,10 @@ describe('EXISTS predicate in where', () => {
     })
     it('MUST ... two EXISTS both on same path in where', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID } where exists genre.children[code = 'ABC'] or exists genre.children[code = 'DEF']`,
+        cds.ql`SELECT from bookshop.Books { ID } where exists genre.children[code = 'ABC'] or exists genre.children[code = 'DEF']`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
       WHERE EXISTS (
         SELECT 1 from bookshop.Genres as genre where genre.ID = Books.genre_ID
           and EXISTS ( SELECT 1 from bookshop.Genres as children where children.parent_ID = genre.ID and children.code = 'ABC' )
@@ -61,10 +61,10 @@ describe('EXISTS predicate in where', () => {
     })
     it('exists predicate for assoc combined with path expression in xpr', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID } where exists author and ((author.name + 's') = 'Schillers')`,
+        cds.ql`SELECT from bookshop.Books { ID } where exists author and ((author.name + 's') = 'Schillers')`,
         model,
       )
-      expect(query).to.deep.equal(CQL`
+      expect(query).to.deep.equal(cds.ql`
       SELECT from bookshop.Books as Books
         left join bookshop.Authors as author on author.ID = Books.author_ID
         {
@@ -76,15 +76,15 @@ describe('EXISTS predicate in where', () => {
     })
 
     it('handles simple where exists with implicit table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists Books.author`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where exists Books.author`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID
         )`)
     })
 
     it('handles simple where exists with explicit table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS Authors.books`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS Authors.books`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID
         )`)
     })
@@ -93,53 +93,53 @@ describe('EXISTS predicate in where', () => {
     // "give me all authors who have a book"
     //
     it('exists predicate for to-many assoc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID
         )`)
     })
 
     it('FROM clause has explicit table alias', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors as A { ID } WHERE EXISTS books`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as A { A.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors as A { ID } WHERE EXISTS books`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as A { A.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = A.ID
         )`)
     })
 
     it('using explicit table alias of FROM clause', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors as A { ID } WHERE EXISTS A.books`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as A { A.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors as A { ID } WHERE EXISTS A.books`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as A { A.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = A.ID
         )`)
     })
 
     it('FROM clause has table alias with the same name as the assoc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors as books { ID } WHERE EXISTS books`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as books { books.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors as books { ID } WHERE EXISTS books`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as books { books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books2 where books2.author_ID = books.ID
         )`)
     })
 
     it('using the mean table alias of the FROM clause to access the association', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors as books { ID } WHERE EXISTS books.books`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as books { books.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors as books { ID } WHERE EXISTS books.books`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as books { books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books2 where books2.author_ID = books.ID
         )`)
     })
 
     it('exists predicate has additional condition', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE exists books and name = 'Horst'`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID }
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE exists books and name = 'Horst'`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID }
           WHERE exists ( select 1 from bookshop.Books as books where books.author_ID = Authors.ID )
            AND Authors.name = 'Horst'
         `)
     })
     it('exists predicate is followed by association-like calculated element', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE exists booksWithALotInStock and name = 'Horst'`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE exists booksWithALotInStock and name = 'Horst'`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID }
           WHERE exists ( select 1 from bookshop.Books as booksWithALotInStock where ( booksWithALotInStock.author_ID = Authors.ID ) and ( booksWithALotInStock.stock > 100 ) )
            AND Authors.name = 'Horst'
         `)
@@ -148,10 +148,10 @@ describe('EXISTS predicate in where', () => {
   describe('wrapped in expression', () => {
     it('exists predicate in xpr combined with infix filter', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID } where ( ( exists author[name = 'Schiller'] ) + 2 ) = 'foo'`,
+        cds.ql`SELECT from bookshop.Books { ID } where ( ( exists author[name = 'Schiller'] ) + 2 ) = 'foo'`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID }
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID }
         WHERE (
           (
             EXISTS ( SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and author.name = 'Schiller' )
@@ -159,19 +159,19 @@ describe('EXISTS predicate in where', () => {
         ) = 'foo'`)
     })
     it('nested exists wrapped in infix filter', () => {
-      let query = CQL`SELECT from bookshop.Authors { ID } where exists books[ exists genre[ parent = 1 ] ]`
+      let query = cds.ql`SELECT from bookshop.Authors { ID } where exists books[ exists genre[ parent = 1 ] ]`
       // some OData requests lead to a nested `xpr: [ exists <assoc> ]` which
-      // cannot be expressed with the template string CQL`` builder
+      // cannot be expressed with the template string cds.ql`` builder
       query.SELECT.where[1].ref[0].where = [{ xpr: [...query.SELECT.where[1].ref[0].where] }]
       const res = cqn4sql(query, model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT from bookshop.Authors as Authors { Authors.ID } where exists (
         SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID
           and exists (
             SELECT 1 from bookshop.Genres as genre where genre.ID = books.genre_ID and genre.parent_ID = 1
           )
       )`
-      // cannot be expressed with the template string CQL`` builder
+      // cannot be expressed with the template string cds.ql`` builder
       expected.SELECT.where[1].SELECT.where.splice(4, Infinity, {
         xpr: [...expected.SELECT.where[1].SELECT.where.slice(4)],
       })
@@ -182,29 +182,29 @@ describe('EXISTS predicate in where', () => {
   describe('infix filter', () => {
     it('where exists to-one association with additional filter', () => {
       // note: now all source side elements are addressed with their table alias
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists author[name = 'Sanderson']`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where exists author[name = 'Sanderson']`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and author.name = 'Sanderson'
         )`)
     })
     it('where exists to-one association with additional filter with xpr', () => {
       // note: now all source side elements are addressed with their table alias
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists author[not (name = 'Sanderson')]`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where exists author[not (name = 'Sanderson')]`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and not (author.name = 'Sanderson')
         )`)
     })
 
     it('MUST ... with simple filter', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[title = 'ABAP Objects']`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[title = 'ABAP Objects']`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND books.title = 'ABAP Objects'
         )`)
     })
 
     it('MUST fail for unknown field in filter (1)', () => {
       expect(() =>
-        cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[books.title = 'ABAP Objects']`, model),
+        cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[books.title = 'ABAP Objects']`, model),
       ).to.throw(/"books" not found in "books"/)
       // it would work if entity "Books" had a field called "books"
       // Done by infer
@@ -212,18 +212,18 @@ describe('EXISTS predicate in where', () => {
 
     it('MUST fail for unknown field in filter (2)', () => {
       expect(() =>
-        cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[Authors.name = 'Horst']`, model),
+        cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[Authors.name = 'Horst']`, model),
       ).to.throw(/"Authors" not found in "books"/)
       //expect (query) .to.fail
     })
 
     it('MUST ... access struc fields in filter', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[dedication.text = 'For Hasso']`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[dedication.text = 'For Hasso']`,
         model,
       )
       // TODO original test had no before `dedication_text`
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND books.dedication_text = 'For Hasso'
         )`)
     })
@@ -231,10 +231,10 @@ describe('EXISTS predicate in where', () => {
     // accessing FK of managed assoc in filter
     it('MUST ... access FK of managed assoc in filter', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[dedication.addressee.ID = 29]`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[dedication.addressee.ID = 29]`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND books.dedication_addressee_ID = 29
         )`)
     })
@@ -242,7 +242,7 @@ describe('EXISTS predicate in where', () => {
     it('MUST not fail if following managed assoc in filter in where exists', () => {
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[dedication.addressee.name = 'Hasso']`,
+          cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[dedication.addressee.name = 'Hasso']`,
           model,
         ),
       ).to.not.throw('Only foreign keys of “addressee” can be accessed in infix filter')
@@ -250,7 +250,7 @@ describe('EXISTS predicate in where', () => {
     it('MUST fail if following managed assoc in filter (path expressions inside filter only enabled for exists subqueries)', () => {
       expect(() =>
         cqn4sql(
-          CQL`SELECT from bookshop.Authors { ID, books[dedication.addressee.name = 'Hasso'].dedication.addressee.name as Hasso }`,
+          cds.ql`SELECT from bookshop.Authors { ID, books[dedication.addressee.name = 'Hasso'].dedication.addressee.name as Hasso }`,
           model,
         ),
       ).to.throw('Only foreign keys of “addressee” can be accessed in infix filter')
@@ -258,10 +258,10 @@ describe('EXISTS predicate in where', () => {
 
     it('MUST handle simple where exists with multiple association and also with $self backlink', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID } where exists author.books[title = 'Harry Potter']`,
+        cds.ql`SELECT from bookshop.Books { ID } where exists author.books[title = 'Harry Potter']`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and EXISTS (
             SELECT 1 from bookshop.Books as books2 where books2.author_ID = author.ID and books2.title = 'Harry Potter'
           )
@@ -269,8 +269,8 @@ describe('EXISTS predicate in where', () => {
     })
 
     it('MUST handle simple where exists with additional filter, shortcut notation', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists author[17]`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where exists author[17]`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and author.ID = 17
         )`)
     })
@@ -279,10 +279,10 @@ describe('EXISTS predicate in where', () => {
   describe('nested exists in infix filter', () => {
     it('MUST handle simple where exists with multiple association and also with $self backlink in shortcut notation', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books { ID } where exists author[exists books[title = 'Harry Potter']]`,
+        cds.ql`SELECT from bookshop.Books { ID } where exists author[exists books[title = 'Harry Potter']]`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books { Books.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID and EXISTS (
             SELECT 1 from bookshop.Books as books2 where books2.author_ID = author.ID and books2.title = 'Harry Potter'
             )
@@ -291,17 +291,17 @@ describe('EXISTS predicate in where', () => {
 
     // --> paths for exists predicates?
 
-    // let { query2 } = cqn4sql (CQL`SELECT from bookshop.Books { ID } where exists author[exists books.title = 'Harry Potter']`, model)
-    // let { query3 } = cqn4sql (CQL`SELECT from bookshop.Books { ID } where exists author[books.title = 'Harry Potter']`, model)
-    // let { query4 } = cqn4sql (CQL`SELECT from bookshop.Books { ID } where exists author.books[title = 'Harry Potter']`, model)
-    // let { query5 } = cqn4sql (CQL`SELECT from bookshop.Books { ID } where exists author.books.title = 'Harry Potter'`, model)
+    // let { query2 } = cqn4sql (cds.ql`SELECT from bookshop.Books { ID } where exists author[exists books.title = 'Harry Potter']`, model)
+    // let { query3 } = cqn4sql (cds.ql`SELECT from bookshop.Books { ID } where exists author[books.title = 'Harry Potter']`, model)
+    // let { query4 } = cqn4sql (cds.ql`SELECT from bookshop.Books { ID } where exists author.books[title = 'Harry Potter']`, model)
+    // let { query5 } = cqn4sql (cds.ql`SELECT from bookshop.Books { ID } where exists author.books.title = 'Harry Potter'`, model)
 
     it('MUST ... nested EXISTS with additional condition', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS author or title = 'Gravity']`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS author or title = 'Gravity']`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE
       EXISTS
         (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND
@@ -315,10 +315,10 @@ describe('EXISTS predicate in where', () => {
     })
     it('nested EXISTS with unmanaged assoc', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS coAuthorUnmanaged[EXISTS books]]`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS coAuthorUnmanaged[EXISTS books]]`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE
       EXISTS
         (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND
@@ -335,9 +335,9 @@ describe('EXISTS predicate in where', () => {
         )`)
     })
     it('MUST ... EXISTS with nested assoc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Books { ID } WHERE EXISTS dedication.addressee`, model)
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } WHERE EXISTS dedication.addressee`, model)
       expect(query).to.deep.equal(
-        CQL`SELECT from bookshop.Books as Books { Books.ID }
+        cds.ql`SELECT from bookshop.Books as Books { Books.ID }
               WHERE EXISTS (
                 SELECT 1 from bookshop.Person as addressee where addressee.ID = Books.dedication_addressee_ID
               )`,
@@ -346,10 +346,10 @@ describe('EXISTS predicate in where', () => {
 
     it('MUST ... nested EXISTS with additional condition reversed', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[title = 'Gravity' or EXISTS author]`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[title = 'Gravity' or EXISTS author]`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
             SELECT 1 from bookshop.Books as books where
             books.author_ID = Authors.ID AND
             ( books.title = 'Gravity' or
@@ -363,10 +363,10 @@ describe('EXISTS predicate in where', () => {
 
     it('MUST ... 3 nested EXISTS', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[NOT EXISTS author[EXISTS books]]`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[NOT EXISTS author[EXISTS books]]`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND NOT EXISTS (
             SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID AND EXISTS (
               SELECT 1 from bookshop.Books as books2 where books2.author_ID = author.ID
@@ -380,10 +380,10 @@ describe('EXISTS predicate in where', () => {
     //
     it('MUST ... 2 assocs with nested EXISTS (1)', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS author or title = 'Gravity'].genre[name = 'Fiction']`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS author or title = 'Gravity'].genre[name = 'Fiction']`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND ( EXISTS (
             SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID
           ) or books.title = 'Gravity' ) AND  EXISTS (
@@ -397,10 +397,10 @@ describe('EXISTS predicate in where', () => {
     //  compare to the second exits subquery which does not need to be wrapped in xpr
     it('MUST ... 2 assocs with nested EXISTS (2)', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS author or title = 'Gravity'].genre[name = 'Fiction' and exists children[name = 'Foo']]`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[EXISTS author or title = 'Gravity'].genre[name = 'Fiction' and exists children[name = 'Foo']]`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND ( EXISTS (
             SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID
           ) or books.title = 'Gravity') AND EXISTS (
@@ -417,8 +417,8 @@ describe('EXISTS predicate in where', () => {
     // more than one assoc in EXISTS
     //
     it('MUST ... with 2 assocs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID
         )
@@ -426,8 +426,8 @@ describe('EXISTS predicate in where', () => {
     })
 
     it('MUST ... with 4 assocs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author.books.author`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author.books.author`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID AND EXISTS (
             SELECT 1 from bookshop.Books as books2 where books2.author_ID = author.ID AND EXISTS (
@@ -440,10 +440,10 @@ describe('EXISTS predicate in where', () => {
 
     it('MUST ... adjacent EXISTS with 4 assocs each', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author.books.author AND EXISTS books.author.books.author`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author.books.author AND EXISTS books.author.books.author`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID AND EXISTS (
             SELECT 1 from bookshop.Books as books2 where books2.author_ID = author.ID AND EXISTS (
@@ -463,10 +463,10 @@ describe('EXISTS predicate in where', () => {
     })
     it.skip('COULD use the same table aliases in independent EXISTS subqueries', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author.books.author AND EXISTS books.author.books.author`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books.author.books.author AND EXISTS books.author.books.author`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books where author_ID = Authors.ID AND EXISTS (
           SELECT 1 from bookshop.Authors as author where ID = books.author_ID AND EXISTS (
             SELECT 1 from bookshop.Books as books2 where author_ID = author.ID AND EXISTS (
@@ -487,10 +487,10 @@ describe('EXISTS predicate in where', () => {
 
     it('MUST ... with 4 assocs and filters', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[stock > 11].author[name = 'Horst'].books[price < 9.99].author[placeOfBirth = 'Rom']`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[stock > 11].author[name = 'Horst'].books[price < 9.99].author[placeOfBirth = 'Rom']`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID AND books.stock > 11 AND EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID AND author.name = 'Horst' AND EXISTS (
             SELECT 1 from bookshop.Books as books2 where books2.author_ID = author.ID AND books2.price < 9.99 AND EXISTS (
@@ -512,7 +512,7 @@ describe('EXISTS predicate in where', () => {
     //
     it('MUST handle simple where exists in CASE', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
         ID,
         case when exists author then 'yes'
              else 'no'
@@ -520,7 +520,7 @@ describe('EXISTS predicate in where', () => {
        }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         case when exists (SELECT 1 from bookshop.Authors as author where author.ID = Books.author_ID) then 'yes'
              else 'no'
@@ -530,7 +530,7 @@ describe('EXISTS predicate in where', () => {
 
     it('MUST handle simple where exists with filter in CASE', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Books {
+        cds.ql`SELECT from bookshop.Books {
         ID,
         case when exists author[name = 'Sanderson'] then 'yes'
              else 'no'
@@ -538,7 +538,7 @@ describe('EXISTS predicate in where', () => {
        }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
         Books.ID,
         case when exists
           (
@@ -551,7 +551,7 @@ describe('EXISTS predicate in where', () => {
 
     it('exists in case with two branches', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors
+        cds.ql`SELECT from bookshop.Authors
        { ID,
          case when exists books[price>10]  then 1
               when exists books[price>100] then 2
@@ -559,7 +559,7 @@ describe('EXISTS predicate in where', () => {
        }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         { Authors.ID,
           case when exists
           (
@@ -577,7 +577,7 @@ describe('EXISTS predicate in where', () => {
     })
     it('exists in case with two branches both are association-like calculated element', () => {
       let query = cqn4sql(
-        CQL`SELECT from bookshop.Authors
+        cds.ql`SELECT from bookshop.Authors
        { ID,
          case when exists booksWithALotInStock[price > 10 or price < 20]  then 1
               when exists booksWithALotInStock[price > 100 or price < 120] then 2
@@ -585,7 +585,7 @@ describe('EXISTS predicate in where', () => {
        }`,
         model,
       )
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Authors
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Authors
         { Authors.ID,
           case 
           when exists
@@ -611,39 +611,39 @@ describe('EXISTS predicate in where', () => {
     //
 
     it('... managed association with structured FK', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } WHERE EXISTS a_struc`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } WHERE EXISTS a_struc`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze2 as a_struc where a_struc.ID_1_a = AM.a_struc_ID_1_a and a_struc.ID_1_b = AM.a_struc_ID_1_b
                                                        and a_struc.ID_2_a = AM.a_struc_ID_2_a and a_struc.ID_2_b = AM.a_struc_ID_2_b
       )`)
     })
 
     it('... managed association with explicit simple FKs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strucX`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strucX`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze2 as a_strucX where a_strucX.a = AM.a_strucX_a and a_strucX.b = AM.a_strucX_b
       )`)
     })
 
     it('... managed association with explicit structured FKs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strucY`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strucY`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze2 as a_strucY where a_strucY.S_1_a = AM.a_strucY_S_1_a and a_strucY.S_1_b = AM.a_strucY_S_1_b
                                                         and a_strucY.S_2_a = AM.a_strucY_S_2_a and a_strucY.S_2_b = AM.a_strucY_S_2_b
       )`)
     })
 
     it('... managed association with explicit structured aliased FKs', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strucXA`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strucXA`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze2 as a_strucXA where a_strucXA.S_1_a = AM.a_strucXA_T_1_a and a_strucXA.S_1_b = AM.a_strucXA_T_1_b
                                                          and a_strucXA.S_2_a = AM.a_strucXA_T_2_a and a_strucXA.S_2_b = AM.a_strucXA_T_2_b
       )`)
     })
 
     it('... managed associations with FKs being managed associations', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_assoc`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_assoc`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze3 as a_assoc where a_assoc.assoc1_ID_1_a = AM.a_assoc_assoc1_ID_1_a and a_assoc.assoc1_ID_1_b = AM.a_assoc_assoc1_ID_1_b
                                                        and a_assoc.assoc1_ID_2_a = AM.a_assoc_assoc1_ID_2_a and a_assoc.assoc1_ID_2_b = AM.a_assoc_assoc1_ID_2_b
                                                        and a_assoc.assoc2_ID_1_a = AM.a_assoc_assoc2_ID_1_a and a_assoc.assoc2_ID_1_b = AM.a_assoc_assoc2_ID_1_b
@@ -652,24 +652,24 @@ describe('EXISTS predicate in where', () => {
     })
 
     it('... managed association with explicit FKs being managed associations', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_assocY`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_assocY`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze2 as a_assocY where a_assocY.A_1_a = AM.a_assocY_A_1_a and a_assocY.A_1_b_ID = AM.a_assocY_A_1_b_ID
                                                         and a_assocY.A_2_a = AM.a_assocY_A_2_a and a_assocY.A_2_b_ID = AM.a_assocY_A_2_b_ID
       )`)
     })
 
     it('... managed association with explicit aliased FKs being managed associations', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_assocYA`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_assocYA`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze2 as a_assocYA where a_assocYA.A_1_a = AM.a_assocYA_B_1_a and a_assocYA.A_1_b_ID = AM.a_assocYA_B_1_b_ID
                                                          and a_assocYA.A_2_a = AM.a_assocYA_B_2_a and a_assocYA.A_2_b_ID = AM.a_assocYA_B_2_b_ID
       )`)
     })
 
     it('... managed associations with FKs being mix of struc and managed assoc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strass`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_strass`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze4 as a_strass where a_strass.A_1_a= AM.a_strass_A_1_a
                                                         and a_strass.A_1_b_assoc1_ID_1_a = AM.a_strass_A_1_b_assoc1_ID_1_a and a_strass.A_1_b_assoc1_ID_1_b = AM.a_strass_A_1_b_assoc1_ID_1_b
                                                         and a_strass.A_1_b_assoc1_ID_2_a = AM.a_strass_A_1_b_assoc1_ID_2_a and a_strass.A_1_b_assoc1_ID_2_b = AM.a_strass_A_1_b_assoc1_ID_2_b
@@ -687,8 +687,8 @@ describe('EXISTS predicate in where', () => {
     // TODO test with ... assoc path in from with FKs being managed assoc with explicit aliased FKs
 
     it('... managed association with explicit FKs being path into a struc', () => {
-      let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_part`, model)
-      expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
+      let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1 as AM { ID } where exists a_part`, model)
+      expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze1 as AM { AM.ID } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze2 as a_part where a_part.A_1_a = AM.a_part_a and a_part.S_2_b = AM.a_part_b
       )`)
     })
@@ -702,9 +702,9 @@ describe('EXISTS predicate in infix filter', () => {
   })
 
   it('... in select', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books {ID, genre[exists children].descr }`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books {ID, genre[exists children].descr }`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as Books
+      cds.ql`SELECT from bookshop.Books as Books
         LEFT OUTER JOIN bookshop.Genres as genre ON genre.ID = Books.genre_ID
           and EXISTS (
             SELECT 1 from bookshop.Genres as children where children.parent_ID = genre.ID
@@ -714,9 +714,9 @@ describe('EXISTS predicate in infix filter', () => {
   })
 
   it('... in select, nested', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books {ID, genre[exists children[exists children]].descr }`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books {ID, genre[exists children[exists children]].descr }`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as Books
+      cds.ql`SELECT from bookshop.Books as Books
         LEFT OUTER JOIN bookshop.Genres as genre ON genre.ID = Books.genre_ID
           and EXISTS (
             SELECT 1 from bookshop.Genres as children where children.parent_ID = genre.ID
@@ -730,11 +730,11 @@ describe('EXISTS predicate in infix filter', () => {
 
   it('... in select, path with 2 assocs', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books {ID, genre[exists children[code=2]].children[exists children[code=3]].descr }`,
+      cds.ql`SELECT from bookshop.Books {ID, genre[exists children[code=2]].children[exists children[code=3]].descr }`,
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as Books
+      cds.ql`SELECT from bookshop.Books as Books
         LEFT OUTER JOIN bookshop.Genres as genre ON genre.ID = Books.genre_ID
           and EXISTS (
             SELECT 1 from bookshop.Genres as children2 where children2.parent_ID = genre.ID
@@ -750,7 +750,7 @@ describe('EXISTS predicate in infix filter', () => {
   })
   it('reject non foreign key access in infix filter', async () => {
     const model = await cds.load(__dirname + '/model/collaborations').then(cds.linked)
-    const q = CQL`
+    const q = cds.ql`
       SELECT from Collaborations {
         id
       }
@@ -759,7 +759,7 @@ describe('EXISTS predicate in infix filter', () => {
     // maybe in the future this could be something like this
     // the future is here...
     // eslint-disable-next-line no-unused-vars
-    const expectation = CQL`
+    const expectation = cds.ql`
       SELECT from Collaborations as Collaborations {
         Collaborations.id
       } where exists (
@@ -785,7 +785,7 @@ describe('Scoped queries', () => {
   })
 
   it('does not ignore the expand root from being considered for the table alias calculation', () => {
-    const originalQuery = CQL`SELECT from bookshop.Genres:parent.parent.parent { ID }`
+    const originalQuery = cds.ql`SELECT from bookshop.Genres:parent.parent.parent { ID }`
     // table aliases for `query.SELECT.expand === true` are not materialized in the transformed query and must be ignored
     // however, for the main query having the `query.SELECT.expand === 'root'` we must consider the table aliases
     originalQuery.SELECT.expand = 'root'
@@ -794,7 +794,7 @@ describe('Scoped queries', () => {
     // clean up so that the queries match
     delete originalQuery.SELECT.expand
 
-    expect(query).to.deep.equal(CQL`
+    expect(query).to.deep.equal(cds.ql`
       SELECT from bookshop.Genres as parent { parent.ID }
       where exists (
         SELECT 1 from bookshop.Genres as parent2
@@ -816,23 +816,23 @@ describe('Scoped queries', () => {
   //(SMW) TODO I'd prefer to have the cond from the filter before the cond coming from the WHERE
   // which, by the way, is the case in tests below where we have a path in FROM -> ???
   it('handles infix filter at entity and WHERE clause', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[price < 12.13]{Books.ID} where stock < 11`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[price < 12.13]{Books.ID} where stock < 11`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.stock < 11) and (Books.price < 12.13)`,
+      cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.stock < 11) and (Books.price < 12.13)`,
     )
   })
   it('handles multiple assoc steps', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.TestPublisher:texts {ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.TestPublisher:texts {ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.TestPublisher.texts as texts {texts.ID} WHERE exists (
+      cds.ql`SELECT from bookshop.TestPublisher.texts as texts {texts.ID} WHERE exists (
         SELECT 1 from bookshop.TestPublisher as TestPublisher where texts.publisher_structuredKey_ID = TestPublisher.publisher_structuredKey_ID
       )`,
     )
   })
   it.skip('handles multiple assoc steps with renamed keys', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.TestPublisher:textsRenamedPublisher {ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.TestPublisher:textsRenamedPublisher {ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.TestPublisher.texts as textsRenamedPublisher {textsRenamedPublisher.ID} WHERE exists (
+      cds.ql`SELECT from bookshop.TestPublisher.texts as textsRenamedPublisher {textsRenamedPublisher.ID} WHERE exists (
         SELECT 1 from bookshop.TestPublisher as TestPublisher where textsRenamedPublisher.publisherRenamedKey_notID = TestPublisher.publisherRenamedKey_notID
       )`,
     )
@@ -840,13 +840,13 @@ describe('Scoped queries', () => {
 
   it('handles infix filter with nested xpr at entity and WHERE clause', () => {
     let query = cqn4sql(
-      CQL`
+      cds.ql`
       SELECT from bookshop.Books[not (price < 12.13)] { Books.ID } where stock < 11
       `,
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.stock < 11) and (not (Books.price < 12.13))`,
+      cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.stock < 11) and (not (Books.price < 12.13))`,
     )
   })
 
@@ -854,80 +854,80 @@ describe('Scoped queries', () => {
   // which, by the way, is the case in tests below where we have a path in FROM -> ???
   it('gets precedence right for infix filter at entity and WHERE clause', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books[price < 12.13 or stock > 77] {Books.ID} where stock < 11 or price > 17.89`,
+      cds.ql`SELECT from bookshop.Books[price < 12.13 or stock > 77] {Books.ID} where stock < 11 or price > 17.89`,
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.stock < 11 or Books.price > 17.89) and (Books.price < 12.13 or Books.stock > 77)`,
+      cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.stock < 11 or Books.price > 17.89) and (Books.price < 12.13 or Books.stock > 77)`,
     )
-    //expect (query) .to.deep.equal (CQL`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.price < 12.13 or Books.stock > 77) and (Books.stock < 11 or Books.price > 17.89)`)  // (SMW) want this
+    //expect (query) .to.deep.equal (cds.ql`SELECT from bookshop.Books as Books {Books.ID} WHERE (Books.price < 12.13 or Books.stock > 77) and (Books.stock < 11 or Books.price > 17.89)`)  // (SMW) want this
   })
 
   it('FROM path ends on to-one association', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:author { name }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as author { author.name }
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:author { name }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as author { author.name }
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
       )`)
   })
   it('unmanaged to one with (multiple) $self in on-condition', () => {
     // $self in refs of length > 1 can just be ignored semantically
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:coAuthorUnmanaged { name }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as coAuthorUnmanaged { coAuthorUnmanaged.name }
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:coAuthorUnmanaged { name }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as coAuthorUnmanaged { coAuthorUnmanaged.name }
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where coAuthorUnmanaged.ID = Books.coAuthor_ID_unmanaged
       )`)
   })
   it('handles FROM path with association with explicit table alias', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:author as author { author.name }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as author { author.name }
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:author as author { author.name }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as author { author.name }
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
       )`)
   })
 
   it('handles FROM path with association with mean explicit table alias', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:author as Books { name, Books.dateOfBirth }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as Books { Books.name, Books.dateOfBirth}
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:author as Books { name, Books.dateOfBirth }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as Books { Books.name, Books.dateOfBirth}
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books2 where Books2.author_ID = Books.ID
       )`)
   })
 
   it('handles FROM path with backlink association', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books {books.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as books {books.ID} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors:books {books.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as books {books.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Authors as Authors where Authors.ID = books.author_ID
       )`)
   })
   it('handles FROM path with backlink association for association-like calculated element', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:booksWithALotInStock {booksWithALotInStock.ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors:booksWithALotInStock {booksWithALotInStock.ID}`, model)
     expect(query).to.deep
-      .equal(CQL`SELECT from bookshop.Books as booksWithALotInStock {booksWithALotInStock.ID} WHERE EXISTS (
+      .equal(cds.ql`SELECT from bookshop.Books as booksWithALotInStock {booksWithALotInStock.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Authors as Authors where ( Authors.ID = booksWithALotInStock.author_ID ) and ( booksWithALotInStock.stock > 100 )
       )`)
   })
 
   it('handles FROM path with unmanaged composition and prepends source side alias', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:texts { locale }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books.texts as texts {texts.locale} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:texts { locale }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books.texts as texts {texts.locale} WHERE EXISTS (
         SELECT 1 from bookshop.Books as Books where texts.ID = Books.ID
       )`)
   })
 
   it('handles FROM path with struct and association', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:dedication.addressee { dateOfBirth }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Person as addressee { addressee.dateOfBirth }
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:dedication.addressee { dateOfBirth }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Person as addressee { addressee.dateOfBirth }
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where Books.dedication_addressee_ID = addressee.ID
       )`)
   })
 
   it('handles FROM path with struct and association (2)', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.DeepRecursiveAssoc:one.two.three.toSelf { ID }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.DeepRecursiveAssoc as toSelf { toSelf.ID }
+    let query = cqn4sql(cds.ql`SELECT from bookshop.DeepRecursiveAssoc:one.two.three.toSelf { ID }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.DeepRecursiveAssoc as toSelf { toSelf.ID }
         WHERE EXISTS (
           SELECT 1 from bookshop.DeepRecursiveAssoc as DeepRecursiveAssoc where DeepRecursiveAssoc.one_two_three_toSelf_ID = toSelf.ID
       )`)
   })
   it('handles FROM path with filter at entity plus association', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[ID=201]:author {author.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as author {author.ID} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[ID=201]:author {author.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as author {author.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID and Books.ID=201
       )`)
   })
@@ -935,11 +935,11 @@ describe('Scoped queries', () => {
   // (SMW) here the explicit WHERE comes at the end (as it should be)
   it('handles FROM path with association and filters and WHERE', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books[ID=201 or ID=202]:author[ID=4711 or ID=4712]{author.ID} where author.name='foo' or name='bar'`,
+      cds.ql`SELECT from bookshop.Books[ID=201 or ID=202]:author[ID=4711 or ID=4712]{author.ID} where author.name='foo' or name='bar'`,
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as author {author.ID}
+      cds.ql`SELECT from bookshop.Authors as author {author.ID}
         WHERE EXISTS (
           SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID and (Books.ID=201 or Books.ID=202)
         ) and (author.ID=4711 or author.ID=4712) and (author.name='foo' or author.name='bar')`,
@@ -947,9 +947,9 @@ describe('Scoped queries', () => {
   })
 
   it('handles FROM path with association with one infix filter at leaf step', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:author[ID=4711] {author.ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:author[ID=4711] {author.ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as author {author.ID}
+      cds.ql`SELECT from bookshop.Authors as author {author.ID}
         WHERE EXISTS (
           SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
         ) and author.ID=4711`,
@@ -964,8 +964,8 @@ describe('Scoped queries', () => {
   // (SMW) TODO check
   // (PB) modified -> additional where condition e.g. infix filter in result are wrapped in `xpr`
   it('MUST ... in from clauses with infix filters, ODATA variant w/o mentioning key', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[201]:author[150] {ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Authors as author {author.ID} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[201]:author[150] {ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Authors as author {author.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID and Books.ID=201
       ) AND author.ID = 150`)
   })
@@ -974,15 +974,15 @@ describe('Scoped queries', () => {
   // only shortcut notation is not allowed
   // TODO: message can include the fix: `write ”<key> = 42” explicitly`
   it('MUST ... reject filters on associations with multiple foreign keys', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.AssocWithStructuredKey:toStructuredKey[42]`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.AssocWithStructuredKey:toStructuredKey[42]`, model)).to.throw(
       /Filters can only be applied to managed associations which result in a single foreign key/,
     )
   })
 
   // (SMW) TODO: check
   it('MUST ... in from clauses with infix filters ODATA variant w/o mentioning key ORDERS/ITEMS', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Orders[201]:items[2] {pos}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Orders.items as items {items.pos} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Orders[201]:items[2] {pos}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Orders.items as items {items.pos} WHERE EXISTS (
         SELECT 1 from bookshop.Orders as Orders where Orders.ID = items.up__ID and Orders.ID = 201
       ) AND items.pos = 2`)
   })
@@ -991,42 +991,42 @@ describe('Scoped queries', () => {
   // but because "up__ID" is the foreign key for the backlink association of "items", it is already part of the inner where
   // `where` condition of the exists subquery. Hence we enable this shortcut notation.
   it('MUST ... contain foreign keys of backlink association in on-condition?', () => {
-    const query = cqn4sql(CQL`SELECT from bookshop.Orders:items[2] {pos}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Orders.items as items {items.pos} WHERE EXISTS (
+    const query = cqn4sql(cds.ql`SELECT from bookshop.Orders:items[2] {pos}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Orders.items as items {items.pos} WHERE EXISTS (
       SELECT 1 from bookshop.Orders as Orders where Orders.ID = items.up__ID
     ) and items.pos = 2`)
   })
 
   it('same as above but mention key', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Orders:items[pos=2] {pos}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Orders.items as items {items.pos} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Orders:items[pos=2] {pos}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Orders.items as items {items.pos} WHERE EXISTS (
         SELECT 1 from bookshop.Orders as Orders where Orders.ID = items.up__ID
       ) and items.pos = 2`)
   })
 
   // TODO
   it.skip('MUST ... contain foreign keys of backlink association in on-condition? (3)', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Orders.items[2] {pos}`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Orders.items[2] {pos}`, model)).to.throw(
       /Please specify all primary keys in the infix filter/,
     )
   })
 
   it('MUST ... be possible to address fully qualified, partial key in infix filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Orders.items[pos=2] {pos}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Orders.items as items {items.pos} where items.pos = 2`)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Orders.items[pos=2] {pos}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Orders.items as items {items.pos} where items.pos = 2`)
   })
 
   it('handles paths with two associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre {genre.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as genre {genre.ID} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors:books.genre {genre.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as genre {genre.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Books as books where books.genre_ID = genre.ID and EXISTS (
           SELECT 1 from bookshop.Authors as Authors where Authors.ID = books.author_ID
         )
       )`)
   })
   it('handles paths with two associations, first is association-like calculated element', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:booksWithALotInStock.genre {genre.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as genre {genre.ID} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors:booksWithALotInStock.genre {genre.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as genre {genre.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Books as booksWithALotInStock where booksWithALotInStock.genre_ID = genre.ID and EXISTS (
           SELECT 1 from bookshop.Authors as Authors where ( Authors.ID = booksWithALotInStock.author_ID ) and ( booksWithALotInStock.stock > 100 )
         )
@@ -1034,8 +1034,8 @@ describe('Scoped queries', () => {
   })
 
   it('handles paths with two associations (mean alias)', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre as books {books.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as books {books.ID} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors:books.genre as books {books.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as books {books.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Books as books2 where books2.genre_ID = books.ID and EXISTS (
           SELECT 1 from bookshop.Authors as Authors where Authors.ID = books2.author_ID
         )
@@ -1043,8 +1043,8 @@ describe('Scoped queries', () => {
   })
 
   it('handles paths with three associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre.parent {parent.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as parent {parent.ID} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors:books.genre.parent {parent.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as parent {parent.ID} WHERE EXISTS (
         SELECT 1 from bookshop.Genres as genre where genre.parent_ID = parent.ID and EXISTS (
           SELECT 1 from bookshop.Books as books where books.genre_ID = genre.ID and EXISTS (
             SELECT 1 from bookshop.Authors as Authors where Authors.ID = books.author_ID
@@ -1054,8 +1054,8 @@ describe('Scoped queries', () => {
   })
 
   it('handles paths with recursive associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors:books.genre.parent.parent.parent {parent.ID}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as parent {parent.ID}
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors:books.genre.parent.parent.parent {parent.ID}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as parent {parent.ID}
       WHERE EXISTS (
         SELECT 1 from bookshop.Genres as parent2 where parent2.parent_ID = parent.ID and EXISTS (
           SELECT 1 from bookshop.Genres as parent3 where parent3.parent_ID = parent2.ID and EXISTS (
@@ -1070,15 +1070,15 @@ describe('Scoped queries', () => {
   })
 
   it('handles paths with unmanaged association', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent {id}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Baz:parent {id}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
         SELECT 1 from bookshop.Baz as Baz where parent.id = Baz.parent_id or parent.id > 17
       )`)
   })
 
   it('handles paths with unmanaged association with alias', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent as A {id}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Baz as A {A.id} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Baz:parent as A {id}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Baz as A {A.id} WHERE EXISTS (
         SELECT 1 from bookshop.Baz as Baz where A.id = Baz.parent_id or A.id > 17
       )`)
   })
@@ -1086,14 +1086,14 @@ describe('Scoped queries', () => {
   // (SMW) need more tests with unmanaged ON conds using all sorts of stuff -> e.g. struc access in ON, FK of mgd assoc in FROM ...
 
   it('transforms unmanaged association to where exists subquery and infix filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent[id<20] {parent.id}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Baz:parent[id<20] {parent.id}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
         SELECT 1 from bookshop.Baz as Baz where parent.id = Baz.parent_id or parent.id > 17
       ) AND parent.id < 20`)
   })
   it('transforms unmanaged association to where exists subquery with multiple infix filter', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Baz:parent[id<20 or id > 12] {parent.id}`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Baz:parent[id<20 or id > 12] {parent.id}`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Baz as parent {parent.id} WHERE EXISTS (
         SELECT 1 from bookshop.Baz as Baz where parent.id = Baz.parent_id or parent.id > 17
       ) AND (parent.id < 20 or parent.id > 12)`)
   })
@@ -1103,9 +1103,9 @@ describe('Scoped queries', () => {
   //
 
   it('exists predicate in infix filter in FROM', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Authors[exists books] {ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Authors[exists books] {ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as Authors {Authors.ID}
+      cds.ql`SELECT from bookshop.Authors as Authors {Authors.ID}
         WHERE EXISTS (
           SELECT 1 from bookshop.Books as books where books.author_ID = Authors.ID
         )`,
@@ -1113,9 +1113,9 @@ describe('Scoped queries', () => {
   })
 
   it('exists predicate in infix filter at ssoc path step in FROM', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:author[exists books] {ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:author[exists books] {ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as author {author.ID}
+      cds.ql`SELECT from bookshop.Authors as author {author.ID}
         WHERE EXISTS (
           SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
         ) and EXISTS (
@@ -1126,11 +1126,11 @@ describe('Scoped queries', () => {
 
   it('exists predicate followed by unmanaged assoc as infix filter (also within xpr)', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books:author[exists books[exists coAuthorUnmanaged or title = 'Sturmhöhe']] { ID }`,
+      cds.ql`SELECT from bookshop.Books:author[exists books[exists coAuthorUnmanaged or title = 'Sturmhöhe']] { ID }`,
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as author {author.ID}
+      cds.ql`SELECT from bookshop.Authors as author {author.ID}
             where exists (
               SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
             ) and exists (
@@ -1147,9 +1147,9 @@ describe('Scoped queries', () => {
   })
 
   it('exists predicate in infix filter followed by assoc in FROM', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[exists genre]:author {ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[exists genre]:author {ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as author {author.ID}
+      cds.ql`SELECT from bookshop.Authors as author {author.ID}
         WHERE EXISTS (
           SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
             and EXISTS (
@@ -1160,9 +1160,9 @@ describe('Scoped queries', () => {
   })
 
   it('exists predicate in infix filters in FROM', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books[exists genre]:author[exists books] {ID}`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books[exists genre]:author[exists books] {ID}`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as author {author.ID}
+      cds.ql`SELECT from bookshop.Authors as author {author.ID}
         WHERE EXISTS (
           SELECT 1 from bookshop.Books as Books where Books.author_ID = author.ID
           and EXISTS (
@@ -1177,11 +1177,11 @@ describe('Scoped queries', () => {
   // (SMW) revisit: semantically correct, but order of infix filter and exists subqueries not consistent
   it('exists predicate in infix filters in FROM, multiple assoc steps', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books[exists genre]:author[exists books].books[exists genre] {ID}`,
+      cds.ql`SELECT from bookshop.Books[exists genre]:author[exists books].books[exists genre] {ID}`,
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Books as books {books.ID}
+      cds.ql`SELECT from bookshop.Books as books {books.ID}
         WHERE EXISTS (
           SELECT 1 from bookshop.Authors as author where author.ID = books.author_ID
             and EXISTS (
@@ -1200,39 +1200,39 @@ describe('Scoped queries', () => {
   })
 
   it('... managed association with structured FK', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_struc { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze2 as a_struc { a_struc.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_struc { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze2 as a_struc { a_struc.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1 where AssocMaze1.a_struc_ID_1_a = a_struc.ID_1_a and AssocMaze1.a_struc_ID_1_b = a_struc.ID_1_b
                                                           and AssocMaze1.a_struc_ID_2_a = a_struc.ID_2_a and AssocMaze1.a_struc_ID_2_b =  a_struc.ID_2_b
       )`)
   })
 
   it('... managed association with explicit simple FKs', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_strucX { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze2 as a_strucX { a_strucX.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_strucX { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze2 as a_strucX { a_strucX.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1 where AssocMaze1.a_strucX_a = a_strucX.a and AssocMaze1.a_strucX_b = a_strucX.b
       )`)
   })
 
   it('... managed association with explicit structured FKs', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_strucY { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze2 as a_strucY { a_strucY.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_strucY { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze2 as a_strucY { a_strucY.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1 where AssocMaze1.a_strucY_S_1_a = a_strucY.S_1_a and AssocMaze1.a_strucY_S_1_b = a_strucY.S_1_b
                                                           and AssocMaze1.a_strucY_S_2_a = a_strucY.S_2_a and AssocMaze1.a_strucY_S_2_b = a_strucY.S_2_b
       )`)
   })
 
   it('... managed association with explicit structured aliased FKs', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_strucXA { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze2 as a_strucXA { a_strucXA.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_strucXA { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze2 as a_strucXA { a_strucXA.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1 where AssocMaze1.a_strucXA_T_1_a = a_strucXA.S_1_a and AssocMaze1.a_strucXA_T_1_b = a_strucXA.S_1_b
                                                           and AssocMaze1.a_strucXA_T_2_a = a_strucXA.S_2_a and AssocMaze1.a_strucXA_T_2_b = a_strucXA.S_2_b
       )`)
   })
 
   it('... managed associations with FKs being managed associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_assoc { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze3 as a_assoc { a_assoc.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_assoc { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze3 as a_assoc { a_assoc.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1 where AssocMaze1.a_assoc_assoc1_ID_1_a = a_assoc.assoc1_ID_1_a and AssocMaze1.a_assoc_assoc1_ID_1_b = a_assoc.assoc1_ID_1_b
                                                           and AssocMaze1.a_assoc_assoc1_ID_2_a = a_assoc.assoc1_ID_2_a and AssocMaze1.a_assoc_assoc1_ID_2_b = a_assoc.assoc1_ID_2_b
                                                           and AssocMaze1.a_assoc_assoc2_ID_1_a = a_assoc.assoc2_ID_1_a and AssocMaze1.a_assoc_assoc2_ID_1_b = a_assoc.assoc2_ID_1_b
@@ -1241,24 +1241,24 @@ describe('Scoped queries', () => {
   })
 
   it('... managed association with explicit FKs being managed associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_assocY { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze2 as a_assocY { a_assocY.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_assocY { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze2 as a_assocY { a_assocY.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1 where AssocMaze1.a_assocY_A_1_a = a_assocY.A_1_a and AssocMaze1.a_assocY_A_1_b_ID = a_assocY.A_1_b_ID
                                                           and AssocMaze1.a_assocY_A_2_a = a_assocY.A_2_a and AssocMaze1.a_assocY_A_2_b_ID = a_assocY.A_2_b_ID
       )`)
   })
 
   it('... managed association with explicit aliased FKs being managed associations', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_assocYA { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze2 as a_assocYA { a_assocYA.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_assocYA { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze2 as a_assocYA { a_assocYA.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1 where AssocMaze1.a_assocYA_B_1_a = a_assocYA.A_1_a and AssocMaze1.a_assocYA_B_1_b_ID = a_assocYA.A_1_b_ID
                                                           and AssocMaze1.a_assocYA_B_2_a = a_assocYA.A_2_a and AssocMaze1.a_assocYA_B_2_b_ID = a_assocYA.A_2_b_ID
       )`)
   })
 
   it('... managed associations with FKs being mix of struc and managed assoc', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.AssocMaze1:a_strass { val }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.AssocMaze4 as a_strass { a_strass.val } WHERE EXISTS (
+    let query = cqn4sql(cds.ql`SELECT from bookshop.AssocMaze1:a_strass { val }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.AssocMaze4 as a_strass { a_strass.val } WHERE EXISTS (
         SELECT 1 from bookshop.AssocMaze1 as AssocMaze1
           where AssocMaze1.a_strass_A_1_a = a_strass.A_1_a
             and AssocMaze1.a_strass_A_1_b_assoc1_ID_1_a = a_strass.A_1_b_assoc1_ID_1_a and AssocMaze1.a_strass_A_1_b_assoc1_ID_1_b = a_strass.A_1_b_assoc1_ID_1_b
@@ -1274,10 +1274,10 @@ describe('Scoped queries', () => {
   })
 
   it('on condition of to many composition in csn model has xpr', () => {
-    const q = CQL`
+    const q = cds.ql`
       SELECT from bookshop.WorklistItems[ID = 1 and snapshotHash = 0]:releaseChecks[ID = 1 and snapshotHash = 0].detailsDeviations
     `
-    const expected = CQL`
+    const expected = cds.ql`
       SELECT from bookshop.QualityDeviations as detailsDeviations {
         detailsDeviations.snapshotHash,
         detailsDeviations.ID,
@@ -1300,12 +1300,12 @@ describe('Scoped queries', () => {
     expect(cqn4sql(q, model)).to.deep.equal(expected)
   })
   it('on condition of to many composition in csn model has xpr and dangling filter', () => {
-    const q = CQL`
+    const q = cds.ql`
       SELECT from bookshop.WorklistItems[ID = 1 and snapshotHash = 0]
       :releaseChecks[ID = 1 and snapshotHash = 0]
       .detailsDeviations[ID='0' and snapshotHash='0'and batch_ID='*' and material_ID='1']
     `
-    const expected = CQL`
+    const expected = cds.ql`
       SELECT from bookshop.QualityDeviations as detailsDeviations {
         detailsDeviations.snapshotHash,
         detailsDeviations.ID,
@@ -1352,8 +1352,8 @@ describe('Path expressions in from combined with `exists` predicate', () => {
   // SMW -> move that in a seperate "describe" ?
   //
   it('MUST ... mixed with path in FROM clause', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:genre { ID } where exists parent`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as genre { genre.ID }
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:genre { ID } where exists parent`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as genre { genre.ID }
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where Books.genre_ID = genre.ID )
           AND EXISTS ( SELECT 1 from bookshop.Genres as parent where parent.ID = genre.parent_ID )
       `)
@@ -1361,8 +1361,8 @@ describe('Path expressions in from combined with `exists` predicate', () => {
 
   // semantically same as above
   it('MUST ... EXISTS in filter in FROM', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books:genre[exists parent] { ID }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Genres as genre { genre.ID }
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books:genre[exists parent] { ID }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Genres as genre { genre.ID }
         WHERE EXISTS ( SELECT 1 from bookshop.Books as Books where Books.genre_ID = genre.ID )
           AND EXISTS ( SELECT 1 from bookshop.Genres as parent where parent.ID = genre.parent_ID )
       `)
@@ -1376,8 +1376,8 @@ describe('comparisons of associations in on condition of elements needs to be ex
   })
 
   it('OData lambda where exists comparing managed assocs', () => {
-    const query = cqn4sql(CQL`SELECT from a2j.Foo { ID } where exists buz`, model)
-    const expected = CQL`
+    const query = cqn4sql(cds.ql`SELECT from a2j.Foo { ID } where exists buz`, model)
+    const expected = cds.ql`
       SELECT from a2j.Foo as Foo {
         Foo.ID
       } where exists (
@@ -1388,8 +1388,8 @@ describe('comparisons of associations in on condition of elements needs to be ex
     expect(query).to.eql(expected)
   })
   it('OData lambda where exists comparing managed assocs with renamed keys', () => {
-    const query = cqn4sql(CQL`SELECT from a2j.Foo { ID } where exists buzRenamed`, model)
-    const expected = CQL`
+    const query = cqn4sql(cds.ql`SELECT from a2j.Foo { ID } where exists buzRenamed`, model)
+    const expected = cds.ql`
       SELECT from a2j.Foo as Foo {
         Foo.ID
       } where exists (
@@ -1400,8 +1400,8 @@ describe('comparisons of associations in on condition of elements needs to be ex
     expect(query).to.eql(expected)
   })
   it('OData lambda where exists with unmanaged assoc', () => {
-    const query = cqn4sql(CQL`SELECT from a2j.Foo { ID } where exists buzUnmanaged`, model)
-    const expected = CQL`
+    const query = cqn4sql(cds.ql`SELECT from a2j.Foo { ID } where exists buzUnmanaged`, model)
+    const expected = cds.ql`
       SELECT from a2j.Foo as Foo {
         Foo.ID
       } where exists (
@@ -1419,32 +1419,32 @@ describe('Sanity checks for `exists` predicate', () => {
     model = cds.model = await cds.load(__dirname + '/../bookshop/srv/cat-service').then(cds.linked)
   })
   it('rejects $self following exists predicate', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author } where exists $self.author`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author } where exists $self.author`, model)).to.throw(
       'Paths starting with “$self” must not contain steps of type “cds.Association”: ref: [ $self, author ]',
     )
   })
 
   it('rejects non assoc following exists predicate', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID, author[exists name].name as author }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author[exists name].name as author }`, model)).to.throw(
       'Expecting path “name” following “EXISTS” predicate to end with association/composition, found “cds.String”',
     )
   })
 
   it('rejects non assoc following exists predicate in scoped query', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books:author[exists name] { ID }`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books:author[exists name] { ID }`, model)).to.throw(
       'Expecting path “name” following “EXISTS” predicate to end with association/composition, found “cds.String”',
     )
   })
 
   it('rejects non assoc following exists predicate in where', () => {
-    expect(() => cqn4sql(CQL`SELECT from bookshop.Books { ID } where exists author[exists name]`, model)).to.throw(
+    expect(() => cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where exists author[exists name]`, model)).to.throw(
       'Expecting path “name” following “EXISTS” predicate to end with association/composition, found “cds.String”',
     )
   })
 
   it('rejects non assoc at leaf of path following exists predicate', () => {
     expect(() =>
-      cqn4sql(CQL`SELECT from bookshop.Books { ID, author[exists books.title].name as author }`, model),
+      cqn4sql(cds.ql`SELECT from bookshop.Books { ID, author[exists books.title].name as author }`, model),
     ).to.throw(
       'Expecting path “books.title” following “EXISTS” predicate to end with association/composition, found “cds.String”',
     )
@@ -1458,11 +1458,11 @@ describe('path expression within infix filter following exists predicate', () =>
   })
 
   it('via managed association', () => {
-    let query = CQL`SELECT from bookshop.Authors { ID } where exists books[genre.name = 'Thriller']`
+    let query = cds.ql`SELECT from bookshop.Authors { ID } where exists books[genre.name = 'Thriller']`
 
     const transformed = cqn4sql(query, model)
     expect(transformed).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books
         inner join bookshop.Genres as genre on genre.ID = books.genre_ID
         where books.author_ID = Authors.ID and genre.name = 'Thriller'
@@ -1470,11 +1470,11 @@ describe('path expression within infix filter following exists predicate', () =>
     )
   })
   it('via managed association multiple assocs', () => {
-    let query = CQL`SELECT from bookshop.Authors { ID } where exists books.author.books[genre.parent.name = 'Thriller']`
+    let query = cds.ql`SELECT from bookshop.Authors { ID } where exists books.author.books[genre.parent.name = 'Thriller']`
 
     const transformed = cqn4sql(query, model)
     expect(transformed).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books
         where books.author_ID = Authors.ID and EXISTS (
 
@@ -1493,11 +1493,11 @@ describe('path expression within infix filter following exists predicate', () =>
     )
   })
   it('via managed association, hidden in a function', () => {
-    let query = CQL`SELECT from bookshop.Authors { ID } where exists books[toLower(genre.name) = 'thriller']`
+    let query = cds.ql`SELECT from bookshop.Authors { ID } where exists books[toLower(genre.name) = 'thriller']`
 
     const transformed = cqn4sql(query, model)
     expect(transformed).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books
         inner join bookshop.Genres as genre on genre.ID = books.genre_ID
         where books.author_ID = Authors.ID and toLower(genre.name) = 'thriller'
@@ -1506,11 +1506,11 @@ describe('path expression within infix filter following exists predicate', () =>
   })
   it('via unmanaged association', () => {
     // match all authors which have co-authored at least one book with King
-    let query = CQL`SELECT from bookshop.Authors { ID } where exists books[coAuthorUnmanaged.name = 'King']`
+    let query = cds.ql`SELECT from bookshop.Authors { ID } where exists books[coAuthorUnmanaged.name = 'King']`
 
     const transformed = cqn4sql(query, model)
     expect(transformed).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books
         inner join bookshop.Authors as coAuthorUnmanaged on coAuthorUnmanaged.ID = books.coAuthor_ID_unmanaged
         where books.author_ID = Authors.ID and coAuthorUnmanaged.name = 'King'
@@ -1519,11 +1519,11 @@ describe('path expression within infix filter following exists predicate', () =>
   })
 
   it('nested exists', () => {
-    let query = CQL`SELECT from bookshop.Authors { ID } where exists books[toLower(genre.name) = 'thriller' and exists genre[parent.name = 'Fiction']]`
+    let query = cds.ql`SELECT from bookshop.Authors { ID } where exists books[toLower(genre.name) = 'thriller' and exists genre[parent.name = 'Fiction']]`
 
     const transformed = cqn4sql(query, model)
     expect(transformed).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
+      cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID } WHERE EXISTS (
         SELECT 1 from bookshop.Books as books
         inner join bookshop.Genres as genre on genre.ID = books.genre_ID
         where books.author_ID = Authors.ID and toLower(genre.name) = 'thriller'
@@ -1537,11 +1537,11 @@ describe('path expression within infix filter following exists predicate', () =>
   })
 
   it('scoped query with nested exists', () => {
-    let query = CQL`SELECT from bookshop.Authors[exists books[genre.name LIKE '%Fiction']]:books { ID }`
+    let query = cds.ql`SELECT from bookshop.Authors[exists books[genre.name LIKE '%Fiction']]:books { ID }`
 
     const transformed = cqn4sql(query, model)
     expect(transformed).to.deep.equal(
-      CQL`SELECT from bookshop.Books as books
+      cds.ql`SELECT from bookshop.Books as books
       { books.ID }
         WHERE EXISTS (
           SELECT 1 from bookshop.Authors as Authors where Authors.ID = books.author_ID and
@@ -1561,7 +1561,7 @@ describe('path expression within infix filter following exists predicate', () =>
     //     but also all books which have no genre at all
     //
     // if this comes up again, we might render inner joins for this node...
-    let query = CQL`SELECT from bookshop.Authors:books[genre.name = null] { ID }`
+    let query = cds.ql`SELECT from bookshop.Authors:books[genre.name = null] { ID }`
 
     expect(() => cqn4sql(query, model)).to.throw(
       `Only foreign keys of “genre” can be accessed in infix filter, but found “name”`
@@ -1571,7 +1571,7 @@ describe('path expression within infix filter following exists predicate', () =>
   it('in case statements', () => {
     // TODO: Aliases for genre could be improved
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Authors
+      cds.ql`SELECT from bookshop.Authors
      { ID,
        case when exists books[toLower(genre.name) = 'Thriller' and price>10]  then 1
             when exists books[toLower(genre.name) = 'Thriller' and price>100 and exists genre] then 2
@@ -1580,7 +1580,7 @@ describe('path expression within infix filter following exists predicate', () =>
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Authors as Authors
+      cds.ql`SELECT from bookshop.Authors as Authors
       { Authors.ID,
         case 
           when exists (
@@ -1606,11 +1606,11 @@ describe('path expression within infix filter following exists predicate', () =>
   it('assoc is defined within a structure', () => {
     expect(
       cqn4sql(
-        CQL`SELECT from bookshop.Authors { ID } WHERE EXISTS books[toLower(toUpper(dedication.addressee.name)) = 'Hasso']`,
+        cds.ql`SELECT from bookshop.Authors { ID } WHERE EXISTS books[toLower(toUpper(dedication.addressee.name)) = 'Hasso']`,
         model,
       ),
     ).to.eql(
-      CQL`SELECT from bookshop.Authors as Authors { Authors.ID }
+      cds.ql`SELECT from bookshop.Authors as Authors { Authors.ID }
       WHERE EXISTS (
         SELECT 1 from bookshop.Books as books
           inner join bookshop.Person as addressee

--- a/db-service/test/cqn4sql/wildcards.test.js
+++ b/db-service/test/cqn4sql/wildcards.test.js
@@ -29,10 +29,10 @@ describe('wildcard expansion and exclude clause', () => {
 
   it('Respects excluding when expanding wildcard', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { *, author.ID as author } excluding {createdBy, modifiedBy}`,
+      cds.ql`SELECT from bookshop.Books { *, author.ID as author } excluding {createdBy, modifiedBy}`,
       model,
     )
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books {
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books {
         Books.createdAt,
         Books.modifiedAt,
         Books.ID,
@@ -54,10 +54,10 @@ describe('wildcard expansion and exclude clause', () => {
   })
 
   it('MUST respect smart wildcard rules', () => {
-    const input = CQL`SELECT from bookshop.Bar { 'first' as first, 'second' as createdAt, *, 'third' as ID }`
+    const input = cds.ql`SELECT from bookshop.Bar { 'first' as first, 'second' as createdAt, *, 'third' as ID }`
     let query = cqn4sql(input, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         'first' as first,
         'second' as createdAt,
         'third' as ID,
@@ -74,10 +74,10 @@ describe('wildcard expansion and exclude clause', () => {
     )
   })
   it('overwrite column with struct', () => {
-    const input = CQL`SELECT from bookshop.Bar { structure as first, 'second' as createdAt, *, structure as ID }`
+    const input = cds.ql`SELECT from bookshop.Bar { structure as first, 'second' as createdAt, *, structure as ID }`
     let query = cqn4sql(input, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.structure_foo as first_foo,
         Bar.structure_baz as first_baz,
         'second' as createdAt,
@@ -97,10 +97,10 @@ describe('wildcard expansion and exclude clause', () => {
   })
 
   it('MUST respect smart wildcard rules -> structure replacement before star', () => {
-    const input = CQL`SELECT from bookshop.Bar { 'first' as structure, * }`
+    const input = cds.ql`SELECT from bookshop.Bar { 'first' as structure, * }`
     let query = cqn4sql(input, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         'first' as structure,
         Bar.ID,
         Bar.stock,
@@ -115,10 +115,10 @@ describe('wildcard expansion and exclude clause', () => {
     )
   })
   it('MUST respect smart wildcard rules -> structure replacement after star', () => {
-    const input = CQL`SELECT from bookshop.Bar { *, 'third' as structure }`
+    const input = cds.ql`SELECT from bookshop.Bar { *, 'third' as structure }`
     let query = cqn4sql(input, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.ID,
         Bar.stock,
         'third' as structure,
@@ -133,10 +133,10 @@ describe('wildcard expansion and exclude clause', () => {
     )
   })
   it('MUST respect smart wildcard rules -> ref replaces wildcard element', () => {
-    const input = CQL`SELECT from bookshop.Bar { *, nested.bar.a as structure }`
+    const input = cds.ql`SELECT from bookshop.Bar { *, nested.bar.a as structure }`
     let query = cqn4sql(input, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.ID,
         Bar.stock,
         Bar.nested_bar_a as structure,
@@ -151,10 +151,10 @@ describe('wildcard expansion and exclude clause', () => {
     )
   })
   it('MUST respect smart wildcard rules -> subquery replacement after star', () => {
-    const input = CQL`SELECT from bookshop.Bar { *, (SELECT from bookshop.Bar {ID}) as structure }`
+    const input = cds.ql`SELECT from bookshop.Bar { *, (SELECT from bookshop.Bar {ID}) as structure }`
     let query = cqn4sql(input, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
           Bar.ID,
           Bar.stock,
           (SELECT from bookshop.Bar as Bar2 {Bar2.ID}) as structure,
@@ -169,8 +169,8 @@ describe('wildcard expansion and exclude clause', () => {
     )
   })
   it('expand after wildcard overwrites assoc from wildcard expansion', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { *, author {name} }`, model)
-    expect(JSON.parse(JSON.stringify(query))).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { *, author {name} }`, model)
+    expect(JSON.parse(JSON.stringify(query))).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         {
           Books.createdAt,
           Books.createdBy,
@@ -200,8 +200,8 @@ describe('wildcard expansion and exclude clause', () => {
   })
   it('expand after wildcard combines assoc from wildcard expansion (flat mode)', () => {
     const flatModel = cds.compile.for.nodejs(JSON.parse(JSON.stringify(model)))
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { *, author {name} }`, flatModel)
-    const expected = CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { *, author {name} }`, flatModel)
+    const expected = cds.ql`SELECT from bookshop.Books as Books
         {
           Books.createdAt,
           Books.createdBy,
@@ -239,8 +239,8 @@ describe('wildcard expansion and exclude clause', () => {
 
   it('path expression after wildcard replaces assoc from wildcard expansion', () => {
     // "author.name as author" will replace the "author" association from Books -> no fk here
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { *, author.name as author }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { *, author.name as author }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         left outer join bookshop.Authors as author on author.ID = Books.author_ID
         {
           Books.createdAt,
@@ -266,8 +266,8 @@ describe('wildcard expansion and exclude clause', () => {
       `)
   })
   it('xpr after wildcard replaces assoc from wildcard expansion', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { *, ('Stephen' || 'King') as author }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { *, ('Stephen' || 'King') as author }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         {
           Books.createdAt,
           Books.createdBy,
@@ -292,8 +292,8 @@ describe('wildcard expansion and exclude clause', () => {
       `)
   })
   it('val after wildcard replaces assoc from wildcard expansion', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Books { *, 'King' as author }`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books { *, 'King' as author }`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Books as Books
         {
           Books.createdAt,
           Books.createdBy,
@@ -319,11 +319,11 @@ describe('wildcard expansion and exclude clause', () => {
   })
 
   it('If a shadowed column is excluded, the shadowing column is inserted where defined', () => {
-    const input = CQL`SELECT from bookshop.Bar { 'first' as first, 'second' as createdAt, *, 'last' as ID } excluding { ID }`
+    const input = cds.ql`SELECT from bookshop.Bar { 'first' as first, 'second' as createdAt, *, 'last' as ID } excluding { ID }`
     let query = cqn4sql(input, model)
     // original query is prototype of transformed query -> JSON.parse(…)
     expect(JSON.parse(JSON.stringify(query))).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         'first' as first,
         'second' as createdAt,
         Bar.stock,
@@ -341,13 +341,13 @@ describe('wildcard expansion and exclude clause', () => {
   })
 
   it('inline wildcard does not ignore large binaries', () => {
-    let inlineWildcard = CQL`select from bookshop.Books.twin as Books {
+    let inlineWildcard = cds.ql`select from bookshop.Books.twin as Books {
       ID,
       struct.{ * }
     }`
 
     expect(cqn4sql(inlineWildcard, model)).to.deep.equal(
-      CQL`select from bookshop.Books.twin as Books {
+      cds.ql`select from bookshop.Books.twin as Books {
         Books.ID,
         Books.struct_deepImage
       }`,
@@ -355,11 +355,11 @@ describe('wildcard expansion and exclude clause', () => {
   })
 
   it('MUST transform wildcard into explicit column refs (1)', () => {
-    const input = CQL`SELECT from bookshop.Bar { * }`
+    const input = cds.ql`SELECT from bookshop.Bar { * }`
     const inputClone = JSON.parse(JSON.stringify(input))
     let query = cqn4sql(input, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.ID,
         Bar.stock,
         Bar.structure_foo,
@@ -379,14 +379,14 @@ describe('wildcard expansion and exclude clause', () => {
 
   it('MUST transform wildcard into explicit column refs (2)', () => {
     let starExpansion = cqn4sql(
-      CQL`SELECT from bookshop.Books { * }`, // resolve star into cols already
+      cds.ql`SELECT from bookshop.Books { * }`, // resolve star into cols already
       model,
     )
     let noColumnsExpansion = cqn4sql(
-      CQL`SELECT from bookshop.Books`, // resolve star into cols already
+      cds.ql`SELECT from bookshop.Books`, // resolve star into cols already
       model,
     )
-    const expected = CQL`SELECT from bookshop.Books as Books {
+    const expected = cds.ql`SELECT from bookshop.Books as Books {
       Books.createdAt,
       Books.createdBy,
       Books.modifiedAt,
@@ -413,15 +413,15 @@ describe('wildcard expansion and exclude clause', () => {
 
   it('MUST transform wildcard into explicit column refs (3)', () => {
     let starExpansion = cqn4sql(
-      CQL`SELECT from bookshop.Bar`, // resolve star into cols already
+      cds.ql`SELECT from bookshop.Bar`, // resolve star into cols already
       model,
     )
     let noColumnsExpansion = cqn4sql(
-      CQL`SELECT from bookshop.Bar`, // resolve star into cols already
+      cds.ql`SELECT from bookshop.Bar`, // resolve star into cols already
       model,
     )
     expect(starExpansion).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.ID,
         Bar.stock,
         Bar.structure_foo,
@@ -436,7 +436,7 @@ describe('wildcard expansion and exclude clause', () => {
       }`,
     )
     expect(noColumnsExpansion).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.ID,
         Bar.stock,
         Bar.structure_foo,
@@ -454,11 +454,11 @@ describe('wildcard expansion and exclude clause', () => {
 
   it('MUST transform wildcard into explicit column refs and respect order', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Bar {structure as beforeStar, *, structure as afterStar}`, // resolve star into cols already
+      cds.ql`SELECT from bookshop.Bar {structure as beforeStar, *, structure as afterStar}`, // resolve star into cols already
       model,
     )
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Bar as Bar {
+      cds.ql`SELECT from bookshop.Bar as Bar {
         Bar.structure_foo as beforeStar_foo,
         Bar.structure_baz as beforeStar_baz,
         Bar.ID,
@@ -481,11 +481,11 @@ describe('wildcard expansion and exclude clause', () => {
   // skipped as queries with multiple sources are not supported (at least for now)
   it.skip('MUST transform wildcard into explicit column refs with multiple entities', () => {
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books, bookshop.WithStructuredKey { * }`, // resolve star into cols already
+      cds.ql`SELECT from bookshop.Books, bookshop.WithStructuredKey { * }`, // resolve star into cols already
       model,
     )
     expect(query).to.deep.eql(
-      CQL`SELECT from bookshop.Books as Books, bookshop.WithStructuredKey as WithStructuredKey {
+      cds.ql`SELECT from bookshop.Books as Books, bookshop.WithStructuredKey as WithStructuredKey {
             Books.createdAt,
             Books.createdBy,
             Books.modifiedAt,
@@ -513,8 +513,8 @@ describe('wildcard expansion and exclude clause', () => {
   })
   it('must not yield duplicate columns for already expanded foreign keys with OData CSN input', () => {
     const flatModel = cds.linked(cds.compile.for.nodejs(JSON.parse(JSON.stringify(model))))
-    let query = cqn4sql(CQL`SELECT from bookshop.Books where author.name = 'Sanderson'`, flatModel)
-    const expected = CQL`SELECT from bookshop.Books as Books
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Books where author.name = 'Sanderson'`, flatModel)
+    const expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       {
       Books.createdAt,
@@ -549,10 +549,10 @@ describe('wildcard expansion and exclude clause', () => {
   it('must be possible to select already expanded foreign keys with OData CSN input', () => {
     const flatModel = cds.linked(cds.compile.for.nodejs(JSON.parse(JSON.stringify(model))))
     let query = cqn4sql(
-      CQL`SELECT from bookshop.Books { genre_ID, author_ID } where author.name = 'Sanderson'`,
+      cds.ql`SELECT from bookshop.Books { genre_ID, author_ID } where author.name = 'Sanderson'`,
       flatModel,
     )
-    const expected = CQL`SELECT from bookshop.Books as Books
+    const expected = cds.ql`SELECT from bookshop.Books as Books
       left outer join bookshop.Authors as author on author.ID = Books.author_ID
       {
       Books.genre_ID,
@@ -570,23 +570,23 @@ describe('wildcard expansion and exclude clause', () => {
   it.skip('must error out for clash of already expanded foreign keys with OData CSN input and manually expanded foreign key', () => {
     const odatamodel = cds.linked(cds.compile.for.nodejs(JSON.parse(JSON.stringify(model))))
     expect(() =>
-      cqn4sql(CQL`SELECT from bookshop.Books { author, author_ID } where author.name = 'Sanderson'`, odatamodel),
+      cqn4sql(cds.ql`SELECT from bookshop.Books { author, author_ID } where author.name = 'Sanderson'`, odatamodel),
     ).to.throw(/Can't flatten "author" as resulting element name conflicts with existing column "author_ID"/)
   })
 
   it('does not mistake "*" as wildcard in GROUP BY clause', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Bar { ID } group by '*'`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar { Bar.ID } group by '*'`)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } group by '*'`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar { Bar.ID } group by '*'`)
   })
   it('does not mistake "*" as wildcard in ORDER BY clause', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Bar { ID } order by '*'`, model)
-    expect(query).to.deep.equal(CQL`SELECT from bookshop.Bar as Bar { Bar.ID } order by '*'`)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Bar { ID } order by '*'`, model)
+    expect(query).to.deep.equal(cds.ql`SELECT from bookshop.Bar as Bar { Bar.ID } order by '*'`)
   })
 
   it('ignores virtual field from wildcard expansion', () => {
-    let query = cqn4sql(CQL`SELECT from bookshop.Foo { * }`, model)
+    let query = cqn4sql(cds.ql`SELECT from bookshop.Foo { * }`, model)
     expect(query).to.deep.equal(
-      CQL`SELECT from bookshop.Foo as Foo { Foo.ID, Foo.toFoo_ID, Foo.stru_u, Foo.stru_nested_nu }`,
+      cds.ql`SELECT from bookshop.Foo as Foo { Foo.ID, Foo.toFoo_ID, Foo.stru_u, Foo.stru_nested_nu }`,
     )
   })
 })

--- a/db-service/test/cqn4sql/with-parameters.test.js
+++ b/db-service/test/cqn4sql/with-parameters.test.js
@@ -22,7 +22,7 @@ describe('entities and views with parameters', () => {
     })
     it('follow association to entity with params', () => {
       const query = cqn4sql(SELECT.from('Books').columns('author(P1: 1, P2: 2).name as author'), model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT FROM Books as Books left join Authors(P1:1, P2: 2) as author
         on author.ID = Books.author_ID {
           author.name as author
@@ -32,7 +32,7 @@ describe('entities and views with parameters', () => {
     })
     it('select from entity with params and follow association to entity with params', () => {
       const query = cqn4sql(SELECT.from('PBooks(P1: 42, P2: 45)').columns('author(P1: 1, P2: 2).name as author'), model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT FROM PBooks(P1: 42, P2: 45) as PBooks left join Authors(P1:1, P2: 2) as author
         on author.ID = PBooks.author_ID {
           author.name as author
@@ -41,7 +41,7 @@ describe('entities and views with parameters', () => {
       expect(query).to.deep.equal(expected)
     })
     it('join identity via params', () => {
-      const cqn = CQL`SELECT from PBooks(P1: 42, P2: 45) {
+      const cqn = cds.ql`SELECT from PBooks(P1: 42, P2: 45) {
             author(P1: 1, P2: 2).name as author,
             author(P1: 1, P2: 2).name as sameAuthor,
 
@@ -50,7 +50,7 @@ describe('entities and views with parameters', () => {
             author(P1: 1)[ID > 15].name as otherOtherAuthor,
     }`
       const query = cqn4sql(cqn, model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT FROM PBooks(P1: 42, P2: 45) as PBooks
       left join Authors(P1:1, P2: 2) as author on author.ID = PBooks.author_ID
       left join Authors(P1:1) as author2 on author2.ID = PBooks.author_ID
@@ -68,11 +68,11 @@ describe('entities and views with parameters', () => {
       expect(query).to.deep.equal(expected)
     })
     it('empty argument list if no params provided for association', () => {
-      const cqn = CQL`SELECT from PBooks(P1: 42, P2: 45) {
+      const cqn = cds.ql`SELECT from PBooks(P1: 42, P2: 45) {
             author.name as author,
     }`
       const query = cqn4sql(cqn, model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT FROM PBooks(P1: 42, P2: 45) as PBooks
       left join Authors(P1: dummy) as author on author.ID = PBooks.author_ID
         {
@@ -84,11 +84,11 @@ describe('entities and views with parameters', () => {
       expect(query).to.deep.equal(expected)
     })
     it('empty argument list if no params provided for entity and association', () => {
-      const cqn = CQL`SELECT from PBooks {
+      const cqn = cds.ql`SELECT from PBooks {
             author.name as author,
     }`
       const query = cqn4sql(cqn, model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT FROM PBooks(P1: dummy) as PBooks
       left join Authors(P1: dummy) as author on author.ID = PBooks.author_ID
         {
@@ -101,11 +101,11 @@ describe('entities and views with parameters', () => {
       expect(query).to.deep.equal(expected)
     })
     it('empty argument list for UDF', () => {
-      const cqn = CQL`SELECT from BooksUDF {
+      const cqn = cds.ql`SELECT from BooksUDF {
       author.name as author,
     }`
       const query = cqn4sql(cqn, model)
-      const expected = CQL`
+      const expected = cds.ql`
       SELECT FROM BooksUDF(P1: dummy) as BooksUDF
       left join AuthorsUDF(P1: dummy) as author on author.ID = BooksUDF.author_ID
         {
@@ -121,8 +121,8 @@ describe('entities and views with parameters', () => {
 
   describe('where exists', () => {
     it('scoped query', () => {
-      const query = CQL`SELECT from Books:author(P1: 1, P2: 2) { ID }`
-      const expected = CQL`
+      const query = cds.ql`SELECT from Books:author(P1: 1, P2: 2) { ID }`
+      const expected = cds.ql`
         SELECT from Authors(P1: 1, P2: 2) as author { author.ID }
           where exists (
             SELECT 1 from Books as Books where Books.author_ID = author.ID
@@ -131,8 +131,8 @@ describe('entities and views with parameters', () => {
       expect(cqn4sql(query, model)).to.deep.equal(expected)
     })
     it('where exists shortcut', () => {
-      const query = CQL`SELECT from Books { ID } where exists author(P1: 1, P2: 2)`
-      const expected = CQL`
+      const query = cds.ql`SELECT from Books { ID } where exists author(P1: 1, P2: 2)`
+      const expected = cds.ql`
         SELECT from Books as Books { Books.ID }
           where exists (
             SELECT 1 from Authors(P1: 1, P2: 2) as author where author.ID = Books.author_ID
@@ -141,8 +141,8 @@ describe('entities and views with parameters', () => {
       expect(cqn4sql(query, model)).to.deep.equal(expected)
     })
     it('where exists shortcut w/o params', () => {
-      const query = CQL`SELECT from Books { ID } where exists author`
-      const expected = CQL`
+      const query = cds.ql`SELECT from Books { ID } where exists author`
+      const expected = cds.ql`
         SELECT from Books as Books { Books.ID }
           where exists (
             SELECT 1 from Authors(P1: dummy) as author where author.ID = Books.author_ID
@@ -156,10 +156,10 @@ describe('entities and views with parameters', () => {
 
   describe('expand subqueries', () => {
     it('expand with params', () => {
-      const query = CQL`SELECT from Books {
+      const query = cds.ql`SELECT from Books {
         author(P1: 1, P2: 2) { ID }
       }`
-      const expected = CQL`SELECT from Books as Books {
+      const expected = cds.ql`SELECT from Books as Books {
         (
           SELECT from Authors(P1: 1, P2: 2) as author {
             author.ID
@@ -169,10 +169,10 @@ describe('entities and views with parameters', () => {
       expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(expected)
     })
     it('expand on parameterized entity without args', () => {
-      const query = CQL`SELECT from Books {
+      const query = cds.ql`SELECT from Books {
         author { ID }
       }`
-      const expected = CQL`SELECT from Books as Books {
+      const expected = cds.ql`SELECT from Books as Books {
         (
           SELECT from Authors(P1: dummy) as author {
             author.ID

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -8,25 +8,25 @@ describe('SELECT', () => {
   describe('from', () => {
     test('table', async () => {
       const { globals } = cds.entities('basic.projection')
-      const res = await cds.run(CQL`SELECT bool FROM ${globals}`)
+      const res = await cds.run(cds.ql`SELECT bool FROM ${globals}`)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('table *', async () => {
       const { globals } = cds.entities('basic.projection')
-      const res = await cds.run(CQL`SELECT * FROM ${globals}`)
+      const res = await cds.run(cds.ql`SELECT * FROM ${globals}`)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('projection', async () => {
       const { globals } = cds.entities('basic.projection')
-      const res = await cds.run(CQL`SELECT bool FROM ${globals}`)
+      const res = await cds.run(cds.ql`SELECT bool FROM ${globals}`)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('join', async () => {
       const { globals } = cds.entities('basic.projection')
-      const res = await cds.run(CQL`
+      const res = await cds.run(cds.ql`
       SELECT A.bool
       FROM ${globals} as A
       LEFT JOIN basic.projection.globals AS B
@@ -44,19 +44,19 @@ describe('SELECT', () => {
 
     test('from select', async () => {
       const { globals } = cds.entities('basic.projection')
-      const res = await cds.run(CQL`SELECT bool FROM (SELECT bool FROM ${globals}) AS nested`)
+      const res = await cds.run(cds.ql`SELECT bool FROM (SELECT bool FROM ${globals}) AS nested`)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('from ref', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT * FROM ${string}[string = ${'yes'}]`
+      const cqn = cds.ql`SELECT * FROM ${string}[string = ${'yes'}]`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, `Ensure that only 'yes' matches`)
     })
 
     test('from non existant entity', async () => {
-      const cqn = CQL`SELECT * FROM ![¿HoWdIdYoUmAnAgeToCaLaNeNtItyThIsNaMe?]`
+      const cqn = cds.ql`SELECT * FROM ![¿HoWdIdYoUmAnAgeToCaLaNeNtItyThIsNaMe?]`
       await expect(cds.run(cqn)).rejected
     })
   })
@@ -64,7 +64,7 @@ describe('SELECT', () => {
   describe('columns', () => {
     test('missing', async () => {
       const { globals } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT FROM ${globals}`
+      const cqn = cds.ql`SELECT FROM ${globals}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual('bool' in res[0], true, 'Ensure that all columns are coming back')
@@ -72,7 +72,7 @@ describe('SELECT', () => {
 
     test('star', async () => {
       const { globals } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT * FROM ${globals}`
+      const cqn = cds.ql`SELECT * FROM ${globals}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual('bool' in res[0], true, 'Ensure that all columns are coming back')
@@ -80,7 +80,7 @@ describe('SELECT', () => {
 
     test('specific', async () => {
       const { globals } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT bool FROM ${globals}`
+      const cqn = cds.ql`SELECT bool FROM ${globals}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual('bool' in res[0], true, 'Ensure that all columns are coming back')
@@ -88,7 +88,7 @@ describe('SELECT', () => {
 
     test('statics', async () => {
       const { globals } = cds.entities('basic.projection')
-      const res = await cds.run(CQL`
+      const res = await cds.run(cds.ql`
         SELECT
           null as ![nullt] : String,
           'String' as ![string],
@@ -111,7 +111,7 @@ describe('SELECT', () => {
 
     test('select func', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT count() FROM ${string}`
+      const cqn = cds.ql`SELECT count() FROM ${string}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
       assert.strictEqual(res[0].count, 3, 'Ensure that the function is applied')
@@ -119,7 +119,7 @@ describe('SELECT', () => {
 
     test('select funcs', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT min(string),max(string),count() FROM ${string}`
+      const cqn = cds.ql`SELECT min(string),max(string),count() FROM ${string}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
       assert.strictEqual(res[0].min, 'no', 'Ensure that the function is applied')
@@ -129,13 +129,13 @@ describe('SELECT', () => {
 
     test('select funcs (duplicates)', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT count(*),count(1),count(string),count(char) FROM ${string}`
+      const cqn = cds.ql`SELECT count(*),count(1),count(string),count(char) FROM ${string}`
       await expect(cds.run(cqn)).rejected
     })
 
     test('select func alias', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT count() as count_renamed FROM ${string}`
+      const cqn = cds.ql`SELECT count() as count_renamed FROM ${string}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
       assert.strictEqual(res[0].count_renamed, 3, 'Ensure that the function is applied and aliased')
@@ -143,7 +143,7 @@ describe('SELECT', () => {
 
     test('select funcs alias', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`
+      const cqn = cds.ql`
       SELECT
         count(*) as count_star,
         count(1) as count_one,
@@ -160,13 +160,13 @@ describe('SELECT', () => {
 
     test('select funcs alias (duplicates)', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT min(string) as count,max(string) as count,count() FROM ${string}`
+      const cqn = cds.ql`SELECT min(string) as count,max(string) as count,count() FROM ${string}`
       await expect(cds.run(cqn)).rejected
     })
 
     test('select function (wrong)', async () => {
       const { globals } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT 'func' as function : cds.String FROM ${globals}`
+      const cqn = cds.ql`SELECT 'func' as function : cds.String FROM ${globals}`
       cqn.SELECT.columns[0].val = function () { }
       await expect(cds.run(cqn)).rejected
     })
@@ -174,7 +174,7 @@ describe('SELECT', () => {
     test('select xpr', async () => {
       // REVISIT: Make HANAService ANSI SQL compliant by wrapping compare expressions into case statements for columns
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT (${'yes'} = string) as xpr : cds.Boolean FROM ${string} order by string`
+      const cqn = cds.ql`SELECT (${'yes'} = string) as xpr : cds.Boolean FROM ${string} order by string`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.equal(res[0].xpr, null)
@@ -184,14 +184,14 @@ describe('SELECT', () => {
 
     test('select calculation', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT (string || string) as string FROM ${string}`
+      const cqn = cds.ql`SELECT (string || string) as string FROM ${string}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('select sub select', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT (SELECT string FROM ${string} as sub WHERE sub.string = root.string) as string FROM ${string} as root`
+      const cqn = cds.ql`SELECT (SELECT string FROM ${string} as sub WHERE sub.string = root.string) as string FROM ${string} as root`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
@@ -236,7 +236,7 @@ describe('SELECT', () => {
 
     test('expand association with static values', async () => {
       const { Authors } = cds.entities('complex.associations.unmanaged')
-      const cqn = CQL`SELECT static{*} FROM ${Authors}`
+      const cqn = cds.ql`SELECT static{*} FROM ${Authors}`
       const res = await cds.run(cqn)
       // ensure that all values are returned in json format
       assert.strictEqual(res[0].static.length, 1)
@@ -244,7 +244,7 @@ describe('SELECT', () => {
 
     test.skip('invalid cast (wrong)', async () => {
       const { globals } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT 'String' as ![string] : cds.DoEsNoTeXiSt FROM ${globals}`
+      const cqn = cds.ql`SELECT 'String' as ![string] : cds.DoEsNoTeXiSt FROM ${globals}`
       await expect(cds.run(cqn), { message: 'Not supported type: cds.DoEsNoTeXiSt' })
         .rejected
     })
@@ -253,7 +253,7 @@ describe('SELECT', () => {
   describe('excluding', () => {
     test('without columns', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT FROM ${string} excluding { string }`
+      const cqn = cds.ql`SELECT FROM ${string} excluding { string }`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual('string' in res[0], false, 'Ensure that excluded columns are missing')
@@ -261,7 +261,7 @@ describe('SELECT', () => {
 
     test('with start', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT FROM ${string} { * } excluding { string }`
+      const cqn = cds.ql`SELECT FROM ${string} { * } excluding { string }`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual('string' in res[0], false, 'Ensure that excluded columns are missing')
@@ -269,7 +269,7 @@ describe('SELECT', () => {
 
     test('with extra columns', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT FROM ${string} { *, ${'extra'} } excluding { string }`
+      const cqn = cds.ql`SELECT FROM ${string} { *, ${'extra'} } excluding { string }`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual('string' in res[0], false, 'Ensure that excluded columns are missing')
@@ -278,7 +278,7 @@ describe('SELECT', () => {
 
     test('with specific columns', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT FROM ${string} { string, char } excluding { string }`
+      const cqn = cds.ql`SELECT FROM ${string} { string, char } excluding { string }`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual('string' in res[0], true, 'Ensure that specific columns are included')
@@ -288,7 +288,7 @@ describe('SELECT', () => {
   describe('where', () => {
     test('empty where clause', async () => {
       const { globals } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT bool FROM ${globals}`
+      const cqn = cds.ql`SELECT bool FROM ${globals}`
       cqn.SELECT.where = []
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
@@ -308,33 +308,33 @@ describe('SELECT', () => {
 
     test('combine expr with nested functions and other compare', async () => {
       const { string } = cds.entities('basic.literals')
-      const res = await cds.run(CQL`SELECT string FROM ${string} WHERE string != ${'foo'} and contains(tolower(string),tolower(${'bar'}))`)
+      const res = await cds.run(cds.ql`SELECT string FROM ${string} WHERE string != ${'foo'} and contains(tolower(string),tolower(${'bar'}))`)
       assert.strictEqual(res.length, 0, 'Ensure that no row is coming back')
     })
 
     test('combine expr and other compare', async () => {
       const { globals } = cds.entities('basic.literals')
-      const res = await cds.run(CQL`SELECT bool FROM ${globals} WHERE (bool != ${true}) and bool = ${false}`)
+      const res = await cds.run(cds.ql`SELECT bool FROM ${globals} WHERE (bool != ${true}) and bool = ${false}`)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
 
     test('exists path expression', async () => {
       const { Books } = cds.entities('complex.associations')
-      const cqn = CQL`SELECT * FROM ${Books} WHERE exists author.books[author.name = ${'Emily'}]`
+      const cqn = cds.ql`SELECT * FROM ${Books} WHERE exists author.books[author.name = ${'Emily'}]`
       const res = await cds.run(cqn)
       expect(res[0]).to.have.property('title', 'Wuthering Heights')
     })
 
     test('exists path expression (unmanaged)', async () => {
       const { Books } = cds.entities('complex.associations.unmanaged')
-      const cqn = CQL`SELECT * FROM ${Books} WHERE exists author.books[author.name = ${'Emily'}]`
+      const cqn = cds.ql`SELECT * FROM ${Books} WHERE exists author.books[author.name = ${'Emily'}]`
       const res = await cds.run(cqn)
       expect(res[0]).to.have.property('title', 'Wuthering Heights')
     })
 
     test('like wildcard', async () => {
       const { string } = cds.entities('basic.projection')
-      const res = await cds.run(CQL`SELECT string FROM ${string} WHERE string LIKE 'ye_'`)
+      const res = await cds.run(cds.ql`SELECT string FROM ${string} WHERE string LIKE 'ye_'`)
       assert.strictEqual(res.length, 1, `Ensure that only 'true' matches`)
     })
 
@@ -350,42 +350,42 @@ describe('SELECT', () => {
 
     test('ref in list', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE string in (${'yes'},${'no'})`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE string in (${'yes'},${'no'})`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 2, 'Ensure that all rows are coming back')
     })
 
     test('list in list of list', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE (string) in ((${'yes'}),(${'no'}))`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE (string) in ((${'yes'}),(${'no'}))`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 2, 'Ensure that all rows are coming back')
     })
 
     test('list in list of list (static)', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE (string,${'static'}) in ((${'yes'},${'static'}),(${'no'},${'static'}))`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE (string,${'static'}) in ((${'yes'},${'static'}),(${'no'},${'static'}))`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 2, 'Ensure that all rows are coming back')
     })
 
     test('ref in SELECT', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE string in (SELECT string from ${string})`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE string in (SELECT string from ${string})`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 2, 'Ensure that all rows are coming back')
     })
 
     test('ref in SELECT alias', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE string in (SELECT string as string_renamed from ${string})`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE string in (SELECT string as string_renamed from ${string})`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 2, 'Ensure that all rows are coming back')
     })
 
     test('param ?', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE string = ?`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE string = ?`
       const res = await cds.run(cqn, ['yes'])
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
@@ -393,21 +393,21 @@ describe('SELECT', () => {
     // REVISIT: it is not yet fully supported to have named parameters on all databases
     test.skip('param named', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE string = :param`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE string = :param`
       const res = await cds.run(cqn, { param: 'yes' })
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
 
     test.skip('param number', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE string = :7`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE string = :7`
       const res = await cds.run(cqn, { 7: 'yes' })
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
 
     test('param multiple uses', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE string = ?`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE string = ?`
       let res = await cds.run(cqn, ['yes'])
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
       res = await cds.run(cqn, [''])
@@ -418,14 +418,14 @@ describe('SELECT', () => {
 
     test('func', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE concat(string, string) = 'yesyes'`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE concat(string, string) = 'yesyes'`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
 
     test('random combination 1', async () => {
       const { string } = cds.entities('basic.projection')
-      const cqn = CQL`SELECT string FROM ${string} WHERE (string || string) = ${'yesyes'} and string in (SELECT string from ${string} WHERE string = ${'yes'})`
+      const cqn = cds.ql`SELECT string FROM ${string} WHERE (string || string) = ${'yesyes'} and string in (SELECT string from ${string} WHERE string = ${'yes'})`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
@@ -439,7 +439,7 @@ describe('SELECT', () => {
 
     test('search multiple column', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT * FROM ${string} WHERE search((string,char,short,medium,large),${'yes'})`
+      const cqn = cds.ql`SELECT * FROM ${string} WHERE search((string,char,short,medium,large),${'yes'})`
       await cds.run(cqn)
     })
 
@@ -471,35 +471,35 @@ describe('SELECT', () => {
 
     test('deep nested not', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`not startswith(string,${'n'})`] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`not startswith(string,${'n'})`] }} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
 
     test('deep nested boolean function w/o operator', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`startswith(string,${'n'})`] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`startswith(string,${'n'})`] }} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'no')
     })
 
     test('deep nested not + and', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`not startswith(string,${'n'}) and not startswith(string,${'n'})`] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`not startswith(string,${'n'}) and not startswith(string,${'n'})`] }} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
 
     test('multiple levels of not negations of expressions', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: ['not', { xpr: ['not', CXL`not startswith(string,${'n'})`] }] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: ['not', { xpr: ['not', CXL`not startswith(string,${'n'})`] }] }} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
 
     test('multiple not in a single deep nested expression', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`not not not startswith(string,${'n'})`] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [CXL`not not not startswith(string,${'n'})`] }} ORDER BY string DESC`
       await cds.tx(async tx => {
         let res
         try {
@@ -514,14 +514,14 @@ describe('SELECT', () => {
 
     test('multiple levels of not negations of expression with not + and', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: ['not', { xpr: ['not', CXL`not startswith(string,${'n'}) and not startswith(string,${'n'})`] }] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: ['not', { xpr: ['not', CXL`not startswith(string,${'n'}) and not startswith(string,${'n'})`] }] }} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
 
     test('multiple levels of not negations of expression with multiple not in a single expression', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: ['not', { xpr: ['not', CXL`not not not startswith(string,${'n'}) and not not not startswith(string,${'n'})`] }] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: ['not', { xpr: ['not', CXL`not not not startswith(string,${'n'}) and not not not startswith(string,${'n'})`] }] }} ORDER BY string DESC`
       await cds.tx(async tx => {
         let res
         try {
@@ -536,14 +536,14 @@ describe('SELECT', () => {
 
     test('deep nested not before xpr with CASE statement', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', CXL`string = 'no' ? true : false`] }] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', CXL`string = 'no' ? true : false`] }] }} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
 
     test('deep nested multiple not before xpr with CASE statement', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', 'not', 'not', CXL`string = 'no' ? true : false`] }] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', 'not', 'not', CXL`string = 'no' ? true : false`] }] }} ORDER BY string DESC`
       await cds.tx(async tx => {
         let res
         try {
@@ -558,14 +558,14 @@ describe('SELECT', () => {
 
     test('deep nested not before CASE statement', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', ...(CXL`string = 'no' ? true : false`).xpr] }] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', ...(CXL`string = 'no' ? true : false`).xpr] }] }} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
 
     test('deep nested multiple not before CASE statement', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', 'not', 'not', ...(CXL`string = 'no' ? true : false`).xpr] }] }} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [{ xpr: ['not', 'not', 'not', ...(CXL`string = 'no' ? true : false`).xpr] }] }} ORDER BY string DESC`
       await cds.tx(async tx => {
         let res
         try {
@@ -580,21 +580,21 @@ describe('SELECT', () => {
 
     test('not before CASE statement', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: ['not', ...(CXL`string = 'no' ? true : false`).xpr]}} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: ['not', ...(CXL`string = 'no' ? true : false`).xpr]}} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
 
     test('and beetwen CASE statements', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: [...(CXL`string = 'no' ? true : false`).xpr, 'and', ...(CXL`string = 'no' ? true : false`).xpr]}} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: [...(CXL`string = 'no' ? true : false`).xpr, 'and', ...(CXL`string = 'no' ? true : false`).xpr]}} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'no')
     })
 
     test('and beetwen CASE statements with not', async () => {
       const { string } = cds.entities('basic.literals')
-      const query = CQL`SELECT * FROM ${string} WHERE ${{ xpr: ['not', ...(CXL`string = 'no' ? true : false`).xpr, 'and', 'not', ...(CXL`string = 'no' ? true : false`).xpr]}} ORDER BY string DESC`
+      const query = cds.ql`SELECT * FROM ${string} WHERE ${{ xpr: ['not', ...(CXL`string = 'no' ? true : false`).xpr, 'and', 'not', ...(CXL`string = 'no' ? true : false`).xpr]}} ORDER BY string DESC`
       const res = await cds.run(query)
       assert.strictEqual(res[0].string, 'yes')
     })
@@ -603,35 +603,35 @@ describe('SELECT', () => {
   describe('groupby', () => {
     test('single ref', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} GROUP BY string`
+      const cqn = cds.ql`SELECT string FROM ${string} GROUP BY string`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('multiple refs', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} GROUP BY string, char`
+      const cqn = cds.ql`SELECT string FROM ${string} GROUP BY string, char`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('static val', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} GROUP BY string,${1}`
+      const cqn = cds.ql`SELECT string FROM ${string} GROUP BY string,${1}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('func', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} GROUP BY string,now()`
+      const cqn = cds.ql`SELECT string FROM ${string} GROUP BY string,now()`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('func', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} GROUP BY string,now()`
+      const cqn = cds.ql`SELECT string FROM ${string} GROUP BY string,now()`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
@@ -652,7 +652,7 @@ describe('SELECT', () => {
   describe('having', () => {
     test('ignore empty array', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string}`
+      const cqn = cds.ql`SELECT string FROM ${string}`
       cqn.SELECT.having = []
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
@@ -660,13 +660,13 @@ describe('SELECT', () => {
 
     test('without groupby (not allowed)', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} HAVING string = ${'yes'}`
+      const cqn = cds.ql`SELECT string FROM ${string} HAVING string = ${'yes'}`
       await expect(cds.run(cqn)).rejected
     })
 
     test('with groupby', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} GROUP BY string HAVING string = ${'yes'}`
+      const cqn = cds.ql`SELECT string FROM ${string} GROUP BY string HAVING string = ${'yes'}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
     })
@@ -678,7 +678,7 @@ describe('SELECT', () => {
 
     test('ignore empty array', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string}`
+      const cqn = cds.ql`SELECT string FROM ${string}`
       cqn.SELECT.orderBy = []
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
@@ -686,7 +686,7 @@ describe('SELECT', () => {
 
     test('single ref', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       const sorted = [...res].sort((a, b) => _localeSort(a.string, b.string))
@@ -695,7 +695,7 @@ describe('SELECT', () => {
 
     test('single ref asc (explicit)', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string asc`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string asc`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       const sorted = [...res].sort((a, b) => _localeSort(a.string, b.string))
@@ -704,7 +704,7 @@ describe('SELECT', () => {
 
     test('single ref desc', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string desc`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string desc`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       const sorted = [...res].sort((a, b) => _localeSort(b.string, a.string))
@@ -725,7 +725,7 @@ describe('SELECT', () => {
 
     test('localized', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string`
       cqn.SELECT.localized = true
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
@@ -737,7 +737,7 @@ describe('SELECT', () => {
   describe('limit', () => {
     test('rows', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string LIMIT ${1}`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string LIMIT ${1}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
       assert.strictEqual(res[0].string, null, 'Ensure that the first row is coming back')
@@ -745,7 +745,7 @@ describe('SELECT', () => {
 
     test('offset', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string LIMIT ${1} OFFSET ${1}`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string LIMIT ${1} OFFSET ${1}`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
       assert.strictEqual(res[0].string, 'no', 'Ensure that the first row is coming back')
@@ -894,28 +894,28 @@ describe('SELECT', () => {
 
     test('single word', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT * FROM ${string}`
+      const cqn = cds.ql`SELECT * FROM ${string}`
       cqn.SELECT.search = [{ val: 'yes' }]
       await cds.run(cqn)
     })
 
     test('single quoted word', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT * FROM ${string}`
+      const cqn = cds.ql`SELECT * FROM ${string}`
       cqn.SELECT.search = [{ val: '"yes"' }]
       await cds.run(cqn)
     })
 
     test('multiple words', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT * FROM ${string}`
+      const cqn = cds.ql`SELECT * FROM ${string}`
       cqn.SELECT.search = [{ val: 'yes no' }]
       await cds.run(cqn)
     })
 
     test('multiple quoted words', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT * FROM ${string}`
+      const cqn = cds.ql`SELECT * FROM ${string}`
       cqn.SELECT.search = [{ val: '"yes" "no"' }]
       await cds.run(cqn)
     })
@@ -935,7 +935,7 @@ describe('SELECT', () => {
   describe('one', () => {
     test('simple', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string`
       cqn.SELECT.one = true
       const res = await cds.run(cqn)
       assert.strictEqual(!Array.isArray(res) && typeof res, 'object', 'Ensure that the result is an object')
@@ -944,7 +944,7 @@ describe('SELECT', () => {
 
     test('conflicting with limit clause', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string} ORDER BY string LIMIT 2 OFFSET 1`
+      const cqn = cds.ql`SELECT string FROM ${string} ORDER BY string LIMIT 2 OFFSET 1`
       cqn.SELECT.one = true
       const res = await cds.run(cqn)
       assert.strictEqual(!Array.isArray(res) && typeof res, 'object', 'Ensure that the result is an object')
@@ -955,7 +955,7 @@ describe('SELECT', () => {
   describe('distinct', () => {
     test('simple', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT string FROM ${string}`
+      const cqn = cds.ql`SELECT string FROM ${string}`
       cqn.SELECT.distinct = true
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
@@ -963,7 +963,7 @@ describe('SELECT', () => {
 
     test('static val', async () => {
       const { string } = cds.entities('basic.literals')
-      const cqn = CQL`SELECT ${'static'} FROM ${string}`
+      const cqn = cds.ql`SELECT ${'static'} FROM ${string}`
       cqn.SELECT.distinct = true
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')

--- a/test/compliance/functions.test.js
+++ b/test/compliance/functions.test.js
@@ -241,7 +241,7 @@ describe('functions', () => {
   })
   describe('COUNT', () => {
     test('simple count', async () => {
-      const cqn = CQL`SELECT count(1) as count FROM edge.hana.functions.timestamps`
+      const cqn = cds.ql`SELECT count(1) as count FROM edge.hana.functions.timestamps`
       const res = await cds.run(cqn)
       expect(res[0].count).to.be.eq(1000)
     })
@@ -363,7 +363,7 @@ describe('functions', () => {
   })
   describe('DAYS_BETWEEN', () => {
     test('sqlite vs HANA', async () => {
-      const cqn = CQL`SELECT a,b,days,DAYS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE days != DAYS_BETWEEN(a,b)`
+      const cqn = cds.ql`SELECT a,b,days,DAYS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE days != DAYS_BETWEEN(a,b)`
       const res = await cds.run(cqn)
 
       if (res.length) {
@@ -677,7 +677,7 @@ describe('functions', () => {
   })
   describe('MONTHS_BETWEEN', () => {
     test('sqlite vs HANA', async () => {
-      const cqn = CQL`SELECT a,b,months,MONTHS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE months != MONTHS_BETWEEN(a,b)`
+      const cqn = cds.ql`SELECT a,b,months,MONTHS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE months != MONTHS_BETWEEN(a,b)`
       const res = await cds.run(cqn)
       if (res.length) {
         throw new Error(
@@ -690,7 +690,7 @@ describe('functions', () => {
   })
   describe('NANO100_BETWEEN', () => {
     test('sqlite vs HANA', async () => {
-      const cqn = CQL`SELECT a,b,nano100,NANO100_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE nano100 != NANO100_BETWEEN(a,b)`
+      const cqn = cds.ql`SELECT a,b,nano100,NANO100_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE nano100 != NANO100_BETWEEN(a,b)`
       const res = await cds.run(cqn)
 
       const unacceptable = res.filter(r => {
@@ -882,7 +882,7 @@ describe('functions', () => {
   })
   describe('SECONDS_BETWEEN', () => {
     test('sqlite vs HANA', async () => {
-      const cqn = CQL`SELECT a,b,seconds,SECONDS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE seconds != SECONDS_BETWEEN(a,b)`
+      const cqn = cds.ql`SELECT a,b,seconds,SECONDS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE seconds != SECONDS_BETWEEN(a,b)`
       const res = await cds.run(cqn)
 
       const unacceptable = res.filter(r => {
@@ -1250,7 +1250,7 @@ describe('functions', () => {
   })
   describe('YEARS_BETWEEN', () => {
     test('sqlite vs HANA', async () => {
-      const cqn = CQL`SELECT a,b,years,YEARS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE years != YEARS_BETWEEN(a,b)`
+      const cqn = cds.ql`SELECT a,b,years,YEARS_BETWEEN(a,b) as sqlite FROM edge.hana.functions.timestamps WHERE years != YEARS_BETWEEN(a,b)`
       const res = await cds.run(cqn)
       if (res.length) {
         throw new Error(

--- a/test/compliance/keywords.test.js
+++ b/test/compliance/keywords.test.js
@@ -22,13 +22,13 @@ describe('keywords', () => {
       ],
     }
     await INSERT(data).into(Order)
-    const select = await cds.run(CQL`SELECT from Order { ID, alter { * } } where exists alter`)
+    const select = await cds.run(cds.ql`SELECT from Order { ID, alter { * } } where exists alter`)
     expect(select[0]).to.deep.eql(data)
 
     data.alter.forEach(e => (e.number = 99)) // change data
     await UPDATE.entity(Order).with(data).where('exists alter')
 
-    const selectAfterChange = await cds.run(CQL`SELECT from Order { ID, alter { * } } where exists alter`)
+    const selectAfterChange = await cds.run(cds.ql`SELECT from Order { ID, alter { * } } where exists alter`)
     expect(selectAfterChange[0]).to.deep.eql(data)
   })
 

--- a/test/scenarios/bookshop/delete.test.js
+++ b/test/scenarios/bookshop/delete.test.js
@@ -48,7 +48,7 @@ describe('Bookshop - Delete', () => {
 
   test('Delete with path expressions', async () => {
     const deleteEmilysBooks = DELETE.from('AdminService.RenameKeys').where(`author.name = 'Emily Brontë'`)
-    const selectEmilysBooks = CQL`SELECT * FROM AdminService.Books where author.name = 'Emily Brontë'`
+    const selectEmilysBooks = cds.ql`SELECT * FROM AdminService.Books where author.name = 'Emily Brontë'`
 
     const beforeDelete = await cds.run(selectEmilysBooks)
     await cds.run(deleteEmilysBooks)

--- a/test/scenarios/bookshop/funcs.test.js
+++ b/test/scenarios/bookshop/funcs.test.js
@@ -49,7 +49,7 @@ describe('Bookshop - Functions', () => {
 
     test('avg', async () => {
       const { Books } = cds.entities
-      const res = await cds.run(CQL`SELECT from ${Books} {
+      const res = await cds.run(cds.ql`SELECT from ${Books} {
         average(stock) as avgStock
       }`)
       expect(res[0].avgStock).to.not.be.undefined

--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -109,7 +109,7 @@ describe('Bookshop - Read', () => {
   })
 
   test('Path expression', async () => {
-    const q = CQL`SELECT title, author.name as author FROM sap.capire.bookshop.Books where author.name LIKE '%a%'`
+    const q = cds.ql`SELECT title, author.name as author FROM sap.capire.bookshop.Books where author.name LIKE '%a%'`
     const res = await cds.run(q)
     expect(res.length).to.be.eq(4)
     const columns = Object.keys(res[0])
@@ -118,7 +118,7 @@ describe('Bookshop - Read', () => {
   })
 
   test('Smart quotation', async () => {
-    const q = CQL`
+    const q = cds.ql`
       SELECT FROM sap.capire.bookshop.Books as ![FROM]
       {
         ![FROM].title as group,
@@ -158,7 +158,7 @@ describe('Bookshop - Read', () => {
     const { Authors } = cds.entities('sap.capire.bookshop')
     const res = await SELECT
       .columns`ID,sum(books_price) as price :Decimal`
-      .from(CQL`SELECT ID,books.price from ${Authors}`)
+      .from(cds.ql`SELECT ID,books.price from ${Authors}`)
       .groupBy`ID`
       .orderBy`price desc`
     expect(res.length).to.be.eq(4)
@@ -306,7 +306,7 @@ describe('Bookshop - Read', () => {
       expect(res2.status).to.be.eq(200)
       expect(res2.data.value[1].title).to.be.eq('dracula')
 
-      const q = CQL`SELECT title FROM sap.capire.bookshop.Books ORDER BY title`
+      const q = cds.ql`SELECT title FROM sap.capire.bookshop.Books ORDER BY title`
       const res3 = await cds.run(q)
       expect(res3[res3.length - 1].title).to.be.eq('dracula')
 

--- a/test/scenarios/bookshop/update.test.js
+++ b/test/scenarios/bookshop/update.test.js
@@ -138,7 +138,7 @@ describe('Bookshop - Update', () => {
     const updateRichardsBooks = UPDATE.entity(RenameKeys)
       .where(`author.name = 'Richard Carpenter'`)
       .set('ID = 42')
-    const selectRichardsBooks = CQL`SELECT * FROM ${RenameKeys} where author.name = 'Richard Carpenter'`
+    const selectRichardsBooks = cds.ql`SELECT * FROM ${RenameKeys} where author.name = 'Richard Carpenter'`
 
     await cds.run(updateRichardsBooks)
     const afterUpdate = await cds.db.run(selectRichardsBooks)
@@ -191,7 +191,7 @@ describe('Bookshop - Update', () => {
     const updateRichardsBooks = UPDATE.entity(MoreDraftEnabledBooks)
     .where(`author.name = 'Richard Carpenter'`)
     .set('ID = 42')
-    const selectRichardsBooks = CQL`SELECT * FROM ${MoreDraftEnabledBooks} where author.name = 'Richard Carpenter'`
+    const selectRichardsBooks = cds.ql`SELECT * FROM ${MoreDraftEnabledBooks} where author.name = 'Richard Carpenter'`
     
     await cds.run(updateRichardsBooks)
     const afterUpdate = await cds.db.run(selectRichardsBooks)


### PR DESCRIPTION
Used search & replace to resolve

```shell
> q = CQL`SELECT from ${Books}`
 
------------------------------------------------------------------------------ 
DEPRECATED: CQL 
 
   Global constant CQL is deprecated and will be removed in upcoming releases! 
   => Please use cds.parse.cql instead. 
 
    at REPL1:1:8
    at ContextifyScript.runInThisContext (node:vm:121:12)
    at REPLServer.defaultEval (node:repl:599:22)
    at bound (node:domain:432:15)
    at REPLServer.runBound [as eval] (node:domain:443:12)
    at REPLServer.onLine (node:repl:929:10)
    at REPLServer.emit (node:events:518:28)
    at REPLServer.emit (node:domain:488:12)
    at [_onLine] [as _onLine] (node:internal/readline/interface:416:12) 
```