### PR TITLE
test(`@cds.search`): enable test with `to-many` deduplication

### DIFF
--- a/sqlite/test/search.test.js
+++ b/sqlite/test/search.test.js
@@ -21,10 +21,8 @@ describe('searching', () => {
     ])
     Authors['@cds.search.books'] = true
     const search = SELECT.from(Authors).search('Potter')
-    await cds.run(search)
-    // TODO: enable
-    // const res = await cds.run(search)
-    // expect(res).to.have.length(1)
+    const res = await cds.run(search)
+    expect(res).to.have.length(1)
   })
 
   // Skipping $search tests as the github action HANA version does not support SCORE


### PR DESCRIPTION
--> after #1341 has been merged, we can enable this test with the proper expectation