### PR TITLE
chore: disable hdb v2 compression feature

### DIFF
--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -35,6 +35,7 @@ class HDBDriver extends driver {
   constructor(creds) {
     creds = {
       fetchSize: 1 << 16, // V8 default memory page size
+      compress: false, // compression is disabled by default to avoic cpu overhead
       ...creds,
     }
 


### PR DESCRIPTION
compression is cpu intense and therefore disabled by default.

also our internal tests should issues with failed packet decrompession.
I will try to create an issue on hdb side for that.