### PR TITLE
ci(`v1`): release `v1` under specific tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,12 @@ jobs:
           name: 'Release v${{ steps.package-version.outputs.current-version}}'
           # prerelease: true
           # body: changelog...
-      - run: npm publish --workspace db-service --access public
+      - run: npm publish --workspace db-service --access public --tag v1
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-      - run: npm publish --workspace sqlite --access public
+      - run: npm publish --workspace sqlite --access public --tag v1
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-      - run: npm publish --workspace postgres --access public
+      - run: npm publish --workspace postgres --access public --tag v1
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
once `cds 9` is generally available and the `V2` codeline is tagged as `latest` we need to release our `V1` downports under a different tag, I used `v1` here.