### PR TITLE
fix: Support `output` converter for `cast` column types

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -1029,7 +1029,7 @@ class CQN2SQLRenderer {
    * @returns {string} SQL
    */
   output_converter4(element, expr) {
-    const fn = element?.[this.class._convertOutput]
+    const fn = element && (element[this.class._convertOutput] ?? cds.builtin.types[element.type]?.[this.class._convertOutput])
     return fn?.(expr, element) || expr
   }
 


### PR DESCRIPTION
It is possible to `cast` the type of a column to a certain `cds` type. Currently the output converter is not properly applied when using `cast` inside a column definition. The type is properly inferred, but doesn't include the prototype chain that actual columns have. Which results in the converter missing from the `element` type definition.