### PR TITLE
ci: add cap/dev test setup

### DIFF
--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global url."https://x-access-token:${{ secrets.GH_TOKEN_TOOLS }}@github.tools.sap/".insteadOf "https://github.tools.sap/"
 
-      # Clone cap/dev monorepo from the Enterprise instance
+      # Clone cap/dev monorepo from the GHE instance
       - name: Clone cap/dev
         run: git clone https://github.tools.sap/cap/dev.git cap-dev
 
@@ -36,13 +36,13 @@ jobs:
         working-directory: cap-dev
         run: npm run setup
 
-      # PR voter – only cds-dbs tests
+      # PR voter – run only cds-dbs tests
       - name: Run cds-dbs tests only (PR)
         if: github.event_name == 'pull_request'
         working-directory: cap-dev
-        run: npm test cap/cds-dbs
+        run: npm test cds-dbs
 
-      # Post-merge – full integration test suite
+      # main – run full integration test suite
       - name: Run full test suite (main)
         if: github.event_name == 'push'
         working-directory: cap-dev

--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout cds-dbs
-        uses: actions/checkout@v4
-
       - name: Set up Node.js 22
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -36,14 +36,7 @@ jobs:
         working-directory: cap-dev
         run: npm run setup
 
-      # PR voter – run only cds-dbs tests
-      - name: Run cds-dbs tests only (PR)
-        if: github.event_name == 'pull_request'
-        working-directory: cap-dev
-        run: npm test cds-dbs
-
-      # main – run full integration test suite
-      - name: Run full test suite (main)
-        if: github.event_name == 'push'
+      # run test suite
+      - name: Run tests
         working-directory: cap-dev
         run: npm test

--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout cds-dbs
+        uses: actions/checkout@v4
+
       - name: Set up Node.js 22
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   build-and-test:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -36,7 +36,14 @@ jobs:
         working-directory: cap-dev
         run: npm run setup
 
-      # Run the full test suite
-      - name: Run tests
+      # PR voter – only cds-dbs tests
+      - name: Run cds-dbs tests only (PR)
+        if: github.event_name == 'pull_request'
+        working-directory: cap-dev
+        run: npm test cap/cds-dbs
+
+      # Post-merge – full integration test suite
+      - name: Run full test suite (main)
+        if: github.event_name == 'push'
         working-directory: cap-dev
         run: npm test

--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -1,0 +1,39 @@
+name: CAP dev integration
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout cds-dbs
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # Inject the GH_TOKEN_TOOLS credential for all calls to github.tools.sap
+      - name: Configure Git credentials for SAP GitHub Enterprise
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GH_TOKEN_TOOLS }}@github.tools.sap/".insteadOf "https://github.tools.sap/"
+
+      # Clone cap/dev monorepo from the Enterprise instance
+      - name: Clone cap/dev
+        run: git clone https://github.tools.sap/cap/dev.git cap-dev
+
+      # Bootstrap cap/dev (updates submodules, checks out latest and PR (or latest main) of cds-dbs)
+      - name: Install & bootstrap cap/dev
+        working-directory: cap-dev
+        run: npm run setup
+
+      # Run the full test suite
+      - name: Run tests
+        working-directory: cap-dev
+        run: npm test

--- a/.github/workflows/cap-dev.yml
+++ b/.github/workflows/cap-dev.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
clone `cap/dev` from our internal gh instance and runs all tests

---

The `npm run setup` script within the `cap/dev` makes sure that the current `HEAD` is checked out:

```log
git checkout main              for cap/incidents
git checkout main              for cap/samples
git checkout main              for cap/sflight
git checkout main              for cap/cds
git checkout main              for cap/cds-attic
git checkout main              for cap/cds-compiler
git checkout patrice/cap-dev-tests for cap/cds-dbs ✅
git checkout main              for cap/cds-dk
git checkout main              for cap/cds-fiori
git checkout main              for cap/cds-foss
git checkout main              for cap/cds-graphql
git checkout main              for cap/cds-hana
git checkout main              for cap/cds-lint
git checkout main              for cap/cds-mtxs
git checkout main              for cap/cds-test
git checkout main              for cap/cds-typer
git checkout main              for cap/cds-types
```
