### PR TITLE
fix: resilience for query re-use scenarios

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -4,7 +4,7 @@ const cds = require('@sap/cds')
 
 const JoinTree = require('./join-tree')
 const { pseudos } = require('./pseudos')
-const { isCalculatedOnRead, getImplicitAlias, getModelUtils } = require('../utils')
+const { isCalculatedOnRead, getImplicitAlias, getModelUtils, defineProperty } = require('../utils')
 const cdsTypes = cds.linked({
   definitions: {
     Timestamp: { type: 'cds.Timestamp' },
@@ -75,7 +75,7 @@ function infer(originalQuery, model) {
       joinTree: { value: joinTree, writable: true, configurable: true }, // REVISIT: eliminate
     })
     // also enrich original query -> writable because it may be inferred again
-    Object.defineProperty(originalQuery, 'elements', { value: elements, writable: true, configurable: true })
+    defineProperty(originalQuery, 'elements', elements)
   }
   return inferred
 
@@ -171,10 +171,7 @@ function infer(originalQuery, model) {
    * @param {csn.Element} element
    */
   function setElementOnColumns(col, element) {
-    Object.defineProperty(col, 'element', {
-      value: element,
-      writable: true,
-    })
+    defineProperty(col, 'element', element)
   }
 
   /**
@@ -245,7 +242,7 @@ function infer(originalQuery, model) {
       // link $refLinks -> special name resolution rules for orderBy
       orderBy.forEach(token => {
         let $baseLink
-        let rejectJoinRelevantPath
+        let needsElementsOfQueryAsBase
         // first check if token ref is resolvable in query elements
         if (columns) {
           const firstStep = token.ref?.[0].id || token.ref?.[0]
@@ -253,14 +250,11 @@ function infer(originalQuery, model) {
             const columnName = c.as || c.flatName || c.ref?.at(-1).id || c.ref?.at(-1) || c.func
             return columnName === firstStep
           })
-          const needsElementsOfQueryAsBase =
+          needsElementsOfQueryAsBase =
             tokenPointsToQueryElements &&
-            queryElements[token.ref?.[0]] &&
-            /* expand on structure can be addressed */ !queryElements[token.ref?.[0]].$assocExpand
+            queryElements[firstStep] &&
+            /* expand on structure can be addressed */ !queryElements[firstStep].$assocExpand
 
-          // if the ref points into the query itself and follows an exposed association
-          // to a non-fk column, we must reject the ref, as we can't join with the queries own results
-          rejectJoinRelevantPath = needsElementsOfQueryAsBase
           if (needsElementsOfQueryAsBase) $baseLink = { definition: { elements: queryElements }, target: inferred }
         } else {
           // fallback to elements of query source
@@ -268,7 +262,9 @@ function infer(originalQuery, model) {
         }
 
         inferArg(token, queryElements, $baseLink, { inQueryModifier: true })
-        if (token.isJoinRelevant && rejectJoinRelevantPath) {
+        // if the ref points into the query itself and follows an exposed association
+        // to a non-fk column, we must reject the ref, as we can't join with the queries own results
+        if (token.isJoinRelevant && needsElementsOfQueryAsBase) {
           // reverse the array, find the last association and calculate the index of the association in non-reversed order
           const assocIndex =
             token.$refLinks.length - 1 - token.$refLinks.reverse().findIndex(link => link.definition.isAssociation)
@@ -416,11 +412,12 @@ function infer(originalQuery, model) {
       return
     }
 
-    // initialize $refLinks
-    Object.defineProperty(arg, '$refLinks', {
-      value: [],
-      writable: true,
-    })
+    // Before the arg is linked, it's meta information should be cleaned up.
+    // This may be important if one manipulates the arg object
+    // __after__ a query has been fired and re-uses the manipulated query
+    defineProperty(arg, '$refLinks', [])
+    defineProperty(arg, 'isJoinRelevant', false)
+
     // if any path step points to an artifact with `@cds.persistence.skip`
     // we must ignore the element from the queries elements
     let isPersisted = true
@@ -431,7 +428,7 @@ function infer(originalQuery, model) {
       expandOnTableAlias = arg.ref.length === 1 && arg.ref[0] in sources && (arg.expand || arg.inline)
     }
     if (dollarSelfRefs && firstStepIsSelf) {
-      Object.defineProperty(arg, 'inXpr', { value: true, writable: true })
+      defineProperty(arg, 'inXpr', true)
       dollarSelfRefs.push(arg)
       return
     }
@@ -458,7 +455,7 @@ function infer(originalQuery, model) {
               const nextStep = arg.ref[1]?.id || arg.ref[1]
               if (isNonForeignKeyNavigation(element, nextStep)) {
                 if (inExists) {
-                  Object.defineProperty($baseLink, 'pathExpressionInsideFilter', { value: true })
+                  defineProperty($baseLink, 'pathExpressionInsideFilter', true)
                 } else {
                   rejectNonFkNavigation(element, element.on ? $baseLink.definition.name : nextStep)
                 }
@@ -522,7 +519,7 @@ function infer(originalQuery, model) {
             const nextStep = arg.ref[i + 1]?.id || arg.ref[i + 1]
             if (isNonForeignKeyNavigation(element, nextStep)) {
               if (inExists) {
-                Object.defineProperty($baseLink, 'pathExpressionInsideFilter', { value: true })
+                defineProperty($baseLink, 'pathExpressionInsideFilter', true)
               } else {
                 rejectNonFkNavigation(element, element.on ? $baseLink.definition.name : nextStep)
               }
@@ -538,7 +535,7 @@ function infer(originalQuery, model) {
         } else if (id === '$dummy') {
           // `some.known.element.$dummy` -> no error; used by cds.ql to simulate joins
           arg.$refLinks.push({ definition: { name: '$dummy', parent: arg.$refLinks[i - 1].target } })
-          Object.defineProperty(arg, 'isJoinRelevant', { value: true })
+          defineProperty(arg, 'isJoinRelevant', true)
         } else {
           const notFoundIn = pseudoPath ? arg.ref[i - 1] : getFullPathForLinkedArg(arg)
           stepNotFoundInPredecessor(id, notFoundIn)
@@ -564,7 +561,7 @@ function infer(originalQuery, model) {
         const definition = arg.$refLinks[i].definition
         if ((!definition.target && definition.kind !== 'entity') || (!inFrom && danglingFilter))
           throw new Error('A filter can only be provided when navigating along associations')
-        if (!inFrom && !arg.expand) Object.defineProperty(arg, 'isJoinRelevant', { value: true })
+        if (!inFrom && !arg.expand)defineProperty(arg, 'isJoinRelevant', true)
         let skipJoinsForFilter = false
         step.where.forEach(token => {
           if (token === 'exists') {
@@ -593,7 +590,7 @@ function infer(originalQuery, model) {
       if (getDefinition(arg.$refLinks[i].definition.target)?.['@cds.persistence.skip'] === true) isPersisted = false
       if (!arg.ref[i + 1]) {
         const flatName = nameSegments.join('_')
-        Object.defineProperty(arg, 'flatName', { value: flatName, writable: true })
+        defineProperty(arg, 'flatName', flatName)
         // if column is casted, we overwrite it's origin with the new type
         if (arg.cast) {
           const base = getElementForCast(arg)
@@ -638,7 +635,7 @@ function infer(originalQuery, model) {
     })
 
     // we need inner joins for the path expressions inside filter expressions after exists predicate
-    if ($baseLink?.pathExpressionInsideFilter) Object.defineProperty(arg, 'join', { value: 'inner' })
+    if ($baseLink?.pathExpressionInsideFilter) defineProperty(arg, 'join', 'inner')
 
     // ignore whole expand if target of assoc along path has ”@cds.persistence.skip”
     if (arg.expand) {
@@ -658,7 +655,7 @@ function infer(originalQuery, model) {
         ? { ref: [...baseColumn.ref, ...arg.ref], $refLinks: [...baseColumn.$refLinks, ...arg.$refLinks] }
         : arg
       if (isColumnJoinRelevant(colWithBase)) {
-        Object.defineProperty(arg, 'isJoinRelevant', { value: true })
+        defineProperty(arg, 'isJoinRelevant', true)
         joinTree.mergeColumn(colWithBase, originalQuery.outerQueries)
       }
     }
@@ -764,7 +761,7 @@ function infer(originalQuery, model) {
         const res = $leafLink.definition.is2one
           ? new cds.struct({ elements: inferredExpandSubquery.elements })
           : new cds.array({ items: new cds.struct({ elements: inferredExpandSubquery.elements }) })
-        return Object.defineProperty(res, '$assocExpand', { value: true })
+        return defineProperty(res, '$assocExpand', true)
       } else if ($leafLink.definition.elements) {
         let elements = {}
         expand.forEach(e => {
@@ -903,13 +900,13 @@ function infer(originalQuery, model) {
         const calcElementIsJoinRelevant = isColumnJoinRelevant(p)
         if (calcElementIsJoinRelevant) {
           if (!calcElement.value.isJoinRelevant)
-            Object.defineProperty(step, 'isJoinRelevant', { value: true, writable: true })
+            defineProperty(step, 'isJoinRelevant',true)
           joinTree.mergeColumn(p, originalQuery.outerQueries)
         } else {
           // we need to explicitly set the value to false in this case,
           // e.g. `SELECT from booksCalc.Books { ID, author.{name }, author {name } }`
           // --> for the inline column, the name is join relevant, while for the expand, it is not
-          Object.defineProperty(step, 'isJoinRelevant', { value: false, writable: true })
+          defineProperty(step, 'isJoinRelevant', false)
         }
       }
     }
@@ -1067,7 +1064,6 @@ function infer(originalQuery, model) {
    * @returns {object} a copy of @param base with all annotations of @param from
    * @TODO prototype based
    */
-  // REVISIT: TODO: inferred.elements should be linked
   function getCopyWithAnnos(from, base) {
     const result = { ...base }
     // REVISIT: we don't need to and hence should not handle annotations at runtime
@@ -1075,7 +1071,7 @@ function infer(originalQuery, model) {
       if (prop.startsWith('@')) result[prop] = from[prop]
     }
 
-    if (from.as && base.name !== from.as) Object.defineProperty(result, 'name', { value: from.as }) // TODO double check if this is needed
+    if (from.as && base.name !== from.as) defineProperty(result, 'name', from.as) // TODO double check if this is needed
     // in subqueries we need the linked element if an outer query accesses it
     return Object.setPrototypeOf(result, base)
   }

--- a/db-service/lib/utils.js
+++ b/db-service/lib/utils.js
@@ -62,6 +62,14 @@ function getImplicitAlias(str, useTechnicalAlias = true) {
   return index != -1 ? str.substring(index + 1) : str
 }
 
+function defineProperty(obj, prop, value) {
+  return Object.defineProperty(obj, prop, {
+    value,
+    writable: true,
+    configurable: true,
+  })
+}
+
 /**
  * Shared utility functions which operate dynamically on the model / query.
  *
@@ -129,5 +137,6 @@ module.exports = {
   isCalculatedOnRead,
   isCalculatedElement,
   getImplicitAlias,
+  defineProperty,
   getModelUtils,
 }

--- a/db-service/test/cds-infer/api.test.js
+++ b/db-service/test/cds-infer/api.test.js
@@ -61,6 +61,28 @@ describe('infer elements', () => {
     expect(inferred).to.eql(inferredInferred)
   })
 
+  it('infer inferred query multiple times, even after manipulation', () => {
+    const flatModel = cds.compile.for.nodejs(model)
+    // the order by path is join relevant
+    let query = cds.ql`SELECT from bookshop.Genres { ID, parent_ID } order by parent.name`
+    let inferred = _inferred(query, flatModel)
+    /*
+    now the order by path is not join relevant anymore
+    if the orderBy's $refLinks are not properly re-constructed
+    the reference looks like it induces a join while navigating along an exposed association
+    which is generally not possible:
+
+    entity V as select from Books {
+      ID,
+      author
+    } order by author.name;
+    --> "Error[ref-invalid-navigation]: Can follow managed association “V:author” only to the keys of its target, not to “name”"
+    */
+    inferred.SELECT.orderBy[0].ref = ['parent_ID']
+    let inferredInferred = _inferred(inferred, flatModel)
+    expect(inferred).to.eql(inferredInferred)
+  })
+
   it('infer without global cds.model', () => {
     // this would trigger "Error: Please specify a model" if recursive infer calls would not pass down model parameter
     const keepModel = cds.model


### PR DESCRIPTION
see cap/issues#18378

---
**TL;DR** customer manipulated the `order by` of an already-fired query and ran the query again. The `isJoinRelevant` flag indicated the _old_ state of the column which has been changed to a foreign key access which obviously does not need a join. As a result, the `order by` token had messed up meta information attached which led to an undefined state.

the issue is described as a test in this pr:

```js
  it('infer inferred query multiple times, even after manipulation', () => {
    const flatModel = cds.compile.for.nodejs(model)
    // the order by path is join relevant
    let query = cds.ql`SELECT from bookshop.Genres { ID, parent_ID } order by parent.name`
    let inferred = _inferred(query, flatModel)
    /*
    now the order by path is not join relevant anymore
    if the orderBy's $refLinks are not properly re-constructed
    the reference looks like it induces a join while navigating along an exposed association
    which is generally not possible:

    entity V as select from Books {
      ID,
      author
    } order by author.name;
    --> "Error[ref-invalid-navigation]: Can follow managed association “V:author” only to the keys of its target, not to “name”"
    */
    inferred.SELECT.orderBy[0].ref = ['parent_ID']
    let inferredInferred = _inferred(inferred, flatModel)
    expect(inferred).to.eql(inferredInferred)
  })
```