### PR TITLE
chore: Revert "chore: release main (#1106)"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "db-service": "1.19.1",
+  "db-service": "1.19.0",
   "sqlite": "1.10.0",
   "postgres": "1.13.0",
   "hana": "1.8.0"

--- a/db-service/CHANGELOG.md
+++ b/db-service/CHANGELOG.md
@@ -4,13 +4,6 @@
 - The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.19.1](https://github.com/cap-js/cds-dbs/compare/db-service-v1.19.0...db-service-v1.19.1) (2025-04-01)
-
-
-### Fixed
-
-* **scoped queries:** wrap filter in `xpr` if needed ([#1105](https://github.com/cap-js/cds-dbs/issues/1105)) ([8f44df3](https://github.com/cap-js/cds-dbs/commit/8f44df37db7bc283933023dab92b348cf92e12bf))
-
 ## [1.19.0](https://github.com/cap-js/cds-dbs/compare/db-service-v1.18.0...db-service-v1.19.0) (2025-03-31)
 
 

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/db-service",
-  "version": "1.19.1",
+  "version": "1.19.0",
   "description": "CDS base database service",
   "homepage": "https://github.com/cap-js/cds-dbs/tree/main/db-service#cds-base-database-service",
   "repository": {


### PR DESCRIPTION
This reverts commit 810781dfd93cd0d76a0ccb0055b020b41fe352b0.

due to messed up cds-dk dependencies, the release did not make it to npm