### PR TITLE
chore: require expect, fix matrix

### DIFF
--- a/db-service/test/cqn4sql/nested-projections.test/expand-structures.spec.js
+++ b/db-service/test/cqn4sql/nested-projections.test/expand-structures.spec.js
@@ -4,6 +4,7 @@ const cds = require('@sap/cds')
 const { loadModel } = require('../helpers/model')
 
 const { expectCqn } = require('../helpers/expectCqn')
+const { expect } = cds.test
 
 let cqn4sql = require('../../../lib/cqn4sql')
 


### PR DESCRIPTION
this is otherwhise not always available and breaks our internal integration tests