### PR TITLE
feat(recurse): object-page hierarchies

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -282,6 +282,17 @@ class CQN2SQLRenderer {
   SELECT_recurse(q) {
     let { from, columns, where, orderBy, recurse, _internal } = q.SELECT
 
+    const keys =[]
+    for (const _key in q._target.keys) {
+      if (!q._target.keys[_key].virtual) {
+        keys.push({ ref: [_key] })
+        break
+      }
+    }
+
+    // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
+    where = [{ list: keys }, 'in', { SELECT: { from, where, columns: keys }}]
+
     const requiredComputedColumns = { PARENT_ID: true, NODE_ID: true }
     if (!_internal) requiredComputedColumns.RANK = true
     const addComputedColumn = (name) => {

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -285,19 +285,21 @@ class CQN2SQLRenderer {
     const keys = []
     const _target = q._target
 
-    for (const _key in _target.keys) {
-      const k = _target.keys[_key]
-      if (!k.virtual && !k.isAssociation && !k.value) {
-        keys.push({ ref: [_key] })
+    if (_target) {
+      for (const _key in _target.keys) {
+        const k = _target.keys[_key]
+        if (!k.virtual && !k.isAssociation && !k.value) {
+          keys.push({ ref: [_key] })
+        }
       }
-    }
 
-    // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
-    const clone = q.clone()
-    clone.columns(keys)
-    clone.SELECT.recurse = undefined
-    clone.SELECT.expand = undefined // omits JSON
-    where = [{ list: keys }, 'in', clone]
+      // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
+      const clone = q.clone()
+      clone.columns(keys)
+      clone.SELECT.recurse = undefined
+      clone.SELECT.expand = undefined // omits JSON
+      where = [{ list: keys }, 'in', clone]
+    }
 
     const requiredComputedColumns = { PARENT_ID: true, NODE_ID: true }
     if (!_internal) requiredComputedColumns.RANK = true

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -287,7 +287,8 @@ class CQN2SQLRenderer {
 
     if (_target) {
       for (const _key in _target.keys) {
-        if (!_target.keys[_key].virtual && !_target.keys[_key].isAssociation) {
+        const k = _target.keys[_key]
+        if (!k.virtual && !k.isAssociation && !k.value) {
           keys.push({ ref: [_key] })
           break
         }

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -294,7 +294,12 @@ class CQN2SQLRenderer {
       }
 
       // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
-      where = [{ list: keys }, 'in', { SELECT: { from, where, columns: keys }}]
+      const clone = q.clone()
+      clone.SELECT.columns = []
+      clone.columns(keys)
+      clone.SELECT.recurse = undefined
+      clone.SELECT.expand = undefined // omits JSON
+      where = [{ list: keys }, 'in', clone]
     }
 
     const requiredComputedColumns = { PARENT_ID: true, NODE_ID: true }

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -295,7 +295,6 @@ class CQN2SQLRenderer {
 
       // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
       const clone = q.clone()
-      clone.SELECT.columns = []
       clone.columns(keys)
       clone.SELECT.recurse = undefined
       clone.SELECT.expand = undefined // omits JSON

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -287,7 +287,7 @@ class CQN2SQLRenderer {
 
     if (_target) {
       for (const _key in _target.keys) {
-        if (!_target.keys[_key].virtual) {
+        if (!_target.keys[_key].virtual && !_target.keys[_key].isAssociation) {
           keys.push({ ref: [_key] })
           break
         }

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -282,16 +282,20 @@ class CQN2SQLRenderer {
   SELECT_recurse(q) {
     let { from, columns, where, orderBy, recurse, _internal } = q.SELECT
 
-    const keys =[]
-    for (const _key in q._target.keys) {
-      if (!q._target.keys[_key].virtual) {
-        keys.push({ ref: [_key] })
-        break
-      }
-    }
+    const keys = []
+    const _target = q._target
 
-    // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
-    where = [{ list: keys }, 'in', { SELECT: { from, where, columns: keys }}]
+    if (_target) {
+      for (const _key in _target.keys) {
+        if (!_target.keys[_key].virtual) {
+          keys.push({ ref: [_key] })
+          break
+        }
+      }
+
+      // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
+      where = [{ list: keys }, 'in', { SELECT: { from, where, columns: keys }}]
+    }
 
     const requiredComputedColumns = { PARENT_ID: true, NODE_ID: true }
     if (!_internal) requiredComputedColumns.RANK = true

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -285,21 +285,19 @@ class CQN2SQLRenderer {
     const keys = []
     const _target = q._target
 
-    if (_target) {
-      for (const _key in _target.keys) {
-        const k = _target.keys[_key]
-        if (!k.virtual && !k.isAssociation && !k.value) {
-          keys.push({ ref: [_key] })
-        }
+    for (const _key in _target.keys) {
+      const k = _target.keys[_key]
+      if (!k.virtual && !k.isAssociation && !k.value) {
+        keys.push({ ref: [_key] })
       }
-
-      // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
-      const clone = q.clone()
-      clone.columns(keys)
-      clone.SELECT.recurse = undefined
-      clone.SELECT.expand = undefined // omits JSON
-      where = [{ list: keys }, 'in', clone]
     }
+
+    // `where` needs to be wrapped to also support `where == ['exists', { SELECT }]` which is not allowed in `START WHERE`
+    const clone = q.clone()
+    clone.columns(keys)
+    clone.SELECT.recurse = undefined
+    clone.SELECT.expand = undefined // omits JSON
+    where = [{ list: keys }, 'in', clone]
 
     const requiredComputedColumns = { PARENT_ID: true, NODE_ID: true }
     if (!_internal) requiredComputedColumns.RANK = true

--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -290,7 +290,6 @@ class CQN2SQLRenderer {
         const k = _target.keys[_key]
         if (!k.virtual && !k.isAssociation && !k.value) {
           keys.push({ ref: [_key] })
-          break
         }
       }
 


### PR DESCRIPTION
Where clauses like `where exists SELECT ...` are not supported in `START WHERE`, therefore such SELECTs are wrapped in `where ID in ...`.