### PR TITLE
feat: set NOW as session var in addition to $now

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -117,6 +117,7 @@ class HANAService extends SQLService {
       : variables['$valid.from']
     if (variables['$user.id']) variables['APPLICATIONUSER'] = variables['$user.id']
     if (variables['$user.locale']) variables['LOCALE'] = variables['$user.locale']
+    if (variables['$now']) variables['NOW'] = variables['$now']
 
     this.ensureDBC().set(variables)
   }

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -248,7 +248,8 @@ describe('SELECT', () => {
         .rejected
     })
 
-    test('$now in view refers to tx timestamp', async () => {
+    // TODO: enable after next compiler release
+    test.skip('$now in view refers to tx timestamp', async () => {
       let ts, res1,res2
       await cds.tx(async tx => {
         ts = tx.context.timestamp

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -247,6 +247,19 @@ describe('SELECT', () => {
       await expect(cds.run(cqn), { message: 'Not supported type: cds.DoEsNoTeXiSt' })
         .rejected
     })
+
+    test('$now in view refers to tx timestamp', async () => {
+      let ts, res1,res2
+      await cds.tx(async tx => {
+        ts = tx.context.timestamp
+        // the statements are run explicitly in sequential order to ensure current_timestamp would create different timestamps
+        res1 = await tx.run(SELECT.one.from('basic.projection.now_in_view'))
+        res2 = await tx.run(SELECT.one.from('basic.projection.now_in_view'))
+      })
+  
+      expect(res1.now).to.eq(ts.toISOString())
+      expect(res1.now).to.eq(res2.now)
+    })
   })
 
   describe('excluding', () => {

--- a/test/compliance/resources/db/basic/projection.cds
+++ b/test/compliance/resources/db/basic/projection.cds
@@ -9,6 +9,8 @@ entity date     as projection on literals.date;
 entity time     as projection on literals.time;
 entity dateTime as projection on literals.dateTime;
 
+entity now_in_view as select $now as now from literals.globals;
+
 entity ![all]   as
     select from literals.globals {
       bool,


### PR DESCRIPTION
compiler will change the $now references in views with SESSION_CONTEXT('NOW'). so far it's CURRENT_TIMESTAMP