### PR TITLE
chore(cds9): use `_target` once; no need to drill down

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -801,9 +801,8 @@ function cqn4sql(originalQuery, model) {
         })
     } else {
       outerAlias = transformedQuery.SELECT.from.as
-      const getInnermostTarget = q => q._target ? getInnermostTarget(q._target) : q
       subqueryFromRef = [
-        ...(transformedQuery.SELECT.from.ref || /* subq in from */ [getInnermostTarget(transformedQuery).name]),
+        ...(transformedQuery.SELECT.from.ref || /* subq in from */ [transformedQuery._target.name]),
         ...ref,
       ]
     }


### PR DESCRIPTION
`q._target` will resolve recursively to the innermost entity, with our streamlined `cds.infer` --> no need to do this manually anymore


this is a follow up of #1126

@danjoa fyi