### PR TITLE
chore(search): prepare for refs not contained in list

### DIFF
--- a/db-service/lib/cql-functions.js
+++ b/db-service/lib/cql-functions.js
@@ -21,7 +21,7 @@ const StandardFunctions = {
       val = sub[2] || sub[3] || ''
     }
     arg.val = val
-    const refs = ref.list
+    const refs = ref.list || [ref]
     return `(${refs.map(ref => this.expr({
       func: 'contains',
       args: [

--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -99,7 +99,7 @@ const StandardFunctions = {
           }
         })
 
-      const columns = ref.list
+      const columns = ref.list || [ref]
       const xpr = []
       for (const s of searchTerms) {
         const nestedXpr = []
@@ -118,7 +118,7 @@ const StandardFunctions = {
     // fuzziness config
     const fuzzyIndex = cds.env.hana?.fuzzy || 0.7
 
-    const csnElements = ref.list
+    const csnElements = ref.list || [ref]
     // if column specific value is provided, the configuration has to be defined on column level
     if (csnElements.some(e => e.element?.['@Search.ranking'] || e.element?.['@Search.fuzzinessThreshold'])) {
       csnElements.forEach(e => {


### PR DESCRIPTION
with updates to `cds.search` the search term may contain a single `ref` which is not necessarily wrapped in a `list` anymore.

---

for #1341