### PR TITLE
test(hierarchy): add necessary annotation

### DIFF
--- a/test/bookshop/srv/tree-service.cds
+++ b/test/bookshop/srv/tree-service.cds
@@ -13,4 +13,10 @@ service TreeService {
       null as MatchedDescendantCount,
       null as LimitedRank,
     };
+
+    annotate Genres with @Aggregation.RecursiveHierarchy#GenresHierarchy: {
+      $Type                   : 'Aggregation.RecursiveHierarchyType',
+      NodeProperty            : ID,
+      ParentNavigationProperty: parent
+    };
 }


### PR DESCRIPTION
Needed to resolve the `parent` pointer, only worked by chance before (because association was called `parent` which is the default for the model-independent part of our parser).