### PR TITLE
fix: Ensure to uses `REAL` for `Decimal` values

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -1203,7 +1203,10 @@ class CQN2SQLRenderer {
       .map((x, i) => {
         if (x in { LIKE: 1, like: 1 } && is_regexp(xpr[i + 1]?.val)) return this.operator('regexp')
         if (typeof x === 'string') return this.operator(x, i, xpr)
-        if (x.xpr && !x.func) return `(${this.xpr(x)})`
+        if (x.xpr && !x.func) {
+          const wrap = x.cast ? sql => `cast(${sql} as ${this.type4(x.cast)})` : sql => sql
+          return wrap(`(${this.xpr(x)})`)
+        }
         else return this.expr(x)
       })
       .join(' ')

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -5,19 +5,8 @@ const cds = require('@sap/cds')
 const JoinTree = require('./join-tree')
 const { pseudos } = require('./pseudos')
 const { isCalculatedOnRead, getImplicitAlias, getModelUtils, defineProperty, hasOwnSkip } = require('../utils')
-const cdsTypes = cds.linked({
-  definitions: {
-    Timestamp: { type: 'cds.Timestamp' },
-    DateTime: { type: 'cds.DateTime' },
-    Date: { type: 'cds.Date' },
-    Time: { type: 'cds.Time' },
-    String: { type: 'cds.String' },
-    Decimal: { type: 'cds.Decimal' },
-    Integer: { type: 'cds.Integer' },
-    Boolean: { type: 'cds.Boolean' },
-  },
-}).definitions
-for (const each in cdsTypes) cdsTypes[`cds.${each}`] = cdsTypes[each]
+const cdsTypes = cds.builtin.types
+
 /**
  * @param {import('@sap/cds/apis/cqn').Query|string} originalQuery
  * @param {import('@sap/cds/apis/csn').CSN} [model]
@@ -974,7 +963,7 @@ function infer(originalQuery, model) {
         let fkIndex = assoc.keys?.findIndex(key => key.ref.every((step, j) => column.ref[i + j] === step))
         // foreign key access without filters never join relevant
         if (fkIndex !== -1) {
-          if(column.ref.slice(i).some(s => s.where)) continue // probably join relevant later on
+          if (column.ref.slice(i).some(s => s.where)) continue // probably join relevant later on
           fkAccess = true
           assoc = null
           continue
@@ -1091,7 +1080,7 @@ function infer(originalQuery, model) {
     if ($refLinks?.[$refLinks.length - 1].definition.elements)
       // no cast on structure
       cds.error`Structured elements can't be cast to a different type`
-    thing.cast = cdsTypes[cast.type] || cast
+    thing.cast = (cdsTypes[cast.type] && new cdsTypes[cast.type].constructor(cast)) || cast
     return thing.cast
   }
 

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -274,6 +274,7 @@ class SQLiteService extends SQLService {
     // Used for CREATE TABLE statements
     static TypeMap = {
       ...super.TypeMap,
+      Decimal: () => `REAL`,
       Binary: e => `BINARY_BLOB(${e.length || 5000})`,
       Date: () => 'DATE_TEXT',
       Time: () => 'TIME_TEXT',

--- a/test/cds.js
+++ b/test/cds.js
@@ -105,8 +105,8 @@ cds.test = Object.setPrototypeOf(function () {
   ret.data.autoIsolation(true)
 
   global.beforeAll(async () => {
-    if (ret.data._autoIsolation && !cds.options.in_memory && !ret.data._deployed) {
-      ret.data._deployed = cds.deploy(cds.options.from[0])
+    if (ret.data._autoIsolation && !cds.options?.in_memory && !ret.data._deployed) {
+      ret.data._deployed = cds.deploy(cds.options?.from?.[0] || '*')
       await ret.data._deployed
     }
   })

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -188,6 +188,30 @@ describe('SELECT', () => {
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
+    test('select div with cast behaviors', async () => {
+      const { number } = cds.entities('basic.literals')
+
+      const cqn = cds.ql`SELECT
+        integer32 / integer64 as div2int:Integer,
+        CAST(integer32 as Decimal) / CAST(integer64 as Decimal) as div2int_decimal:Decimal(2,1),
+
+        double / decimal as div2double:Decimal(2,1),
+        CAST(double as Integer) / CAST(decimal as Integer) as div2double_int:Integer,
+
+        float / decimal as div2decimal:Decimal(2,1),
+        CAST(float as Integer) / CAST(decimal as Integer) as div2decimal_int:Integer
+      FROM ${number}`
+      const res = await cqn
+      expect(res).to.match([{
+        div2int: 0,
+        div2int_decimal: '0.5',
+        div2double: '0.5',
+        div2double_int: 0,
+        // div2decimal: '0.5', // broken on SQLite as DECIMAL is NUMERIC and not REAL
+        div2decimal_int: 0,
+      }])
+    })
+
     test('select sub select', async () => {
       const { string } = cds.entities('basic.projection')
       const cqn = cds.ql`SELECT (SELECT string FROM ${string} as sub WHERE sub.string = root.string) as string FROM ${string} as root`

--- a/test/compliance/resources/db/data/basic.literals-number.csv
+++ b/test/compliance/resources/db/data/basic.literals-number.csv
@@ -1,0 +1,2 @@
+integer32;integer64;double;float;decimal;
+2;4;2;2;4;


### PR DESCRIPTION
Currently when using `cds.Decimal` values on `SQLite` it results in the table using `NUMERIC` as the column type. This type is very similar to the javascript `Number` type, but with one primary difference that it behaves based upon the native type of the value.

```javascript
// javascript
1   / 2   // 0.5
1.0 / 2.0 // 0.5
1n  / 2n  // 0n
```

```C
// C/C++
1   / 2   // 0
1.0 / 2.0 // 0.5
```

So SQLite has the same behavior as `C`, but with the dynamic typing of `javascript` resulting in inconsistent and unpredictable behaviors. By explicitly defining `Decimal` as a `REAL` it will behave consistently as the floating number that it is supposed to be.