### PR TITLE
fix: Improve transaction handling for special behavior of `forUpdate({ wait: n })`

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -213,7 +213,7 @@ class HANAService extends SQLService {
         // Clear current tenant connection pool
         this.disconnect(this.context.tenant)
       }
-      throw err
+      return this.rollback(err)
     }
   }
 

--- a/hana/test/lock.test.js
+++ b/hana/test/lock.test.js
@@ -1,0 +1,51 @@
+const { tx } = require('@sap/cds')
+const cds = require('../../test/cds.js')
+
+describe('locking', () => {
+  const { expect } = cds.test(__dirname + '/../../test/bookshop')
+
+  describe('forUpdate', async () => {
+
+    test('wait=0', async () => {
+      const { Books } = cds.entities
+      let tx1, tx2
+      try {
+        tx1 = await cds.tx()
+        tx2 = await cds.tx()
+        const query = cds.ql.SELECT.from(Books).forUpdate({ wait: 0 })
+
+        await tx1.run(query)
+        await expect(tx2.run(query)).rejected
+      } finally {
+        await tx1?.rollback()
+        await tx2?.rollback()
+      }
+    })
+
+    test('wait>0', async () => {
+      const { Books } = cds.entities
+      let tx1, tx2
+      try {
+        tx1 = await cds.tx()
+        tx2 = await cds.tx()
+        const query = cds.ql.SELECT.from(Books).forUpdate({ wait: 1 })
+
+        await tx2.run(INSERT({ ID: 999 }).into(Books))
+
+        await tx1.run(query)
+
+        await expect(tx2.run(query)).rejected
+
+        await tx2.commit()
+        await tx1.commit()
+
+        const res = await cds.ql.SELECT.from(Books).where({ ID: 999 })
+        expect(res).length(0)
+      } finally {
+        await tx1?.rollback()
+        await tx2?.rollback()
+      }
+    })
+
+  })
+})


### PR DESCRIPTION
When using `FOR UPDATE` with a `WAIT` provided. Once the lock acquire files the whole transaction is automatically rolled back. Which creates a disconnect between the `cds.context.tx` and the physical database connection. Only when the lock acquire error was `caught` inside the custom code. If the error is allowed to reach the outside of the transaction the current behavior will already cause the `cds.context.tx` to be properly rolled back.