### PR TITLE
fix: updated fuzzy search syntax to include now require search mode 'text'

### DIFF
--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -141,14 +141,14 @@ const StandardFunctions = {
               `Invalid configuration ${rank} for @Search.ranking. HIGH, MEDIUM, LOW are supported values.`,
             )
         }
-        fuzzy += ` MINIMAL TOKEN SCORE ${e.element?.['@Search.fuzzinessThreshold'] || fuzzyIndex} SIMILARITY CALCULATION MODE 'search'`
+        fuzzy += ` MINIMAL TOKEN SCORE ${e.element?.['@Search.fuzzinessThreshold'] || fuzzyIndex} SIMILARITY CALCULATION MODE 'search' SEARCH MODE 'text'`
         // rewrite ref to xpr to mix in search config
         // ensure in place modification to reuse .toString method that ensures quoting
         e.xpr = [{ ref: e.ref }, fuzzy]
         delete e.ref
       })
     } else {
-      ref = `${ref} FUZZY MINIMAL TOKEN SCORE ${fuzzyIndex} SIMILARITY CALCULATION MODE 'search'`
+      ref = `${ref} FUZZY MINIMAL TOKEN SCORE ${fuzzyIndex} SIMILARITY CALCULATION MODE 'search' SEARCH MODE 'text'`
     }
 
     if (Array.isArray(arg.xpr)) {


### PR DESCRIPTION
With the latest HANA cloud version it is required to include the `SEARCH MODE 'text'` explicitly in the search query to prevent the search query from failing.