### PR TITLE
fix(`exists`): do not loose custom where

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -2196,7 +2196,7 @@ function cqn4sql(originalQuery, model) {
       next.pathExpressionInsideFilter ||
       (queryModifier && ['orderBy', 'groupBy', 'having', 'limit', 'offset'].some(key => key in queryModifier))
     ) {
-      SELECT.where = next.pathExpressionInsideFilter ? customWhere : []
+      SELECT.where = customWhere || []
       if (queryModifier) assignQueryModifiers(SELECT, queryModifier)
 
       const transformedExists = transformSubquery({ SELECT })

--- a/db-service/test/cqn4sql/where-exists.test.js
+++ b/db-service/test/cqn4sql/where-exists.test.js
@@ -1691,13 +1691,14 @@ describe('define additional query modifiers', () => {
 
   it('...for scoped queries', () => {
     const q = cds.ql`
-      SELECT from bookshop.Books[group by author.ID having count(*) > 5]:author { name }
+      SELECT from bookshop.Books[1 = 1 group by author.ID having count(*) > 5]:author { name }
     `;
     const expected = cds.ql`
       SELECT from bookshop.Authors as $a { $a.name }
       WHERE EXISTS (
         SELECT 1 from bookshop.Books as $B
         where $B.author_ID = $a.ID
+        and 1 = 1
         group by $B.author_ID
         having count(*) > 5
       )
@@ -1705,9 +1706,10 @@ describe('define additional query modifiers', () => {
     expect(cqn4sql(q, model)).to.deep.equal(expected);
   });
   it('...after exists predicate', () => {
-    const q = cds.ql`SELECT from bookshop.Authors { name } where exists books[group by author.ID having count(*) > 5]`
+    const q = cds.ql`SELECT from bookshop.Authors { name } where exists books[1=1 group by author.ID having count(*) > 5]`
     const expected = cds.ql`SELECT from bookshop.Authors as $A { $A.name } WHERE EXISTS (
       SELECT 1 from bookshop.Books as $b where $b.author_ID = $A.ID
+      and 1 = 1
       group by $b.author_ID
       having count(*) > 5
     )`


### PR DESCRIPTION
this was the case if other query modifiers have been provided in the infix filter