### PR TITLE
ci: add workflow which fails fast and points to local testing

### DIFF
--- a/.github/workflows/reject-pr.yml
+++ b/.github/workflows/reject-pr.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  issues: write # to create comments in PRs the issues API is used
   pull-requests: write
 
 jobs:
@@ -14,12 +14,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # 0. Locate an existing guidance comment (if any)
+      - name: Find guidance comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Until cds9 is released'
+
+      # 1. Create the comment if it doesn't exist, or update it if it does
       - name: Create or update guidance comment
         uses: peter-evans/create-or-update-comment@v4
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}   # empty on first run → create; otherwise update
           issue-number: ${{ github.event.pull_request.number }}
-          comment-tag: cap-dev-guidance           # ← ensures only one comment
-          edit-mode: replace                      # replace body on subsequent runs
+          edit-mode: replace                               # overwrite the previous body
           body: |
             ❗️Until cds9 is released, we need to ensure code integrity by local testing.  
 
@@ -32,6 +42,7 @@ jobs:
             Once the matrix tests are **green**, confirm it here.  
             An admin will then merge your PR. 😊
 
+      # 2. Fail the workflow on purpose so the PR stays blocked
       - name: Fail immediately
         run: |
           echo "Failing intentionally until cds9 release."

--- a/.github/workflows/reject-pr.yml
+++ b/.github/workflows/reject-pr.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  issues: write        # PR comments use the Issues API
+  issues: write
   pull-requests: write
 
 jobs:
@@ -14,21 +14,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Drop the instructional comment on the PR
-      - name: Post guidance comment
+      - name: Create or update guidance comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
+          comment-tag: cap-dev-guidance           # ← ensures only one comment
+          edit-mode: replace                      # replace body on subsequent runs
           body: |
             ❗️Until cds9 is released, we need to ensure code integrity by local testing.  
 
             Please follow these steps to run your changes against all tests in our pipeline:
-            - Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml)
-            - click **“run workflow”**
-            - for **“specific branches for the cds packages”** insert `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  
-            Once the matrix tests are green, confirm it here. An admin will then merge your PR.
+            1. Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml).
+            2. Click **“Run workflow”**.
+            3. For **“specific branches for the cds packages”** insert  
+               `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  
 
-      # 2. Fail the workflow on purpose
+            Once the matrix tests are **green**, confirm it here.  
+            An admin will then merge your PR. 😊
+
       - name: Fail immediately
         run: |
           echo "Failing intentionally until cds9 release."

--- a/.github/workflows/reject-pr.yml
+++ b/.github/workflows/reject-pr.yml
@@ -36,8 +36,7 @@ jobs:
             Please follow these steps to run your changes against all tests in our pipeline:
             1. Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml).
             2. Click **“Run workflow”**.
-            3. For **“specific branches for the cds packages”** insert  
-               `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  
+            3. For **“specific branches for the cds packages”** insert `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  
 
             Once the matrix tests are **green**, confirm it here.  
             An admin will then merge your PR. 😊

--- a/.github/workflows/reject-pr.yml
+++ b/.github/workflows/reject-pr.yml
@@ -1,0 +1,33 @@
+name: run tests in cap/dev setup locally
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write        # PR comments use the Issues API
+  pull-requests: write
+
+jobs:
+  fail-fast:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Drop the instructional comment on the PR
+      - name: Post guidance comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ❗️Until cds9 is released, we need to ensure code integrity by local testing.  
+            Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml),
+            click **“run workflow”** and for **“specific branches for the cds packages”**
+            insert `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  
+            Once the matrix tests are green, confirm it here. An admin will then merge your PR.
+
+      # 2. Fail the workflow on purpose
+      - name: Fail immediately
+        run: |
+          echo "Failing intentionally until cds9 release."
+          exit 1

--- a/.github/workflows/reject-pr.yml
+++ b/.github/workflows/reject-pr.yml
@@ -21,9 +21,11 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ❗️Until cds9 is released, we need to ensure code integrity by local testing.  
-            Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml),
-            click **“run workflow”** and for **“specific branches for the cds packages”**
-            insert `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  
+
+            Please follow these steps to run your changes against all tests in our pipeline:
+            - Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml)
+            - click **“run workflow”**
+            - for **“specific branches for the cds packages”** insert `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  
             Once the matrix tests are green, confirm it here. An admin will then merge your PR.
 
       # 2. Fail the workflow on purpose

--- a/.github/workflows/reject-pr.yml
+++ b/.github/workflows/reject-pr.yml
@@ -24,7 +24,7 @@ jobs:
             ❗️Until cds9 is released, we need to ensure code integrity by local testing.  
 
             Please follow these steps to run your changes against all tests in our pipeline:
-            1. Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml).
+            1. Go to [our matrix tests](https:<tools instance>/cap/.github/actions/workflows/matrix.yml).
             2. Click **“Run workflow”**.
             3. For **“specific branches for the cds packages”** insert  
                `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  

--- a/.github/workflows/reject-pr.yml
+++ b/.github/workflows/reject-pr.yml
@@ -24,7 +24,7 @@ jobs:
             ❗️Until cds9 is released, we need to ensure code integrity by local testing.  
 
             Please follow these steps to run your changes against all tests in our pipeline:
-            1. Go to [our matrix tests](https:<tools instance>/cap/.github/actions/workflows/matrix.yml).
+            1. Go to [our matrix tests](https://github.tools.sap/cap/.github/actions/workflows/matrix.yml).
             2. Click **“Run workflow”**.
             3. For **“specific branches for the cds packages”** insert  
                `cds-dbs:${{ github.event.pull_request.head.ref }}` and execute the workflow.  


### PR DESCRIPTION
until cds9 is released, we need to make sure that PR authors do not break the code integrity _manually_.

This workflow helps with this and points to our matrix tests, for increased accessibility.