### PR TITLE
fix(scoped queries): wrap filter in `xpr` if needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,9 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
-      - run: npm install -g @sap/cds-dk
+      # REMOVE ONCE hdi-deploy 5.4.2 is released
+      # see cap/issues#18158
+      - run: npm install -g @sap/cds-dk@8.8.2
       - run: npm run lint
       - id: hxe
         uses: ./.github/actions/hxe

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1766,7 +1766,7 @@ function cqn4sql(originalQuery, model) {
         filterConditions.forEach(f => {
           transformedWhere.push('and')
           if (filterConditions.length > 1) transformedWhere.push(asXpr(f))
-          else if (f.length > 3) transformedWhere.push(asXpr(f))
+          else if (f.length > 3 || f.includes('or') || f.includes('and')) transformedWhere.push(asXpr(f))
           else transformedWhere.push(...f)
         })
       } else {

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -202,7 +202,7 @@ describe('EXISTS predicate in where', () => {
         cds.ql`SELECT from bookshop.Authors:books[contains(title, 'Gravity') or contains(title, 'Dark')] { ID }`,
         model,
       )
-      let queryEquivalent = cqn4sql(
+      let otherWayOfWritingFilter = cqn4sql(
         cds.ql`SELECT from bookshop.Authors:books { ID } where contains(title, 'Gravity') or contains(title, 'Dark')`,
         model,
       )
@@ -214,7 +214,7 @@ describe('EXISTS predicate in where', () => {
            contains($b.title, 'Gravity') or contains($b.title, 'Dark')
         )
       `
-      expect(query).to.deep.equal(queryEquivalent).to.deep.equal(expected)
+      expect(query).to.deep.equal(otherWayOfWritingFilter).to.deep.equal(expected)
     })
     it('where exists to-one association with additional filter with xpr', () => {
       // note: now all source side elements are addressed with their table alias

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -187,6 +187,35 @@ describe('EXISTS predicate in where', () => {
           SELECT 1 from bookshop.Authors as $a where $a.ID = $B.author_ID and $a.name = 'Sanderson'
         )`)
     })
+    it('additional condition needs to be wrapped in brackets', () => {
+      let query = cqn4sql(
+        cds.ql`SELECT from bookshop.Authors { ID } where exists books[contains(title, 'Gravity') or contains(title, 'Dark')]`,
+        model,
+      )
+      const expected = cds.ql`SELECT from bookshop.Authors as $A { $A.ID } WHERE EXISTS (
+          SELECT 1 from bookshop.Books as $b where $b.author_ID = $A.ID and ( contains($b.title, 'Gravity') or contains($b.title, 'Dark') )
+        )`
+      expect(query).to.deep.equal(expected)
+    })
+    it('additional condition needs to be wrapped in brackets (scoped)', () => {
+      let query = cqn4sql(
+        cds.ql`SELECT from bookshop.Authors:books[contains(title, 'Gravity') or contains(title, 'Dark')] { ID }`,
+        model,
+      )
+      let queryEquivalent = cqn4sql(
+        cds.ql`SELECT from bookshop.Authors:books { ID } where contains(title, 'Gravity') or contains(title, 'Dark')`,
+        model,
+      )
+      const expected = cds.ql`
+      SELECT from bookshop.Books as $b { $b.ID }
+        where exists (
+          SELECT 1 from bookshop.Authors as $A where $A.ID = $b.author_ID
+        ) and (
+           contains($b.title, 'Gravity') or contains($b.title, 'Dark')
+        )
+      `
+      expect(query).to.deep.equal(queryEquivalent).to.deep.equal(expected)
+    })
     it('where exists to-one association with additional filter with xpr', () => {
       // note: now all source side elements are addressed with their table alias
       let query = cqn4sql(cds.ql`SELECT from bookshop.Books { ID } where exists author[not (name = 'Sanderson')]`, model)


### PR DESCRIPTION
if `from.ref.at(-1).where` contains any logical operator such as
 `and` or `or`, we must wrap the filter condition in an `xpr` so that
it is quoted in `toSQL` to avoid operator precedence issues.

fix cap/issue#18155