### PR TITLE
feat: add default support for `[hybrid]` profile

### DIFF
--- a/hana/package.json
+++ b/hana/package.json
@@ -44,6 +44,9 @@
     "requires": {
       "kinds": {
         "sql": {
+          "[hybrid]": {
+            "kind": "hana"
+          },
           "[production]": {
             "kind": "hana"
           }


### PR DESCRIPTION
Then intend of the `[hybrid]` profile is to run the production state on a local machine. As `@cap-js/hana` current defines itself as the `[production]` implementation it should also define itself as the `[hybrid]` profile.