### PR TITLE
fix: cds build for postgres

### DIFF
--- a/postgres/cds-plugin.js
+++ b/postgres/cds-plugin.js
@@ -47,6 +47,12 @@ cds.build?.register?.('postgres', class PostgresBuildPlugin extends cds.build.Pl
         }
       }
 
+      if (cds.env?.requires?.db) {
+        packageJson.cds ??= {}
+        packageJson.cds.requires ??= {}
+        packageJson.cds.requires.db = { ...cds.env.requires.db }
+      }
+
       // propagate cds.env.cdsc (minus disallowed)
       const envCdsc = cds.env?.cdsc ?? {}
       const cdscClean = Object.fromEntries(

--- a/postgres/test/cds-build.test.js
+++ b/postgres/test/cds-build.test.js
@@ -45,4 +45,12 @@ describe('cds build plugin', () => {
     // this is excluded from being copied over
     expect(packageJson.cds?.cdsc?.moduleLookupDirectories).to.be.undefined
   })
+  
+  test('should retain db settings', () => {
+    execSync('npx cds build --production', { cwd: workDir })
+    const packageJson = require(path.join(pgDest, 'package.json'))
+    expect(packageJson.cds?.requires?.db?.kind).to.equal('postgres')
+    expect(packageJson.cds?.requires?.db?.vcap?.label).to.be.false
+    expect(packageJson.cds?.requires?.db?.vcap?.name).to.equal('postgres-external')
+  })
 })

--- a/postgres/test/tiny-sample/package.json
+++ b/postgres/test/tiny-sample/package.json
@@ -12,6 +12,15 @@
     "cdsc": {
       "defaultStringLength": 1000,
       "standardDatabaseFunctions": true
+    },
+    "requires": {
+      "db": {
+        "kind": "postgres",
+        "vcap": {
+          "label": false,
+          "name": "postgres-external"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
`cds.requires.db` settings from `package.json` are now copied to `package.json` generated with `cds build`. 