### PR TITLE
fix(`search`): do not search on non-projected elements

### DIFF
--- a/db-service/lib/search.js
+++ b/db-service/lib/search.js
@@ -112,13 +112,12 @@ const _getSearchableColumns = entity => {
 
   if (deepSearchCandidates.length) {
     deepSearchCandidates.forEach(c => {
-      let element = entity // running “cursor”
+      let element = entity
       for (let i = 0; i < c.ref.length; ++i) {
         const curr = c.ref[i]
         const next = element.elements?.[curr] ?? element._target?.elements?.[curr]
 
-        if (!next) {
-          // nothing found → bail out
+        if (!next) { // e.g. if a search element is not part of a projection
           element = undefined
           break
         }

--- a/db-service/lib/search.js
+++ b/db-service/lib/search.js
@@ -79,7 +79,7 @@ const _getSearchableColumns = entity => {
     const column = entity.elements[columnName]
     if (column?.isAssociation || columnName.includes('.')) {
       deepSearchCandidates.push({ ref: columnName.split('.') })
-      continue;
+      continue
     }
     cdsSearchColumnMap.set(columnName, annotationValue)
   }
@@ -93,8 +93,8 @@ const _getSearchableColumns = entity => {
     // `@cds.search { element1: true }` or `@cds.search { element1 }`
     if (annotatedColumnValue) return true
 
-    // calculated elements are only searchable if requested through `@cds.search` 
-    if(column.value) return false
+    // calculated elements are only searchable if requested through `@cds.search`
+    if (column.value) return false
 
     // if at least one element is explicitly annotated as searchable, e.g.:
     // `@cds.search { element1: true }` or `@cds.search { element1 }`
@@ -112,16 +112,24 @@ const _getSearchableColumns = entity => {
 
   if (deepSearchCandidates.length) {
     deepSearchCandidates.forEach(c => {
-      const element = c.ref.reduce((resolveIn, curr, i) => {
-        const next = resolveIn.elements?.[curr] || resolveIn._target.elements[curr]
-        if (next?.isAssociation && !c.ref[i + 1]) {
-          const searchInTarget = _getSearchableColumns(next._target)
-          searchInTarget.forEach(elementRefInTarget => {
-            searchableColumns.push({ ref: c.ref.concat(...elementRefInTarget.ref) })
-          })
+      let element = entity // running “cursor”
+      for (let i = 0; i < c.ref.length; ++i) {
+        const curr = c.ref[i]
+        const next = element.elements?.[curr] ?? element._target?.elements?.[curr]
+
+        if (!next) {
+          // nothing found → bail out
+          element = undefined
+          break
         }
-        return next
-      }, entity)
+
+        if (next.isAssociation && i === c.ref.length - 1) {
+          _getSearchableColumns(next._target).forEach(r => searchableColumns.push({ ref: c.ref.concat(...r.ref) }))
+        }
+
+        element = next
+      }
+
       if (element?.type === DEFAULT_SEARCHABLE_TYPE) {
         searchableColumns.push({ ref: c.ref })
       }
@@ -129,9 +137,8 @@ const _getSearchableColumns = entity => {
   }
 
   return searchableColumns.map(column => {
-    if(column.ref)
-      return column
-    return { ref: [ column.name ] }
+    if (column.ref) return column
+    return { ref: [column.name] }
   })
 }
 
@@ -183,15 +190,16 @@ const computeColumnsToBeSearched = (cqn, entity = { __searchableColumns: [] }) =
       }
     })
   } else {
-    if(entity.kind === 'entity') {
+    if (entity.kind === 'entity') {
       // first check cache
-      toBeSearched = entity.own('__searchableColumns') || entity.set('__searchableColumns', _getSearchableColumns(entity))
+      toBeSearched =
+        entity.own('__searchableColumns') || entity.set('__searchableColumns', _getSearchableColumns(entity))
     } else {
       // if we search on a subquery, we don't have a cache
       toBeSearched = _getSearchableColumns(entity)
     }
     toBeSearched = toBeSearched.map(c => {
-      const column = {ref: [...c.ref]}
+      const column = { ref: [...c.ref] }
       return column
     })
   }

--- a/db-service/test/bookshop/db/search.cds
+++ b/db-service/test/bookshop/db/search.cds
@@ -13,6 +13,16 @@ entity Books {
 @cds.search: {author.lastName}
 entity BooksSearchAuthorName : Books {}
 
+@cds.search: {title}
+entity PathInSearchNotProjected as select from BooksSearchAuthorName {
+    ID,
+    title
+};
+
+entity NoSearchCandidateProjected as select from PathInSearchNotProjected {
+    ID
+};
+
 // search through all searchable fields in the author
 @cds.search: {author}
 entity BooksSearchAuthor : Books {}

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -255,8 +255,33 @@ describe('search w/ path expressions', () => {
     {
       BooksSearchAuthorName.ID,
       BooksSearchAuthorName.title
-  }`
+    }`
     expected.SELECT.where = [ {func: 'search', args: [{ list: [{ref: ['author', 'lastName']}]}, {val: 'x'}]}]
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
+  })
+
+  it('deep search candidate of base entity not projected', () => {
+    let query = cds.ql`SELECT from search.PathInSearchNotProjected as PathInSearchNotProjected { title }`
+    query.SELECT.search = [{ val: 'x' }]
+
+    let res = cqn4sql(query, model)
+    const expected = cds.ql`
+    SELECT from search.PathInSearchNotProjected as PathInSearchNotProjected {
+      PathInSearchNotProjected.title
+    }`
+    expected.SELECT.where = [ {func: 'search', args: [{ list: [{ref: ['PathInSearchNotProjected', 'title']}]}, {val: 'x'}]}]
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
+  })
+
+  it('no search candidate of base entity projected', () => {
+    let query = cds.ql`SELECT from search.NoSearchCandidateProjected as NoSearchCandidateProjected { ID }`
+    query.SELECT.search = [{ val: 'x' }]
+
+    let res = cqn4sql(query, model)
+    const expected = cds.ql`
+    SELECT from search.NoSearchCandidateProjected as NoSearchCandidateProjected {
+      NoSearchCandidateProjected.ID
+    }`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 


### PR DESCRIPTION
the `@cds.search` annotation is propagated as-is.

If a path expression was used in the `@cds.search` annotation of a base entity, but the association for the path is _not_ projected in a view on top of the entity, we must not try to resolve the path expression in the view.

reported in cap/issue#18465