### PR TITLE
fix: remove cds._context.disable() from tests

### DIFF
--- a/test/cds.js
+++ b/test/cds.js
@@ -131,8 +131,3 @@ const _includes = expect.includes
 expect.includes = function (x) {
   return typeof x === 'object' ? this.subset(...arguments) : _includes.apply(this, arguments)
 }
-
-// Release cds._context for garbage collection
-global.afterEach(() => {
-  cds._context.disable()
-})


### PR DESCRIPTION
This is using undocumented APIs which blocks cleanups in `@sap/cds`. 
Should not be required anyways. 