### PR TITLE
fix(dbs): Filter streams to only process ParameterStream (#1168)

### DIFF
--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -240,7 +240,7 @@ GROUP BY k
           text: 'CREATE TEMP TABLE IF NOT EXISTS "$$PARAMETER_BUFFER$$" (PARAM TEXT, NAME TEXT, ID INT) ON COMMIT DROP',
         })
         const proms = []
-        for (const stream of streams) {
+        for (const stream of streams.filter(s => s && s.constructor.name === 'ParameterStream')) {
           proms.push(this.dbc.query(stream))
         }
         await Promise.all(proms)


### PR DESCRIPTION
Ensures that the database query execution loop in the DBS layer only attempts to process objects that are instances of ParameterStream. This prevents unexpected errors when the streams array contains null/undefined values or other non-stream objects, as reported in issue #1168.

Closes #1168