### PR TITLE
fix: exists within expression is properly detected

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -406,7 +406,10 @@ function infer(originalQuery, model) {
     if (arg.param || arg.SELECT) return // parameter references are only resolved into values on execution e.g. :val, :1 or ?
     if (arg.args) applyToFunctionArgs(arg.args, inferArg, [null, $baseLink, context])
     if (arg.list) arg.list.forEach(arg => inferArg(arg, null, $baseLink, context))
-    if (arg.xpr) arg.xpr.forEach(token => inferArg(token, queryElements, $baseLink, { ...context, inXpr: true })) // e.g. function in expression
+    if (arg.xpr)
+      arg.xpr.forEach((token, i) =>
+        inferArg(token, queryElements, $baseLink, { ...context, inXpr: true, inExists: arg.xpr[i - 1] === 'exists' }),
+      ) // e.g. function in expression
 
     if (!arg.ref) {
       if (arg.expand && queryElements) queryElements[arg.as] = resolveExpand(arg)


### PR DESCRIPTION
in a column expression, an `exists` predicate was not always properly detected, the absence of this information lead to a an error because of subsequent "dangling" filter conditions, which are usually not allowed with the exception of being used in combination with the `exists` predicate.