### PR TITLE
test: ensure default $now always points to tx timestamp

### DIFF
--- a/test/compliance/INSERT.test.js
+++ b/test/compliance/INSERT.test.js
@@ -187,4 +187,19 @@ describe('INSERT', () => {
     // InsertResult
     expect(affectedRows).not.to.include({ _affectedRows: 1 }) // lastInsertRowid not available on postgres
   })
+
+  test('default $now adds current tx timestamp in correct format', async () => {
+    await cds.tx(async tx => {
+      // the statements are run explicitly in sequential order to ensure current_timestamp would create different timestamps
+      await tx.run(INSERT.into('basic.common.dollar_now_default').entries({ id: 5 }))
+      await tx.run(INSERT.into('basic.common.dollar_now_default').entries({ id: 6 }))
+    })
+
+    const result = await SELECT.from('basic.common.dollar_now_default')
+
+    expect(result.length).to.eq(2)
+    ;['date ', 'time', 'dateTime', 'timestamp'].forEach(prop => {
+      expect(result[0][prop]).to.eq(result[1][prop])
+    })
+  })
 })

--- a/test/compliance/INSERT.test.js
+++ b/test/compliance/INSERT.test.js
@@ -198,7 +198,6 @@ describe('INSERT', () => {
     const result = await SELECT.from('basic.common.dollar_now_default')
     
     expect(result.length).to.eq(2)
-    console.log(result)
     expect(result[0].date).to.match(/^\d{4}-\d{2}-\d{2}$/)
     expect(result[0].date).to.eq(result[1].date)
     expect(result[0].time).to.match(/^\d{2}:\d{2}:\d{2}$/)

--- a/test/compliance/INSERT.test.js
+++ b/test/compliance/INSERT.test.js
@@ -196,10 +196,16 @@ describe('INSERT', () => {
     })
 
     const result = await SELECT.from('basic.common.dollar_now_default')
-
+    
     expect(result.length).to.eq(2)
-    ;['date ', 'time', 'dateTime', 'timestamp'].forEach(prop => {
-      expect(result[0][prop]).to.eq(result[1][prop])
-    })
+    console.log(result)
+    expect(result[0].date).to.match(/^\d{4}-\d{2}-\d{2}$/)
+    expect(result[0].date).to.eq(result[1].date)
+    expect(result[0].time).to.match(/^\d{2}:\d{2}:\d{2}$/)
+    expect(result[0].time).to.eq(result[1].time)
+    expect(result[0].dateTime).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+    expect(result[0].dateTime).to.eq(result[1].dateTime)
+    expect(result[0].timestamp).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    expect(result[0].timestamp).to.eq(result[1].timestamp)
   })
 })

--- a/test/compliance/resources/db/basic/common.cds
+++ b/test/compliance/resources/db/basic/common.cds
@@ -43,6 +43,14 @@ entity ![default] : _cuid {
   // vector : Vector default '[1.0,0.5,0.0,...]';
 }
 
+entity dollar_now_default {
+  key id    : Integer;
+  date      : Date default $now;
+  time      : Time default $now;
+  dateTime  : DateTime default $now;
+  timestamp : Timestamp default $now;
+}
+
 entity keys {
   key id      : Integer;
   key default : String default 'defaulted';


### PR DESCRIPTION
This test already ensures that `default $now` is using the session context instead of current_timestamp for generating the default value.

It has to be done in the SQL statement since the compiler generates current_timestamp in the default clause since the db do not allow usage of session context for default clauses.