### PR TITLE
fix: current_utctimestamp as default

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -1400,7 +1400,7 @@ class CQN2SQLRenderer {
 
       let onInsert = this.managed_session_context(element[cdsOnInsert]?.['='])
         || this.managed_session_context(element.default?.ref?.[0])
-        || (element.default?.val !== undefined && { val: element.default.val, param: false })
+        || element.default
       let onUpdate = this.managed_session_context(element[cdsOnUpdate]?.['='])
 
       if (onInsert) onInsert = this.expr(onInsert)

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -1400,7 +1400,7 @@ class CQN2SQLRenderer {
 
       let onInsert = this.managed_session_context(element[cdsOnInsert]?.['='])
         || this.managed_session_context(element.default?.ref?.[0])
-        || element.default
+        || (element.default && { __proto__:  element.default, param: false })
       let onUpdate = this.managed_session_context(element[cdsOnUpdate]?.['='])
 
       if (onInsert) onInsert = this.expr(onInsert)

--- a/test/compliance/resources/db/basic/common.cds
+++ b/test/compliance/resources/db/basic/common.cds
@@ -30,9 +30,12 @@ entity ![default] : _cuid {
   // default value cannot be created on column of data type NCLOB: BLOB
   // blob        : LargeString default 'default';
   date      : Date default '1970-01-01';
+  date_lit  : Date default date'2021-05-05';
   time      : Time default '01:02:03';
   dateTime  : DateTime default '1970-01-01T01:02:03Z';
   timestamp : Timestamp default '1970-01-01T01:02:03.123456789Z';
+  // HANA Does not support default functions in general
+  func      : Date default current_utctimestamp();
 // Binary default values don't make sense. while technically possible
 // binary      : Binary default 'YmluYXJ5'; // base64 encoded 'binary';
 // largebinary : LargeBinary default 'YmluYXJ5'; // base64 encoded 'binary';

--- a/test/compliance/resources/db/basic/common.cds
+++ b/test/compliance/resources/db/basic/common.cds
@@ -34,13 +34,13 @@ entity ![default] : _cuid {
   time      : Time default '01:02:03';
   dateTime  : DateTime default '1970-01-01T01:02:03Z';
   timestamp : Timestamp default '1970-01-01T01:02:03.123456789Z';
-  // HANA Does not support default functions in general
-  func      : Date default current_utctimestamp();
-// Binary default values don't make sense. while technically possible
-// binary      : Binary default 'YmluYXJ5'; // base64 encoded 'binary';
-// largebinary : LargeBinary default 'YmluYXJ5'; // base64 encoded 'binary';
-// Vector default values probably also don't make sense
-// vector : Vector default '[1.0,0.5,0.0,...]';
+  // Comment out, when HANA supports default functions or compiler generates them not as defaults 
+  // func      : String(100) default tolower('DEfAUlT');
+  // Binary default values don't make sense. while technically possible
+  // binary      : Binary default 'YmluYXJ5'; // base64 encoded 'binary';
+  // largebinary : LargeBinary default 'YmluYXJ5'; // base64 encoded 'binary';
+  // Vector default values probably also don't make sense
+  // vector : Vector default '[1.0,0.5,0.0,...]';
 }
 
 entity keys {

--- a/test/compliance/resources/db/basic/common/basic.common.default.js
+++ b/test/compliance/resources/db/basic/common/basic.common.default.js
@@ -1,4 +1,5 @@
 const dstring = size => ({ d: 'default'.slice(0, size), o: 'not default'.slice(0, size) })
+const currentDate = () => ({ d: new Date().toJSON().slice(0, 10), o: '2000-01-01' }) 
 
 const columns = {
   uuidDflt: { d: '00000000-0000-0000-4000-000000000000', o: '11111111-1111-1111-4111-111111111111'},
@@ -17,9 +18,11 @@ const columns = {
   large: dstring(5000),
   // blob: dstring(5001),
   date: { d: '1970-01-01', o: '2000-01-01' },
+  date_lit: { d: '2021-05-05', o: '2011-08-01' },   
   time: { d: '01:02:03', o: '21:02:03' },
   dateTime: { d: '1970-01-01T01:02:03Z', o: '2000-01-01T21:02:03Z' },
   timestamp: { d: '1970-01-01T01:02:03.123Z', o: '2000-01-01T21:02:03.123Z' },
+  func: currentDate(),
   // Binary default values don't make sense. while technically possible
   // binary: { d: Buffer.from('binary'), o: Buffer.from('...') },
   // largebinary: { d: Buffer.from('binary'), o: Buffer.from('...') },

--- a/test/compliance/resources/db/basic/common/basic.common.default.js
+++ b/test/compliance/resources/db/basic/common/basic.common.default.js
@@ -1,5 +1,8 @@
 const dstring = size => ({ d: 'default'.slice(0, size), o: 'not default'.slice(0, size) })
-const currentDate = () => ({ d: new Date().toJSON().slice(0, 10), o: '2000-01-01' }) 
+const currentDate = date => {
+  const date_utc = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  return { d: new Date(date_utc).toJSON().slice(0, 10), o: '2000-01-01' } 
+}
 
 const columns = {
   uuidDflt: { d: '00000000-0000-0000-4000-000000000000', o: '11111111-1111-1111-4111-111111111111'},
@@ -22,7 +25,7 @@ const columns = {
   time: { d: '01:02:03', o: '21:02:03' },
   dateTime: { d: '1970-01-01T01:02:03Z', o: '2000-01-01T21:02:03Z' },
   timestamp: { d: '1970-01-01T01:02:03.123Z', o: '2000-01-01T21:02:03.123Z' },
-  func: currentDate(),
+  func: currentDate(new Date()),
   // Binary default values don't make sense. while technically possible
   // binary: { d: Buffer.from('binary'), o: Buffer.from('...') },
   // largebinary: { d: Buffer.from('binary'), o: Buffer.from('...') },

--- a/test/compliance/resources/db/basic/common/basic.common.default.js
+++ b/test/compliance/resources/db/basic/common/basic.common.default.js
@@ -1,8 +1,4 @@
 const dstring = size => ({ d: 'default'.slice(0, size), o: 'not default'.slice(0, size) })
-const currentDate = date => {
-  const date_utc = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
-  return { d: new Date(date_utc).toJSON().slice(0, 10), o: '2000-01-01' } 
-}
 
 const columns = {
   uuidDflt: { d: '00000000-0000-0000-4000-000000000000', o: '11111111-1111-1111-4111-111111111111'},
@@ -25,7 +21,7 @@ const columns = {
   time: { d: '01:02:03', o: '21:02:03' },
   dateTime: { d: '1970-01-01T01:02:03Z', o: '2000-01-01T21:02:03Z' },
   timestamp: { d: '1970-01-01T01:02:03.123Z', o: '2000-01-01T21:02:03.123Z' },
-  func: currentDate(new Date()),
+  // func: { d: 'default', o: 'DefaULT' },
   // Binary default values don't make sense. while technically possible
   // binary: { d: Buffer.from('binary'), o: Buffer.from('...') },
   // largebinary: { d: Buffer.from('binary'), o: Buffer.from('...') },


### PR DESCRIPTION
- HANA doesn't allow functions as default values. 
- `current_utctimestamp()` looks like an exception
- asked by stakeholder