### PR TITLE
fix: set proper element link for path into fk

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1211,7 +1211,7 @@ function cqn4sql(originalQuery, model) {
       if(column.element && !isAssocOrStruct(column.element)) {
         columnAlias = column.as || leafAssocIndex === -1 ? columnAlias : column.ref.slice(leafAssocIndex - 1).map(idOnly).join('_')
         const res = { ref: [tableAlias, calculateElementName(column)], as: columnAlias }
-        setElementOnColumns(res, element)
+        setElementOnColumns(res, column.element)
         return [res]
       }
 

--- a/db-service/test/cqn4sql/column.element.test.js
+++ b/db-service/test/cqn4sql/column.element.test.js
@@ -162,4 +162,16 @@ describe('assign element onto columns with flat model', () => {
     // foreign key is part of flat model
     expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(TestPublisher.elements.publisherRenamedKey_notID)
   })
+
+  it('attaches foreign key and not the association as element', () => {
+    let query = cqn4sql(cds.ql`
+      SELECT from bookshop.Books as Books {
+        genre.parent.ID,
+        genre.parent as assoc
+      }
+    `, model)
+    const { Genres } = model.entities
+    expect(query.SELECT.columns[0]).to.have.property('element').that.eqls(Genres.elements.ID)
+    expect(query.SELECT.columns[1]).to.have.property('element').that.eqls(Genres.elements.parent_ID)
+  })
 })


### PR DESCRIPTION
→ in the changed `if` branch, we (re) set the leaf link again to the last association. However, the path in the column already drilled down to the respective element. We just need to propagate the already calculated element and attach it to the flat column.

Before this change, in this particular case the association (`parent` in the test) was erroneously set as `element` link for the column, which led to a faulty `cqn2sql` rendering down the line.