### PR TITLE
chore: put defaults not provided only with `cds.runtime.put_as_replace = true`

### DIFF
--- a/sqlite/test/general/managed.test.js
+++ b/sqlite/test/general/managed.test.js
@@ -1,3 +1,5 @@
+process.env.cds_runtime_put__as__replace = 'true'
+
 const cds = require('../../../test/cds.js')
 
 describe('Managed thingies', () => {


### PR DESCRIPTION
prepares for `cds.runtime.put_as_replace` (regardless of what the default will be)