### PR TITLE
chore: don't error on recurse queries

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -258,8 +258,9 @@ class CQN2SQLRenderer {
     return (this.sql = sql)
   }
 
-  SELECT_recurse() {
+  SELECT_recurse(q) {
     // cds.error`Feature "recurse" queries not supported.`
+    return this.from(q.SELECT.from, q)
   }
 
   /**

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -226,10 +226,8 @@ class CQN2SQLRenderer {
    * @param {import('./infer/cqn').SELECT} q
    */
   SELECT(q) {
-    let { from, expand, where, groupBy, having, orderBy, limit, one, distinct, localized, forUpdate, forShareLock, recurse } =
+    let { from, expand, where, groupBy, having, orderBy, limit, one, distinct, localized, forUpdate, forShareLock } =
       q.SELECT
-
-    if (recurse && !this._supports_recurse) recurse = undefined // expects the rest to work
 
     if (from?.join && !q.SELECT.columns) {
       throw new Error('CQN query using joins must specify the selected columns.')
@@ -241,13 +239,11 @@ class CQN2SQLRenderer {
     let sql = `SELECT`
     if (distinct) sql += ` DISTINCT`
     if (!_empty(columns)) sql += ` ${columns}`
-    if (recurse) sql += ` FROM ${this.SELECT_recurse(q)}`
-    else if (!_empty(from)) sql += ` FROM ${this.from(from, q)}`
-    else sql += this.from_dummy()
-    if (!recurse && !_empty(where)) sql += ` WHERE ${this.where(where)}`
-    if (!recurse && !_empty(groupBy)) sql += ` GROUP BY ${this.groupBy(groupBy)}`
-    if (!recurse && !_empty(having)) sql += ` HAVING ${this.having(having)}`
-    if (!recurse && !_empty(orderBy)) sql += ` ORDER BY ${this.orderBy(orderBy, localized)}`
+    if (!_empty(from)) sql += ` FROM ${this.from(from, q)}`; else sql += this.from_dummy()
+    if (!_empty(where)) sql += ` WHERE ${this.where(where)}`
+    if (!_empty(groupBy)) sql += ` GROUP BY ${this.groupBy(groupBy)}`
+    if (!_empty(having)) sql += ` HAVING ${this.having(having)}`
+    if (!_empty(orderBy)) sql += ` ORDER BY ${this.orderBy(orderBy, localized)}`
     if (one) limit = Object.assign({}, limit, { rows: { val: 1 } })
     if (limit) sql += ` LIMIT ${this.limit(limit)}`
     if (forUpdate) sql += ` ${this.forUpdate(forUpdate)}`
@@ -258,11 +254,6 @@ class CQN2SQLRenderer {
       else cds.error`Query was not inferred and includes expand. For which the metadata is missing.`
     }
     return (this.sql = sql)
-  }
-
-  get _supports_recurse() { return false }
-  SELECT_recurse() {
-    cds.error`Feature "recurse" queries not supported.`
   }
 
   /**

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -229,6 +229,8 @@ class CQN2SQLRenderer {
     let { from, expand, where, groupBy, having, orderBy, limit, one, distinct, localized, forUpdate, forShareLock, recurse } =
       q.SELECT
 
+    if (recurse && !this._supports_recurse) recurse = undefined // expects the rest to work
+
     if (from?.join && !q.SELECT.columns) {
       throw new Error('CQN query using joins must specify the selected columns.')
     }
@@ -258,9 +260,9 @@ class CQN2SQLRenderer {
     return (this.sql = sql)
   }
 
-  SELECT_recurse(q) {
-    // cds.error`Feature "recurse" queries not supported.`
-    return this.from(q.SELECT.from, q)
+  get _supports_recurse() { return false }
+  SELECT_recurse() {
+    cds.error`Feature "recurse" queries not supported.`
   }
 
   /**

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -259,7 +259,7 @@ class CQN2SQLRenderer {
   }
 
   SELECT_recurse() {
-    cds.error`Feature "recurse" queries not supported.`
+    // cds.error`Feature "recurse" queries not supported.`
   }
 
   /**


### PR DESCRIPTION
But simply run the supported parts of the query. 
Currently I created mock behaviour by doing this before sending the query to `cds.db` and all looks fine:  
```js
// Avoid error message: Feature "recurse" queries not supported.
delete SELECT.recurse 
delete SELECT.__proto__.recurse
```

Simply ignoring it / not knowing about it at all seems to be just fine