### PR TITLE
chore(cqn4sql): always use cqn list for search columns

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -2248,7 +2248,7 @@ function cqn4sql(originalQuery, model) {
     const searchFunc = {
       func: 'search',
       args: [
-        searchIn.length === 1 ? searchIn[0] : { list: searchIn },
+        { list: searchIn },
         searchTerm.length === 1 && 'val' in searchTerm[0] ? searchTerm[0] : { xpr: searchTerm },
       ],
     }

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -338,9 +338,11 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     // it would sort by a constant boolean.
     const ranksSearch =
       cds.db?.kind === 'hana' && cds.env.hana?.fuzzy !== false && cds.env.hana?.fuzzy?.ranked_search !== false
-    // count queries do not need ranked search
-    const isCountQuery = columns?.length === 1 && columns[0].func === 'count'
-    const searchRank = ranksSearch && !isCountQuery && inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
+    // count queries or static values do not need ranked search
+    const isCountQuery = columns?.length === 1 && typeof columns[0] === 'object' && (columns[0].func === 'count' || 'val' in columns[0])
+    // a user-provided ORDER BY takes precedence over the search rank — don't inject the ranking then
+    const hasExplicitOrderBy = (orderBy || []).some(o => !o.implicit)
+    const searchRank = ranksSearch && !isCountQuery && !hasExplicitOrderBy && inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
     if (searchRank) {
       // precedence: user ordering, then rank, then the runtime's implicit key ordering
       const implicitAt = (orderBy || []).findIndex(o => o.implicit)

--- a/hana/test/search-ranking.test.js
+++ b/hana/test/search-ranking.test.js
@@ -51,11 +51,13 @@ describe('search ranking', () => {
     expect(ids[1]).to.eq(20)
   })
 
-  test('user-provided order by takes precedence over the search rank', async () => {
+  test('user-provided order by takes precedence', async () => {
     const { SearchAuthors } = cds.entities('search.ranking')
-    // by name desc: 'Weak' (20) before 'Strong' (10) — the OPPOSITE of the relevance order,
-    // so this only holds if user ordering wins and the rank is applied after it.
-    const res = await SELECT.from(SearchAuthors).columns('ID').search('Cat').orderBy('name desc')
+    const q = SELECT.from(SearchAuthors).columns('ID').search('Cat').orderBy('name desc')
+    const { sql } = cds.db.cqn2sql(q)
+    expect(sql).not.to.match(/ORDER BY .*\(SELECT max\(SCORE\(/i)
+
+    const res = await q
     expect(res.map(r => r.ID)).to.eql([20, 10])
   })
 
@@ -77,6 +79,24 @@ describe('search ranking', () => {
 
     const { sql } = cds.db.cqn2sql(q)
     expect(sql).to.not.match(/ORDER BY/i)
+  })
+
+  test('a search query that only selects static values is not ranked', () => {
+    const { SearchAuthors } = cds.entities('search.ranking')
+    // a single count element collapses all matches into one row -> nothing to rank
+    const q = SELECT.from(SearchAuthors).columns({ val: 1, param: false, as: '1' }).search('Cat')
+
+    const { sql } = cds.db.cqn2sql(q)
+    expect(sql).to.not.match(/ORDER BY/i)
+  })
+
+  test('a search query that selects * is ranked', () => {
+    const { SearchAuthors } = cds.entities('search.ranking')
+    // a single count element collapses all matches into one row -> nothing to rank
+    const q = SELECT.from(SearchAuthors).columns('*').search('Cat')
+
+    const { sql } = cds.db.cqn2sql(q)
+    expect(sql).to.match(/ORDER BY/i)
   })
 
   test('opting out via hana.fuzzy.ranked_search = false skips the ranking', async () => {


### PR DESCRIPTION
The current implementation for `cds.hana.fuzzy: false` always expects a cqn list of columns which is only the case if multiple columns are searched.

Imo, it makes it easier to implement against the stable representation as cqn list no matter how many columns are searched. Also (future use case) if app developers want to oversteer the default behavior, the structure is easier to use/document.

@patricebender I'll also adapt the tests if you agree with the design