### PR TITLE
[PoC]: Database level Data Integration

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:16-bullseye
+
+RUN apt-get update && apt-get -y install postgresql-16-http

--- a/postgres/lib/PostgresService.js
+++ b/postgres/lib/PostgresService.js
@@ -622,6 +622,7 @@ GROUP BY k
         DROP USER IF EXISTS "${creds.user}";
         CREATE GROUP "${creds.usergroup}";
         CREATE USER "${creds.user}" WITH CREATEROLE IN GROUP "${creds.usergroup}" PASSWORD '${creds.user}';
+        ALTER USER "${creds.user}" SUPERUSER;
         GRANT "${creds.usergroup}" TO "${creds.user}" WITH ADMIN OPTION;
       `)
       await this.exec(`CREATE DATABASE "${creds.database}" OWNER="${creds.user}" TEMPLATE=template0`)

--- a/postgres/pg-stack.yml
+++ b/postgres/pg-stack.yml
@@ -3,13 +3,13 @@ version: '3.1'
 
 services:
   db:
-    image: postgres:16-alpine
+    build: .
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres
     ports:
       - '5432:5432'
-    command: ['postgres', '-c', 'log_statement=all']
+    command: postgres
   ### use at will at dev time - save mem on ci time
   # adminer:
   #   image: adminer

--- a/postgres/test/integration.cds
+++ b/postgres/test/integration.cds
@@ -1,0 +1,6 @@
+using {CatalogService} from '../../test/bookshop/apis/CatalogService';
+
+service integration {
+  entity Genres as projection on CatalogService.Genres;
+  entity Books  as projection on CatalogService.ListOfBooks;
+}

--- a/postgres/test/integration.test.js
+++ b/postgres/test/integration.test.js
@@ -1,0 +1,86 @@
+const cds = require('../../test/cds.js')
+
+describe('Data Integration', () => {
+  before(() => {
+    cds.env.features.ieee754compatible = true
+  })
+
+  const _deploy = cds.deploy
+  cds.deploy = async function () {
+    const sys = await cds.connect.to('sys', {
+      ...cds.requires.db,
+      credentials: {
+        ...cds.db.options.credentials,
+        user: `${cds.db.options.credentials.database}_USER_MANAGER`,
+        password: `${cds.db.options.credentials.database}_USER_MANAGER`,
+      },
+    })
+    await sys.run(`CREATE EXTENSION IF NOT EXISTS http SCHEMA public`)
+
+    const db = await cds.connect.to('db')
+
+    const convertInput = cds.db.class.CQN2SQL._convertInput ?? new cds.db.class.CQN2SQL().class._convertInput
+
+    for (const name in cds.model.definitions) {
+      const entity = cds.model.definitions[name]
+      if (!entity.__REMOTE__) continue
+
+      const columns = []
+      function add(element, name = element.name) {
+        if (element.isAssociation) {
+          for (const key of element.keys || []) {
+            if (key.ref.length > 1) { cds.error`Association with deep foreign key currently not supported!!!` }
+            if (!entity.elements[`${name}_${key.ref[0]}`]) add(element._target.elements[key.ref[0]], `${name}_${key.ref[0]}`)
+          }
+        } else {
+          const converter = element[convertInput] || (a => a)
+          columns.push(`${converter(`value->>'${name}'`)} as ${name}`)
+        }
+      }
+
+      for (const name in entity.elements) add(entity.elements[name])
+
+      const from = `jsonb_array_elements((SELECT (content::jsonb->>'value')::jsonb FROM public.http_get('http://host.docker.internal:4004/browse/${name.split('.').at(-1)}?src=postgres') LIMIT 1))`
+
+      await db.run(`CREATE VIEW ${entity} AS SELECT ${columns} FROM ${from}`)
+    }
+
+    return _deploy.apply(this, arguments)
+  }
+
+  cds.on('loaded', (csn) => {
+    const remotes = []
+    for (const name in csn.definitions) {
+      const service = csn.definitions[name]
+      if (service.kind !== 'service') continue
+      if (service['@data.product']) remotes.push(name)
+    }
+
+    for (const name in csn.definitions) {
+      const entity = csn.definitions[name]
+      if (entity.kind !== 'entity') continue
+      const service = remotes.find(srv => name.startsWith(srv))
+      if (!service) continue
+      entity.__REMOTE__ = true
+      entity['@cds.persistence.exists'] = true
+    }
+  })
+
+  const { expect, GET } = cds.test(__dirname, 'integration.cds')
+
+  test('debug', async () => {
+    const [db, org] = await Promise.all([
+      GET`/odata/v4/integration/Books`,
+      GET`http://localhost:4004/browse/ListOfBooks?src=test`,
+    ])
+    expect(db.data.value).deep.eq(org.data.value)
+  })
+
+  test('expand', async () => {
+    const [db, org] = await Promise.all([
+      GET`/odata/v4/integration/Books?$expand=genre`,
+      GET`http://localhost:4004/browse/ListOfBooks?$expand=genre&src=test`,
+    ])
+    expect(db.data.value).deep.eq(org.data.value)
+  })
+})

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -1,3 +1,5 @@
+const child_process = require('node:child_process')
+
 const { SQLService } = require('@cap-js/db-service')
 const cds = require('@sap/cds')
 const sqlite = require('better-sqlite3')
@@ -41,6 +43,13 @@ class SQLiteService extends SQLService {
         dbc.function('hour', deterministic, d => d === null ? null : toDate(d, true).getUTCHours())
         dbc.function('minute', deterministic, d => d === null ? null : toDate(d, true).getUTCMinutes())
         dbc.function('second', deterministic, d => d === null ? null : toDate(d, true).getUTCSeconds())
+
+        let http_get = url => child_process.execSync(`node -e "fetch('${url}').then(r => r.body.pipeTo(require('node:stream').Writable.toWeb(process.stdout)))"`)
+        try {
+          child_process.execSync(`curl --help`)
+          http_get = url => child_process.execSync(`curl "${url}"`, { stdio: ['ignore', 'pipe', 'ignore'] })
+        } catch { }
+        dbc.function('http_get', deterministic, http_get)
         if (!dbc.memory) dbc.pragma('journal_mode = WAL')
         return dbc
       },

--- a/sqlite/test/integration.cds
+++ b/sqlite/test/integration.cds
@@ -1,0 +1,6 @@
+using {CatalogService} from '../../test/bookshop/apis/CatalogService';
+
+service integration {
+  entity Genres as projection on CatalogService.Genres;
+  entity Books  as projection on CatalogService.ListOfBooks;
+}

--- a/sqlite/test/integration.test.js
+++ b/sqlite/test/integration.test.js
@@ -1,0 +1,76 @@
+const cds = require('../../test/cds.js')
+
+describe('Data Integration', () => {
+  before(() => {
+    cds.env.features.ieee754compatible = true
+  })
+
+  const _deploy = cds.deploy
+  cds.deploy = async function () {
+    const db = await cds.connect.to('db')
+
+    const convertInput = cds.db.class.CQN2SQL._convertInput ?? new cds.db.class.CQN2SQL().class._convertInput
+
+    for (const name in cds.model.definitions) {
+      const entity = cds.model.definitions[name]
+      if (!entity.__REMOTE__) continue
+
+      const columns = []
+      function add(element, name = element.name) {
+        if (element.isAssociation) {
+          for (const key of element.keys || []) {
+            if (key.ref.length > 1) { cds.error`Association with deep foreign key currently not supported!!!` }
+            if (!entity.elements[`${name}_${key.ref[0]}`]) add(element._target.elements[key.ref[0]], `${name}_${key.ref[0]}`)
+          }
+        } else {
+          const converter = element[convertInput] || (a => a)
+          columns.push(`${converter(`value->>'$.${JSON.stringify(name)}'`)} as ${name}`)
+        }
+      }
+
+      for (const name in entity.elements) add(entity.elements[name])
+
+      const from = `json_each(http_get('http://localhost:4004/browse/${name.split('.').at(-1)}?src=sqlite')->>'$.value')`
+
+      await db.run(`CREATE VIEW ${entity} AS SELECT ${columns} FROM ${from}`)
+    }
+
+    return _deploy.apply(this, arguments)
+  }
+
+  cds.on('loaded', (csn) => {
+    const remotes = []
+    for (const name in csn.definitions) {
+      const service = csn.definitions[name]
+      if (service.kind !== 'service') continue
+      if (service['@data.product']) remotes.push(name)
+    }
+
+    for (const name in csn.definitions) {
+      const entity = csn.definitions[name]
+      if (entity.kind !== 'entity') continue
+      const service = remotes.find(srv => name.startsWith(srv))
+      if (!service) continue
+      entity.__REMOTE__ = true
+      entity['@cds.persistence.exists'] = true
+    }
+  })
+
+  const { expect, GET } = cds.test(__dirname, 'integration.cds')
+
+  test('simple', async () => {
+    const [db, org] = await Promise.all([
+      GET`/odata/v4/integration/Books`,
+      GET`http://localhost:4004/browse/ListOfBooks?src=test`,
+    ])
+    expect(db.data.value).deep.eq(org.data.value)
+  })
+
+  test('expand', async () => {
+    const [db, org] = await Promise.all([
+      GET`/odata/v4/integration/Books?$expand=genre`,
+      GET`http://localhost:4004/browse/ListOfBooks?$expand=genre&src=test`,
+    ])
+    expect(db.data.value).deep.eq(org.data.value)
+  })
+})

--- a/test/bookshop/apis/CatalogService/cds-plugin.js
+++ b/test/bookshop/apis/CatalogService/cds-plugin.js
@@ -1,0 +1,1 @@
+// just a tag file for plug & play

--- a/test/bookshop/apis/CatalogService/index.cds
+++ b/test/bookshop/apis/CatalogService/index.cds
@@ -1,0 +1,3 @@
+// This file acts as a central facade to exported service definitions.
+// You can modify it to tweak things, without your changes being overridden.
+using from './services';

--- a/test/bookshop/apis/CatalogService/package.json
+++ b/test/bookshop/apis/CatalogService/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@capire/bookshop-CatalogService",
+  "version": "1.0.0",
+  "cds": {
+    "requires": {
+      "CatalogService": true
+    }
+  }
+}

--- a/test/bookshop/apis/CatalogService/services.csn
+++ b/test/bookshop/apis/CatalogService/services.csn
@@ -1,0 +1,289 @@
+{
+  "definitions": {
+    "CatalogService": {
+      "@source": "srv/cat-service.cds",
+      "kind": "service",
+      "@path": "/browse",
+      "@data.product": true,
+      "@cds.external": 2
+    },
+    "CatalogService.ListOfBooks": {
+      "kind": "entity",
+      "@readonly": true,
+      "elements": {
+        "createdAt": {
+          "@cds.on.insert": {
+            "=": "$now"
+          },
+          "@Core.Immutable": true,
+          "@title": "{i18n>CreatedAt}",
+          "@readonly": true,
+          "type": "cds.Timestamp"
+        },
+        "modifiedAt": {
+          "@cds.on.insert": {
+            "=": "$now"
+          },
+          "@cds.on.update": {
+            "=": "$now"
+          },
+          "@title": "{i18n>ChangedAt}",
+          "@readonly": true,
+          "type": "cds.Timestamp"
+        },
+        "ID": {
+          "key": true,
+          "type": "cds.Integer"
+        },
+        "title": {
+          "type": "cds.String",
+          "length": 111
+        },
+        "author": {
+          "type": "cds.String",
+          "length": 111
+        },
+        "genre": {
+          "type": "cds.Association",
+          "target": "CatalogService.Genres",
+          "default": {
+            "val": 10
+          }
+        },
+        "stock": {
+          "type": "cds.Integer"
+        },
+        "price": {
+          "type": "cds.Decimal"
+        },
+        "currency": {
+          "@title": "{i18n>Currency}",
+          "@description": "{i18n>CurrencyCode.Description}",
+          "type": "Currency",
+          "target": "CatalogService.Currencies"
+        },
+        "image": {
+          "@Core.MediaType": "image/png",
+          "type": "cds.LargeBinary"
+        },
+        "footnotes": {
+          "items": {
+            "type": "cds.String"
+          }
+        },
+        "authorsAddress": {
+          "type": "cds.String"
+        }
+      }
+    },
+    "CatalogService.Genres": {
+      "kind": "entity",
+      "@cds.autoexposed": true,
+      "@cds.autoexpose": true,
+      "@cds.persistence.skip": "if-unused",
+      "@cds.odata.valuelist": true,
+      "elements": {
+        "name": {
+          "@title": "{i18n>Name}",
+          "type": "cds.String",
+          "length": 255
+        },
+        "descr": {
+          "@title": "{i18n>Description}",
+          "type": "cds.String",
+          "length": 1000
+        },
+        "ID": {
+          "key": true,
+          "type": "cds.Integer"
+        },
+        "parent": {
+          "type": "cds.Association",
+          "target": "CatalogService.Genres"
+        },
+        "children": {
+          "type": "cds.Composition",
+          "cardinality": {
+            "max": "*"
+          },
+          "target": "CatalogService.Genres",
+          "on": [
+            {
+              "ref": [
+                "children",
+                "parent"
+              ]
+            },
+            "=",
+            {
+              "ref": [
+                "$self"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CatalogService.Currencies": {
+      "kind": "entity",
+      "@cds.autoexposed": true,
+      "@cds.autoexpose": true,
+      "@cds.persistence.skip": "if-unused",
+      "@cds.odata.valuelist": true,
+      "elements": {
+        "name": {
+          "@title": "{i18n>Name}",
+          "type": "cds.String",
+          "length": 255
+        },
+        "descr": {
+          "@title": "{i18n>Description}",
+          "type": "cds.String",
+          "length": 1000
+        },
+        "code": {
+          "@title": "{i18n>CurrencyCode}",
+          "@Common.Text": {
+            "=": "name"
+          },
+          "key": true,
+          "type": "cds.String",
+          "length": 3
+        },
+        "symbol": {
+          "@title": "{i18n>CurrencySymbol}",
+          "type": "cds.String",
+          "length": 5
+        },
+        "minorUnit": {
+          "@title": "{i18n>CurrencyMinorUnit}",
+          "type": "cds.Int16"
+        }
+      }
+    },
+    "CatalogService.Books": {
+      "kind": "entity",
+      "@readonly": true,
+      "elements": {
+        "createdAt": {
+          "@cds.on.insert": {
+            "=": "$now"
+          },
+          "@Core.Immutable": true,
+          "@title": "{i18n>CreatedAt}",
+          "@readonly": true,
+          "type": "cds.Timestamp"
+        },
+        "modifiedAt": {
+          "@cds.on.insert": {
+            "=": "$now"
+          },
+          "@cds.on.update": {
+            "=": "$now"
+          },
+          "@title": "{i18n>ChangedAt}",
+          "@readonly": true,
+          "type": "cds.Timestamp"
+        },
+        "ID": {
+          "key": true,
+          "type": "cds.Integer"
+        },
+        "title": {
+          "type": "cds.String",
+          "length": 111
+        },
+        "descr": {
+          "type": "cds.String",
+          "length": 1111
+        },
+        "author": {
+          "type": "cds.String",
+          "length": 111
+        },
+        "genre": {
+          "type": "cds.Association",
+          "target": "CatalogService.Genres",
+          "default": {
+            "val": 10
+          }
+        },
+        "stock": {
+          "type": "cds.Integer"
+        },
+        "price": {
+          "type": "cds.Decimal"
+        },
+        "currency": {
+          "@title": "{i18n>Currency}",
+          "@description": "{i18n>CurrencyCode.Description}",
+          "type": "Currency",
+          "target": "CatalogService.Currencies"
+        },
+        "image": {
+          "@Core.MediaType": "image/png",
+          "type": "cds.LargeBinary"
+        },
+        "footnotes": {
+          "items": {
+            "type": "cds.String"
+          }
+        },
+        "authorsAddress": {
+          "type": "cds.String"
+        }
+      }
+    },
+    "CatalogService.submitOrder": {
+      "kind": "action",
+      "params": {
+        "book": {
+          "type": {
+            "ref": [
+              "CatalogService.Books",
+              "ID"
+            ]
+          }
+        },
+        "quantity": {
+          "type": "cds.Integer"
+        }
+      },
+      "returns": {
+        "elements": {
+          "stock": {
+            "type": "cds.Integer"
+          }
+        }
+      }
+    },
+    "CatalogService.OrderedBook": {
+      "kind": "event",
+      "elements": {
+        "book": {
+          "type": {
+            "ref": [
+              "CatalogService.Books",
+              "ID"
+            ]
+          }
+        },
+        "quantity": {
+          "type": "cds.Integer"
+        },
+        "buyer": {
+          "type": "cds.String"
+        }
+      }
+    }
+  },
+  "meta": {
+    "creator": "CDS Compiler v6.3.5",
+    "flavor": "inferred",
+    "minified": true
+  },
+  "$version": "2.0",
+  "requires": [
+    "@sap/cds/common"
+  ]
+}


### PR DESCRIPTION
## Concept

Wouldn't it be nice if your database could connect to other systems to use their data ? To do this using SAP HANA Cloud it is possible to use a `virtual table`. It functions like a `view` on top of a `table`/`view` in a `remote source`. The underlying functioning of a `remote source` is a specific `ODBC` driver. One of the more interesting drivers is the `OData` driver. Which doesn't use a proprietary database connection, but rather relies on `HTTP` to fetch the data out of a remote system.

With the current `INSERT` and `UPSERT` implementation being `JSON` based. The obvious next step was to check whether `postgres` and `sqlite` could trigger an `HTTP` request. For `sqlite` with the custom functions being simple javascript functions it was clearly possible. With `postgres` there are a lot of extensions so of course [pgsql-http](https://github.com/pramsey/pgsql-http) exists.

## Proof of Concept

First thing we need is the "other" system. Simple `cds export` the catalog service of the bookshop.

```sh
cd test/bookshop
cds export ./srv/cat-service.cds
```

Next consume the `data product` in the test model.

```cds
using {CatalogService} from '../../test/bookshop/apis/CatalogService';

service integration {
  entity Genres as projection on CatalogService.Genres;
  entity Books  as projection on CatalogService.ListOfBooks;
}
```

Using the `@data.product` annotation it is possible to identify the entities that are located in the "other" system. Making sure to annotate the entities with `cds.persistence.exists` so that the compiler will expect them to already be deployed. So ensure to make a view which uses the `HTTP` function of the database to download the data.

```sql
SELECT * FROM http('http://localhost:4004/browse/ListOfBooks')->>'$.value'
```

If only it was so simple. All the `JSON` functions produce `string` values as types have to be consistent. This is where the `INSERT` logic comes into play. By looking at the `elements` of the entity it is possible to use the `input converter` to create the correct `SQL` data type out of the `JSON` string values. Allowing the database to process the data as if it was provided by a native `view`.

```sql
SELECT cast(value->>'$.ID' as Integer) AS ID, ... FROM json_each(http('http://localhost:4004/browse/ListOfBooks')->>'$.value')
```

You might at this point have started to ask "why ?". As there is also `service level data integration` which does pretty much the same thing. Well the `@cap-js/cds-dbs` can do a lot of advanced features. Which are non trivial to re implement in the javascript layer. Additionally any javascript implementation of these features wouldn't have a "good" performance. It would both cost a lot of CPU cycles and a lot of memory to achieve the same results. As `HANA`, `postgres` and `sqlite` all are written in `C/C++` with their primary focus on optimizing relational data manipulation. So when a query has to do a `where`, `join`, `group by`, `order by`, `path expression` or `expand` the databases have all the optimized tools available in native implementations.

```javascript
// postgres / sqlite
await cds.ql`SELECT FROM ${Books} { * }`
// [odata] - GET /browse/ListOfBooks
await cds.ql`SELECT FROM ${Books} { *, genre { * } }`
// [odata] - GET /browse/ListOfBooks
// [odata] - GET /browse/Genres

// SAP HANA Cloud OData remote source behavior
await cds.ql`SELECT FROM ${Books} { * }`
// [odata] - GET /browse/ListOfBooks
await cds.ql`SELECT FROM ${Books} { ID }`
// [odata] - GET /browse/ListOfBooks?$select=ID
await cds.ql`SELECT FROM ${Books} { *, genre { * } }`
// [odata] - GET /browse/ListOfBooks?$expand=genre
```

So while this is a very simple solution it provides a lot of power. Additionally in the case of `postgres` it is possible to take a more robust implementation by using [foreign data wrappers](https://wiki.postgresql.org/wiki/Foreign_data_wrappers). Which comes with the same benefits (and drawbacks) as SAP HANA Cloud remote sources.

## FYI

In the case of `sqlite` the `http` function is defined as `deterministic`. Depending on the interpretation of the word `deterministic` the function could only be called a single time, but in reality the function will be called once per query. Therefor it is safe to have it defined as `deterministic`. With the additional benefit that it will only be called once for an expand instead of once for each row.