### PR TITLE
fix?: allow for outer query column references without alias

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -494,6 +494,15 @@ function infer(originalQuery, model) {
             definition: getDefinitionFromSources(sources, id),
             target: getDefinitionFromSources(sources, id),
           })
+        } else if (ref.length === 1 && inferred.outerQueries?.find(outer => id in outer.$combinedElements)) {
+          // outer query accessed without alias
+          const outerAlias = inferred.outerQueries?.find(outer => id in outer.$combinedElements)
+
+          if (outerAlias.$combinedElements[id].length > 1) stepIsAmbiguous(id) // exit
+          const definition = outerAlias.$combinedElements[id][0].tableAlias.elements[id]
+          const $refLink = { definition, target: outerAlias.$combinedElements[id][0].tableAlias }
+          arg.$refLinks.push($refLink)
+          nameSegments.push(id)
         } else {
           stepNotFoundInCombinedElements(id) // REVISIT: fails with {__proto__:elements)
         }

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -494,7 +494,7 @@ function infer(originalQuery, model) {
             definition: getDefinitionFromSources(sources, id),
             target: getDefinitionFromSources(sources, id),
           })
-        } else if (ref.length === 1 && inferred.outerQueries?.find(outer => id in outer.$combinedElements)) {
+        } else if (/* arg.ref.length === 1 && */ inferred.outerQueries?.find(outer => id in outer.$combinedElements)) {
           // outer query accessed without alias
           const outerAlias = inferred.outerQueries?.find(outer => id in outer.$combinedElements)
 


### PR DESCRIPTION
For some use cases it is not possible to apply and `alias` to the outer query, but it is required to reference columns from the root query inside the disjointed sub select definition.

```cds
using { sap.capire.bookshop as my } from '../db/schema';

@protocol: { odata: '/admin', rest }
service AdminService {
  @restrict: [
    {
      grant: ['UPDATE'],
      where: `exists(
        select 1 from AdminService.Authors as authors
        where authors.ID = author.ID -- author.ID = Books.author.ID
        and authors.name = $user
      )`
    },
    {
      grant: ['DELETE'],
      where: `author.ID = $user` // potential work around
    }
  ]
  entity Books as projection on my.Books;
  entity Authors as projection on my.Authors;
}
```