### PR TITLE
fix: include missing `key` columns for `UPSERT` from `SELECT` queries

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -1448,11 +1448,13 @@ class CQN2SQLRenderer {
     const keyZero = keys[0] && this.quote(keys[0])
 
     return [...columns, ...requiredColumns].map(({ name, sql }) => {
+      const isNull = sql === 'NULL'
+      const json = !sql
+
       const element = elements?.[name] || {}
 
       const converter = a => element[_convertInput]?.(a, element) || a
       let extract
-      const json = !sql
       if (!sql) {
         ({ sql, extract } = this.managed_extract(name, element, converter))
       } else {
@@ -1470,8 +1472,8 @@ class CQN2SQLRenderer {
 
       const qname = this.quote(name)
 
-      const insert = onInsert ? json ? this.managed_default(name, converter(onInsert), sql) : onInsert : sql
-      const update = onUpdate ? json ? this.managed_default(name, converter(onUpdate), sql) : onUpdate : sql
+      const insert = onInsert ? json ? this.managed_default(name, converter(onInsert), sql) : !isNull ? sql : onInsert : sql
+      const update = onUpdate ? json ? this.managed_default(name, converter(onUpdate), sql) : !isNull ? sql : onUpdate : sql
       const upsert = keyZero && (
         // upsert requires the keys to be provided for the existance join (default values optional)
         element.key

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -851,7 +851,7 @@ class HANAService extends SQLService {
       // temporal data
       keys.push(...ObjectKeys(q._target.elements).filter(e => q._target.elements[e]['@cds.valid.from']))
 
-      const managed = this.managed(
+      const managed = this._managed || this.managed(
         this.columns.map(c => ({ name: c })),
         elements
       )
@@ -871,10 +871,21 @@ SELECT ${mixing} FROM JSON_TABLE(SRC.JSON, '$' COLUMNS(${extraction}) ERROR ON E
       } else {
         const src = this.cqn4sql(UPSERT.from || UPSERT.as)
         if (this.values) this.values = []
+        const missingKeys = this._managed.slice(src.SELECT.columns.length)
+          .filter(c => keys.includes(c.name))
+          .map(c => ({
+            __proto__: this.managed_session_context(elements[c.name]['@cds.on.insert']?.['='])
+              || this.managed_session_context(elements[c.name].default?.ref?.[0])
+              || (elements[c.name].default && { __proto__: elements[c.name].default, param: false })
+              || { val: null, param: false },
+            as: c.name,
+          }))
         const aliasedQuery = cds.ql.SELECT
-          .columns(src.SELECT.columns
-            .map((c, i) => ({ ref: [this.column_name(c)], as: this.columns[i] }))
-          )
+          .columns([
+            ...src.SELECT.columns
+              .map((c, i) => ({ ref: [this.column_name(c)], as: this.columns[i] })),
+            ...missingKeys,
+          ])
           .from(src)
         sql = `SELECT ${mixing} FROM (${this.SELECT(aliasedQuery)}) AS NEW LEFT JOIN ${this.quote(entity)} AS OLD ON ${keyCompare}`
         this.entries = [this.values]

--- a/hana/package.json
+++ b/hana/package.json
@@ -20,10 +20,8 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "(([ -z \"${HANA_HOST}\" ] && npm start) || true) && npm run test:plain && npm run test:bookshop:quoted",
-    "test:bookshop:quoted": "cds_sql_names=quoted cds-test bookshop",
-    "test:plain": "cds-test",
-    "test:remote": "cds-test",
+    "test": "sh -c '(([ -z \"${HANA_HOST}\" ] && npm start) || true) && (([ -z $1 ] && npm run test:ci) || ([ -n $1 ] && cds-test $@))' --",
+    "test:ci": "cds-test && cds_sql_names=quoted cds-test bookshop",
     "start": "npm run start:hce || npm run start:hxe",
     "start:hce": "cd ./tools/docker/hce/ && ./start.sh",
     "start:hxe": "cd ./tools/docker/hxe/ && ./start.sh"


### PR DESCRIPTION
It is possible to leave out `key` columns which have a `default` or `cds.on.insert` value when calling `UPSERT`. This case was not properly considered when using `UPSERT` from `SELECT` queries. This PR ensures to include all `key` columns into the source `SELECT` query.

## behavior

In the case of `HANA` the result of the source `SELECT` is not allowed to have duplicate `key` values. As for `postgres` and `sqlite` they leverage the emergent behavior of an `UPSERT` that the rows are allowed to overwrite each other. This is actually an undefined behavior for `postgres` and `sqlite`.

As example book `1` is being updated inside a single `UPSERT` statement twice. There is no guarantee that `title 2` will be the final result. It is just as valid for `title 1` to be the final result. To prevent these edge cases `HANA` will throw an error that `ID` is violating an unique constraint even before applying the `UPSERT` behavior which invalidates the unique constraint restriction.

```sql
UPSERT INTO Books (
  SELECT 1 as ID, 'title 1' as title
UNION ALL
  SELECT 1 as ID, 'title 2' as title
)
```