### PR TITLE
fix: introduce repository.url in package.json

### DIFF
--- a/hana/package.json
+++ b/hana/package.json
@@ -3,6 +3,10 @@
   "version": "2.4.0",
   "description": "CDS database service for SAP HANA",
   "homepage": "https://cap.cloud.sap/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cap-js/cds-dbs.git"
+  },
   "keywords": [
     "CAP",
     "CDS",


### PR DESCRIPTION
required for provenance publication, see https://github.com/cap-js/cds-dbs/actions/runs/19700654725/job/56435842449