### PR TITLE
fix: detect path expression inside nested xpr after `exists`

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -404,7 +404,7 @@ function infer(originalQuery, model) {
     if (arg.list) arg.list.forEach(arg => inferArg(arg, null, $baseLink, context))
     if (arg.xpr)
       arg.xpr.forEach((token, i) =>
-        inferArg(token, queryElements, $baseLink, { ...context, inXpr: true, inExists: arg.xpr[i - 1] === 'exists' }),
+        inferArg(token, queryElements, $baseLink, { ...context, inXpr: true, inExists: inExists || arg.xpr[i - 1] === 'exists' }),
       ) // e.g. function in expression
 
     if (!arg.ref) {


### PR DESCRIPTION
fix a regression introduced by https://github.com/cap-js/cds-dbs/pull/1156/files#diff-8392404ad436e8eeaa98fcbc648744a3ab8a4fea7fd94b2901b88700b0ccd53cR411

closes #1225