### PR TITLE
test: Improve test isolation logic for HANA containers

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1425,8 +1425,8 @@ SELECT ${mixing} FROM JSON_TABLE(SRC.JSON, '$' COLUMNS(${extraction}) ERROR ON E
     const creds = {
       containerGroup: database.toUpperCase(),
       usergroup: `${database}_USERS`.toUpperCase(),
-      schema: tenant.toUpperCase(),
-      user: `${tenant}_USER`.toUpperCase(),
+      schema: `${database}_${tenant}`.toUpperCase(),
+      user: `${database}_${tenant}_USER`.toUpperCase(),
     }
     creds.password = creds.user + 'Val1d' // Password restrictions require Aa1
 


### PR DESCRIPTION
Currently the HDI Container group isolation layer doesn't provide the isolation required for the parallel test execution. While the container group doesn't contain the container the container name clashes with those of the other container groups. Creating undefined behaviors additionally the user groups don't provide any isolation resulting in the creating side effects of creating users with the same name.