### PR TITLE
Prevent `Statement is dropped` Error

### DIFF
--- a/hana/lib/drivers/hana-client.js
+++ b/hana/lib/drivers/hana-client.js
@@ -69,7 +69,10 @@ class HANAClientDriver extends driver {
         const stmt = await ret._prep
         // Create result set
         const reset = async function () {
-          if (this) await prom(this, 'close')()
+          if (this) {
+            await prom(this, 'close')()
+            return
+          }
           const rs = await prom(stmt, 'executeQuery')(values)
           rs.reset = reset
           return rs


### PR DESCRIPTION
I can not clearly tell how to reproduce the `Statement is dropped` error, but I receive it sometimes. Maybe it depends on execution times.
For my understanding after the result is read, the result rest should be closed and the result should be returned (https://github.com/cap-js/cds-dbs/blob/main/hana/lib/drivers/hana-client.js#L115). After the result is returned the prepared statement will be dropped. But as there is an additional `executeQuery` call after the `close` it might happen that the statement is already dropped. I am not to deep in the details of the implementation, but I wonder if there is a scenario where this is needed.