### PR TITLE
test: filtered select one from entity with composite-key

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -176,18 +176,20 @@ class HANAService extends SQLService {
       const resultQuery = query.clone()
       resultQuery.SELECT.forUpdate = undefined
       resultQuery.SELECT.forShareLock = undefined
+      
       const keys = Object.keys(req.target?.keys || {})
+      
       if (keys.length && query.SELECT.forUpdate?.ignoreLocked) {
-        // Exit early when ALL existing rows are locked
+        // Exit early when no row was found in the inital query
         if (rows.length === 0) return isOne ? undefined : []
         
-        // REVISIT: No Support for count
-        // Filter for those rows that are not locked
+        // Filter for those rows that were locked by the initial query
         const left = { list: keys.map(k => ({ ref: [k] })) }
         const right = { list: rows.map(r => ({ list: keys.map(k => ({ val: r[k.toUpperCase()] })) })) }
         resultQuery.SELECT.limit = undefined
         resultQuery.SELECT.where = [left, 'in', right]
       }
+      
       return this.onSELECT({ query: resultQuery, __proto__: req })
     }
 

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -147,11 +147,9 @@ class HANAService extends SQLService {
     }
 
     const isLockQuery = query.SELECT.forUpdate || query.SELECT.forShareLock
-    if (!isLockQuery) {
-      // REVISIT: disable this for queries like (SELECT 1)
-      // Will return multiple rows with objects inside
-      query.SELECT.expand = 'root'
-    }
+    // REVISIT: disable this for queries like (SELECT 1)
+    // Will return multiple rows with objects inside
+    if (!isLockQuery) query.SELECT.expand = 'root'
 
     const { cqn, sql, temporary, blobs, withclause, values } = this.cqn2sql(query, data)
     delete query.SELECT.expand
@@ -164,6 +162,7 @@ class HANAService extends SQLService {
     let sqlScript = isLockQuery || isSimple ? sql : this.wrapTemporary(temporary, withclause, blobs)
     const { hints } = query.SELECT
     if (hints) sqlScript += ` WITH HINT (${hints.join(',')})`
+    
     let rows
     if (values?.length || blobs.length > 0 || isStream) {
       const ps = await this.prepare(sqlScript, blobs.length)
@@ -179,9 +178,11 @@ class HANAService extends SQLService {
       resultQuery.SELECT.forShareLock = undefined
       const keys = Object.keys(req.target?.keys || {})
       if (keys.length && query.SELECT.forUpdate?.ignoreLocked) {
+        // Exit early when ALL existing rows are locked
         if (rows.length === 0) return isOne ? undefined : []
-        // REVISIT: No support for count
-        // where [keys] in [values]
+        
+        // REVISIT: No Support for count
+        // Filter for those rows that are not locked
         const left = { list: keys.map(k => ({ ref: [k] })) }
         const right = { list: rows.map(r => ({ list: keys.map(k => ({ val: r[k.toUpperCase()] })) })) }
         resultQuery.SELECT.limit = undefined

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -179,6 +179,7 @@ class HANAService extends SQLService {
       resultQuery.SELECT.forShareLock = undefined
       const keys = Object.keys(req.target?.keys || {})
       if (keys.length && query.SELECT.forUpdate?.ignoreLocked) {
+        if (rows.length === 0) return isOne ? undefined : []
         // REVISIT: No support for count
         // where [keys] in [values]
         const left = { list: keys.map(k => ({ ref: [k] })) }

--- a/hana/test/lock.test.js
+++ b/hana/test/lock.test.js
@@ -73,37 +73,32 @@ describe('locking', () => {
 
       describe('when the target entity uses a composite key', () => {
         test('returns empty array when all rows are locked', async () => {
-          const { WithRelationship, LeftChild, RightChild } = cds.entities('complex.associations.unmanaged')
-          const LEFT_CHILD_ID = cds.utils.uuid(),
-            RIGHT_CHILD_ID = cds.utils.uuid()
+          const { keys } = cds.entities('basic.common')
 
-          await INSERT.into(LeftChild).entries({ ID: LEFT_CHILD_ID, title: 'L' })
-          await INSERT.into(RightChild).entries({ ID: RIGHT_CHILD_ID, title: 'R' })
-          await INSERT.into(WithRelationship).entries({ leftChildId: LEFT_CHILD_ID, rightChildId: RIGHT_CHILD_ID })
+          await INSERT.into(keys).entries({ id: 42 })
 
           let tx1
           try {
             tx1 = cds.tx()
-            await tx1.run(SELECT.from(WithRelationship).forUpdate({ wait: 0 }))
+            await tx1.run(SELECT.from(keys).forUpdate({ wait: 0 }))
 
-            const res = await SELECT.from(WithRelationship).forUpdate({ ignoreLocked: true })
+            const res = await SELECT.from(keys).forUpdate({ ignoreLocked: true })
             expect(res).length(0)
           } finally {
             await tx1?.rollback()
-            await DELETE.from(WithRelationship).where({ leftChildId: LEFT_CHILD_ID, rightChildId: RIGHT_CHILD_ID })
-            await DELETE.from(LeftChild).where({ ID: LEFT_CHILD_ID })
-            await DELETE.from(RightChild).where({ ID: RIGHT_CHILD_ID })
+            await DELETE.from(keys).where({ id: 42 })
           }
         })
 
         test('composite-key entity with expand returns undefined without SQL error when table is empty', async () => {
-          const { WithRelationship } = cds.entities('complex.associations.unmanaged')
+          const { keys } = cds.entities('basic.common')
 
-          const res = await SELECT.one.from(WithRelationship).columns`*, leftChild { * }, rightChild { * }`.forUpdate({
-            ignoreLocked: true,
-          })
+          await INSERT.into(keys).entries({ id: 42 })
+
+          const res = await SELECT.one.from(keys).where({ id: 42 }).forUpdate({ ignoreLocked: true })
 
           expect(res).undefined
+          await DELETE.from(keys).where({ id: 42 })
         })
       })
     })

--- a/hana/test/lock.test.js
+++ b/hana/test/lock.test.js
@@ -75,6 +75,7 @@ describe('locking', () => {
         test('returns empty array when all rows are locked', async () => {
           const { keys } = cds.entities('basic.common')
 
+          // Guarantee at least one item is present
           await INSERT.into(keys).entries({ id: 42 })
 
           let tx1
@@ -90,15 +91,14 @@ describe('locking', () => {
           }
         })
 
-        test('composite-key entity with expand returns undefined without SQL error when table is empty', async () => {
+        test('returns undefined when select does not yield any results ', async () => {
           const { keys } = cds.entities('basic.common')
 
-          await INSERT.into(keys).entries({ id: 42 })
-
+          // Guarantee no item with id 42 can be found
+          await DELETE.from(keys).where({ id: 42 })
           const res = await SELECT.one.from(keys).where({ id: 42 }).forUpdate({ ignoreLocked: true })
 
           expect(res).undefined
-          await DELETE.from(keys).where({ id: 42 })
         })
       })
     })

--- a/hana/test/lock.test.js
+++ b/hana/test/lock.test.js
@@ -2,12 +2,11 @@ const { tx } = require('@sap/cds')
 const cds = require('../../test/cds.js')
 
 describe('locking', () => {
-  const { expect } = cds.test(__dirname + '/../../test/bookshop')
+  const { expect } = cds.test(__dirname + '/../../test/compliance/resources')
 
   describe('forUpdate', async () => {
-
     test('wait=0', async () => {
-      const { Books } = cds.entities
+      const { Books } = cds.entities('complex.associations.unmanaged')
       let tx1, tx2
       try {
         tx1 = await cds.tx()
@@ -23,7 +22,7 @@ describe('locking', () => {
     })
 
     test('wait>0', async () => {
-      const { Books } = cds.entities
+      const { Books } = cds.entities('complex.associations.unmanaged')
       let tx1, tx2
       try {
         tx1 = await cds.tx()
@@ -47,5 +46,66 @@ describe('locking', () => {
       }
     })
 
+    describe('ignoreLocked', async () => {
+      test('skips rows locked by another transaction, returns the rest', async () => {
+        const { Books } = cds.entities('complex.associations.unmanaged')
+        await INSERT.into(Books).entries([
+          { ID: 8001, title: 'Locked' },
+          { ID: 8002, title: 'Free' },
+        ])
+
+        let tx1
+        try {
+          tx1 = cds.tx()
+          await tx1.run(SELECT.from(Books).where({ ID: 8001 }).forUpdate({ wait: 0 }))
+
+          const res = await SELECT.from(Books)
+            .where({ ID: { in: [8001, 8002] } })
+            .forUpdate({ ignoreLocked: true })
+
+          expect(res).length(1)
+          expect(res[0].ID).equal(8002)
+        } finally {
+          await tx1?.rollback()
+          await DELETE.from(Books).where({ ID: { in: [8001, 8002] } })
+        }
+      })
+
+      describe('when the target entity uses a composite key', () => {
+        test('returns empty array when all rows are locked', async () => {
+          const { WithRelationship, LeftChild, RightChild } = cds.entities('complex.associations.unmanaged')
+          const LEFT_CHILD_ID = cds.utils.uuid(),
+            RIGHT_CHILD_ID = cds.utils.uuid()
+
+          await INSERT.into(LeftChild).entries({ ID: LEFT_CHILD_ID, title: 'L' })
+          await INSERT.into(RightChild).entries({ ID: RIGHT_CHILD_ID, title: 'R' })
+          await INSERT.into(WithRelationship).entries({ leftChildId: LEFT_CHILD_ID, rightChildId: RIGHT_CHILD_ID })
+
+          let tx1
+          try {
+            tx1 = cds.tx()
+            await tx1.run(SELECT.from(WithRelationship).forUpdate({ wait: 0 }))
+
+            const res = await SELECT.from(WithRelationship).forUpdate({ ignoreLocked: true })
+            expect(res).length(0)
+          } finally {
+            await tx1?.rollback()
+            await DELETE.from(WithRelationship).where({ leftChildId: LEFT_CHILD_ID, rightChildId: RIGHT_CHILD_ID })
+            await DELETE.from(LeftChild).where({ ID: LEFT_CHILD_ID })
+            await DELETE.from(RightChild).where({ ID: RIGHT_CHILD_ID })
+          }
+        })
+
+        test('composite-key entity with expand returns undefined without SQL error when table is empty', async () => {
+          const { WithRelationship } = cds.entities('complex.associations.unmanaged')
+
+          const res = await SELECT.one.from(WithRelationship).columns`*, leftChild { * }, rightChild { * }`.forUpdate({
+            ignoreLocked: true,
+          })
+
+          expect(res).undefined
+        })
+      })
+    })
   })
 })

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -304,7 +304,7 @@ describe('SELECT', () => {
       await INSERT.into(RightChild).entries({ ID: rightChildId, title: 'right' })
       await INSERT.into(WithRelationship).entries({ leftChildId, rightChildId })
 
-      const cqn = SELECT.one(WithRelationship, cds.ql.columns`*, leftChild { ID, title }`)
+      const cqn = SELECT.one(WithRelationship, cds.ql.columns`*, leftChild { ID, title }`).forUpdate({ ignoreLocked: true })
       const res = await cds.run(cqn)
       assert.equal(res.leftChild.title, 'left')
     })

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -295,23 +295,6 @@ describe('SELECT', () => {
       assert.strictEqual(res[0].static.length, 1)
     })
 
-    test('select one with expand', async () => {
-      const { LeftChild, RightChild, WithRelationship } = cds.entities('complex.associations.unmanaged')
-
-      const leftChildId = cds.utils.uuid()
-      const rightChildId = cds.utils.uuid()
-      await INSERT.into(LeftChild).entries({ ID: leftChildId, title: 'left' })
-      await INSERT.into(RightChild).entries({ ID: rightChildId, title: 'right' })
-      await INSERT.into(WithRelationship).entries({ leftChildId, rightChildId })
-
-      const cqn = SELECT.one.from(WithRelationship)
-        .columns`*, leftChild { * }, rightChild { * }`
-        .where({ 'rightChild.title': 'A' })
-        .forUpdate({ ignoreLocked: true })
-      const res = await cds.run(cqn)
-      assert.equal(res.leftChild.title, 'left')
-    })
-
     test.skip('invalid cast (wrong)', async () => {
       const { globals } = cds.entities('basic.projection')
       const cqn = cds.ql`SELECT 'String' as ![string] : cds.DoEsNoTeXiSt FROM ${globals}`

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -295,6 +295,20 @@ describe('SELECT', () => {
       assert.strictEqual(res[0].static.length, 1)
     })
 
+    test('select one with expand', async () => {
+      const { LeftChild, RightChild, WithRelationship } = cds.entities('complex.associations.unmanaged')
+
+      const leftChildId = cds.utils.uuid()
+      const rightChildId = cds.utils.uuid()
+      await INSERT.into(LeftChild).entries({ ID: leftChildId, title: 'left' })
+      await INSERT.into(RightChild).entries({ ID: rightChildId, title: 'right' })
+      await INSERT.into(WithRelationship).entries({ leftChildId, rightChildId })
+
+      const cqn = SELECT.one(WithRelationship, cds.ql.columns`*, leftChild { ID, title }`)
+      const res = await cds.run(cqn)
+      assert.equal(res.leftChild.title, 'left')
+    })
+
     test.skip('invalid cast (wrong)', async () => {
       const { globals } = cds.entities('basic.projection')
       const cqn = cds.ql`SELECT 'String' as ![string] : cds.DoEsNoTeXiSt FROM ${globals}`

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -304,7 +304,10 @@ describe('SELECT', () => {
       await INSERT.into(RightChild).entries({ ID: rightChildId, title: 'right' })
       await INSERT.into(WithRelationship).entries({ leftChildId, rightChildId })
 
-      const cqn = SELECT.one(WithRelationship, cds.ql.columns`*, leftChild { ID, title }`).forUpdate({ ignoreLocked: true })
+      const cqn = SELECT.one.from(WithRelationship)
+        .columns`*, leftChild { * }, rightChild { * }`
+        .where({ 'rightChild.title': 'A' })
+        .forUpdate({ ignoreLocked: true })
       const res = await cds.run(cqn)
       assert.equal(res.leftChild.title, 'left')
     })

--- a/test/compliance/resources/db/complex/associationsUnmanaged.cds
+++ b/test/compliance/resources/db/complex/associationsUnmanaged.cds
@@ -18,24 +18,3 @@ entity Authors {
                  and static.ID     >  0
                  and name          != null;
 }
-
-// ---
-
-entity LeftChild {
-  key ID    : UUID;
-      title : String;
-}
-
-entity RightChild {
-  key ID    : UUID;
-      title : String;
-}
-
-entity WithRelationship {
-  key leftChildId  : UUID;
-  key rightChildId : UUID;
-      leftChild    : Association to one LeftChild
-                       on leftChild.ID = $self.leftChildId;
-      rightChild   : Association to one RightChild
-                       on rightChild.ID = $self.rightChildId;
-}

--- a/test/compliance/resources/db/complex/associationsUnmanaged.cds
+++ b/test/compliance/resources/db/complex/associationsUnmanaged.cds
@@ -1,15 +1,41 @@
 namespace complex.associations.unmanaged;
 
 entity Books {
-  key ID : Integer;
-  title  : String(111);
-  author_ID: Integer;
-  author : Association to Authors on author.ID = $self.author_ID;
+  key ID        : Integer;
+      title     : String(111);
+      author_ID : Integer;
+      author    : Association to Authors
+                    on author.ID = $self.author_ID;
 }
 
 entity Authors {
-  key ID : Integer;
-  name   : String(111);
-  books  : Association to many Books on books.author = $self;
-  static  : Association to many Books on static.author = $self and static.ID > 0 and name != null;
+  key ID     : Integer;
+      name   : String(111);
+      books  : Association to many Books
+                 on books.author = $self;
+      static : Association to many Books
+                 on  static.author =  $self
+                 and static.ID     >  0
+                 and name          != null;
+}
+
+// ---
+
+entity LeftChild {
+  key ID    : UUID;
+      title : String;
+}
+
+entity RightChild {
+  key ID    : UUID;
+      title : String;
+}
+
+entity WithRelationship {
+  key leftChildId  : UUID;
+  key rightChildId : UUID;
+      leftChild    : Association to one LeftChild
+                       on leftChild.ID = $self.leftChildId;
+      rightChild   : Association to one RightChild
+                       on rightChild.ID = $self.rightChildId;
 }


### PR DESCRIPTION
Currently, the HANA Service will first query locked columns and then, in case `ignoreLocked` is set, filter a subsequent query for the rows it found. When an entity has a composite key, that filter is a check for whether the key tuple is `IN` a list of key tuples returned by the first query. In case no unlocked rows can be found, the way we format the filter will cause a HANA error, because an empty list parameter `{ list: [ ] }` will be interpreted as `{ val: null }` during `cqn4sql`, resulting in a HANA filter like `WHERE (keyField1, keyField2, ...) IS null`. 

This PR prevents the problem by exiting early in case no un-locked rows can be found. 