### PR TITLE
feat(`a2j`): enable path expression inside filter

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -1138,6 +1138,7 @@ function isNonForeignKeyNavigation(assoc, nextStep) {
 }
 
 function rejectNonFkNavigation(assoc, additionalInfo) {
+  return
   if (assoc.on) {
     throw new Error(`Unexpected unmanaged association “${assoc.name}” in filter expression of “${additionalInfo}”`)
   }


### PR DESCRIPTION
for join relevant paths within infix filters __always__ build a correlated subquery with the current join node and put the complete filter condition into the subqueries `where`.

I tested quite some examples with this approach and they all seem to do the trick. This approach also works for trivial conditions like `where books[author.ID = 5]` for which we would not necessarily need to do this.