### PR TITLE
fix: guard access to hana server version

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1171,7 +1171,7 @@ SELECT ${mixing} FROM JSON_TABLE(SRC.JSON, '$' COLUMNS(${extraction}) ERROR ON E
     }
 
     managed_extract(name, element, converter) {
-      const path = this.string(this.srv.server.major <= 2 ? `$.${name}` : `$[${JSON.stringify(name)}]`)
+      const path = this.string(this.srv?.server.major <= 2 ? `$.${name}` : `$[${JSON.stringify(name)}]`)
       return {
         extract: `${this.quote(name)} ${this.insertType4(element)} PATH ${path}, ${this.quote('$.' + name)} NVARCHAR(2147483647) FORMAT JSON PATH ${path}`,
         sql: converter(`NEW.${this.quote(name)}`),


### PR DESCRIPTION
[this change](https://github.com/cap-js/cds-dbs/pull/1263) introduced a dump as reported in `cap/issues/19316` - not sure under which circumstences though. However, this guard will lead to the old behavior (before https://github.com/cap-js/cds-dbs/pull/1263) in case the `this.srv` is not available.