### PR TITLE
fix(forUpdate): ignoreLocked has precedence over wait

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -458,7 +458,7 @@ class CQN2SQLRenderer {
     let sql = 'FOR UPDATE'
     if (!_empty(of)) sql += ` OF ${of.map(x => this.expr(x)).join(', ')}`
     if (ignoreLocked) sql += ' IGNORE LOCKED'
-    if (typeof wait === 'number') sql += ` WAIT ${wait}`
+    else if (typeof wait === 'number') sql += ` WAIT ${wait}`// IGNORE LOCKED wins
     return sql
   }
 

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -468,8 +468,8 @@ GROUP BY k
     forUpdate(update) {
       const { wait, ignoreLocked } = update
       let sql = 'FOR UPDATE'
-      if (wait === 0) sql += ' NOWAIT'
       if (ignoreLocked) sql += ' SKIP LOCKED'
+      else if (wait === 0) sql += ' NOWAIT' // SKIP LOCKED wins
       return sql
     }
 

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -901,6 +901,20 @@ describe('SELECT', () => {
     )
   })
 
+  describe('forUpdate ignore locked with ignored wait', () => {
+    const boolLock = SELECT.from('basic.projection.globals')
+      .forShareLock({
+        of: ['bool'],
+        ignoreLocked: true,
+        wait: 0, // ignored, happens if global defaults are set
+      })
+
+    generalLockTest(bool => boolLock.clone()
+      .where([{ ref: ['bool'] }, '=', { val: bool }]),
+      { ignoreLocked: true }
+    )
+  })
+
   describe('search', () => {
     // Make sure that the queries work, but never check their behavior as it is undefined
 

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -890,7 +890,7 @@ describe('SELECT', () => {
 
   describe('forUpdate ignore locked', () => {
     const boolLock = SELECT.from('basic.projection.globals')
-      .forShareLock({
+      .forUpdate({
         of: ['bool'],
         ignoreLocked: true
       })
@@ -903,7 +903,7 @@ describe('SELECT', () => {
 
   describe('forUpdate ignore locked with ignored wait', () => {
     const boolLock = SELECT.from('basic.projection.globals')
-      .forShareLock({
+      .forUpdate({
         of: ['bool'],
         ignoreLocked: true,
         wait: 0, // ignored, happens if global defaults are set


### PR DESCRIPTION
Senseless to send such queries, but it can happen when global `sql.lock_acquire_timeout` is set.