### PR TITLE
feat: Enable path expression inside aggregate functions

### DIFF
--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -1252,7 +1252,6 @@ describe('SELECT', () => {
       ...unified.ref.filter(numberRefs).map(ref => ({ func: 'average', args: [ref] })),
       ...unified.ref.filter(noBlobRefs).map(ref => ({ func: 'count', args: [ref] })),
       { func: 'count', args: ['*'] },
-      { func: 'count', args: [''] },
       { func: 'count' },
       ...unified.ref.filter(noBlobRefs).map(ref => ({ func: 'countdistinct', args: [ref] })),
       ...unified.ref.filter(noBlobRefs).filter(noBooleanRefs).map(ref => ({ func: 'max', args: [ref] })),

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -163,6 +163,12 @@ describe('SELECT', () => {
       await expect(cds.run(cqn)).rejected
     })
 
+    test('select func path expression', async () => {
+      const { Authors } = cds.entities('complex.associations')
+      const cqn = cds.ql`SELECT count(books) FROM ${Authors}`
+      await cds.run(cqn)
+    })
+
     test('select function (wrong)', async () => {
       const { globals } = cds.entities('basic.projection')
       const cqn = cds.ql`SELECT 'func' as function : cds.String FROM ${globals}`
@@ -1246,6 +1252,7 @@ describe('SELECT', () => {
       ...unified.ref.filter(numberRefs).map(ref => ({ func: 'average', args: [ref] })),
       ...unified.ref.filter(noBlobRefs).map(ref => ({ func: 'count', args: [ref] })),
       { func: 'count', args: ['*'] },
+      { func: 'count', args: [''] },
       { func: 'count' },
       ...unified.ref.filter(noBlobRefs).map(ref => ({ func: 'countdistinct', args: [ref] })),
       ...unified.ref.filter(noBlobRefs).filter(noBooleanRefs).map(ref => ({ func: 'max', args: [ref] })),


### PR DESCRIPTION
This scenario happens when sending an OData request like `/Authors?$filter=books/$count > 1`.