### PR TITLE
fix: Better opt in flag for builtin generic pool

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -68,7 +68,7 @@ class HANAService extends SQLService {
           return dbc
         } catch (err) {
           if (isMultitenant) {
-            if (cds.requires.db?.pool?.builtin) {
+            if (cds.requires.db?.pool?.builtin || cds.env.features.pool === 'builtin') {
               if (err.status === 404 || err.status === 429) {
                 throw new Error(`Pool failed connecting to '${tenant}'`, { cause: err })
               }


### PR DESCRIPTION
As just discussed with @johannes-vogel and @chgeo :

- [x] Using config option `cds.env.features.pool = 'builtin'` instead of `cds.requires.db.pool.builtin`
- [x] Don't call `require('generic-pool')` again and again at runtime → pls always avoid that very bad habit 
- [ ] Please publish a hotfix asap

Subsequently: 

- [ ] When trying it out with the tests in here **one test fails** → we should fix that
- [ ] We should always run the test suite in here with that flag → pls add to pipeline 

Reason for the changed flag: With the former opt in flag set globally, lots of tests and samples which intentionally didn't use a database at all were broken. ( The former flag is still supported w/ this PR though )