### PR TITLE
fix: ensure ordering of `ParameterStream` chunks

### DIFF
--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -812,15 +812,13 @@ class ParameterStream extends Writable {
       delete this.flushChunk
 
       this.lengthBuffer.writeUInt32BE(chunk.length + 5, 1)
-      this.connection.stream.write(this.lengthBuffer, () => {
-        this.connection.stream.write(Buffer.from(this.constructor.sep), () => {
-          this.connection.stream.write(chunk, cb)
-        })
-      })
+      this.connection.stream.write(this.lengthBuffer)
+      this.connection.stream.write(this.constructor.sep)
+      this.connection.stream.write(chunk, cb)
     }
   }
 
-  static sep = String.fromCharCode(31) // Separator One
+  static sep = Buffer.from(String.fromCharCode(31)) // Separator One
   static done = Buffer.from([0x63, 0, 0, 0, 4])
 
   then(resolve, reject) {
@@ -877,9 +875,8 @@ class ParameterStream extends Writable {
 
   flushChunk(chunk, cb) {
     this.lengthBuffer.writeUInt32BE(chunk.length + 4, 1)
-    this.connection.stream.write(this.lengthBuffer, () => {
-      this.connection.stream.write(chunk, cb)
-    })
+    this.connection.stream.write(this.lengthBuffer)
+    this.connection.stream.write(chunk, cb)
   }
 
   handleError(e) {


### PR DESCRIPTION
Under certain conditions, the chunks written by the `ParameterStream` class were transmitted in the wrong order:


<img width="1687" height="1415" alt="image" src="https://github.com/user-attachments/assets/f049a2a2-1516-474e-ab1f-df20819105dc" />
In this example, there was a correct copydata header with length 0x158 written to the stream, but the header of another chunk with length 0x11 was transmitted first.


This leads to errors like these because copydata message headers/announced lengths do not match the actual message length:
`Error in ParameterStream: error: unexpected message type 0x6B during COPY from stdin`

I could only observe the issue with TLS enabled (local/BTP) Postgres, so it looks like TLS sockets are a bit more sensitive to timing. It happens predictably for me there, though. Also it never happened with the patches included in this PR, so there is hope that it actually resolves the issue.

It could be that the code in this PR is a bit too strict in ensuring sequence, but at least it works for me. I'm not sure how to unit test this, because the requirements are quite high (I think adding a TLS-enabled postgres instance to the test environment is asking a bit too much?)