### PR TITLE
chore: Don't fix peerDeps version

### DIFF
--- a/hana/package.json
+++ b/hana/package.json
@@ -29,7 +29,7 @@
     "hdb": "^0.19.5"
   },
   "peerDependencies": {
-    "@sap/hana-client": "2",
+    "@sap/hana-client": "^2",
     "@sap/cds": ">=9"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
The `peerDependencies` `@sap/hana-client` was fixed to v2.