### PR TITLE
fix: `Date` OutputConverter on sqlite

### DIFF
--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -243,6 +243,7 @@ class SQLiteService extends SQLService {
           : expr => `CASE ${expr} when 1 then 'true' when 0 then 'false' END ->'$'`,
       // DateTimes are returned without ms added by InputConverters
       DateTime: e => `substr(${e},0,20)||'Z'`,
+      Date: e => `substr(${e},0,11)`,
       // Timestamps are returned with ms, as written by InputConverters.
       // And as cds.builtin.classes.Timestamp inherits from DateTime we need
       // to override the DateTime converter above


### PR DESCRIPTION
I'm seeing the same issue as reported in https://github.com/cap-js/cds-dbs/issues/1002.

I managed to work around the issue by converting the output, so that at least it is not apparent after reading.

However I like the proposal from issue https://github.com/cap-js/cds-dbs/issues/1002 more, that is, to convert during UPDATE.