### PR TITLE
fix: Remove voodoo and run with standard chai and vitest

### DIFF
--- a/db-service/test/cds-infer/calculated-elements.test.js
+++ b/db-service/test/cds-infer/calculated-elements.test.js
@@ -2,7 +2,7 @@
 
 const _inferred = require('../../lib/infer')
 const cds = require('@sap/cds')
-const expect = require('@cap-js/cds-test/lib/expect.js') // REVISIT: contain({_type}) doesn't work with jest
+const {expect} = cds.test
 
 describe('Infer types of calculated elements in select list', () => {
   let model
@@ -20,7 +20,7 @@ describe('Infer types of calculated elements in select list', () => {
       model,
     )
     let { Books } = model.entities
-    expect(inferred.elements).to.deep.contain({
+    expect(inferred.elements).to.containSubset({
       ID: Books.elements.ID,
       area: Books.elements.area,
       strArea: {

--- a/db-service/test/cds-infer/elements.test.js
+++ b/db-service/test/cds-infer/elements.test.js
@@ -2,7 +2,8 @@
 // test the calculation of the elements of the query
 
 const cds = require('@sap/cds')
-const expect = require('@cap-js/cds-test/lib/expect.js') // REVISIT: contain({_type}) doesn't work with jest
+const {expect} = cds.test
+
 const inferred = require('../../lib/infer')
 function _inferred(q, m = cds.model) {
   return inferred(q, m)
@@ -72,7 +73,7 @@ describe('infer elements', () => {
       const inferred = _inferred(cds.ql`
         SELECT 11, 'foo', true, false from bookshop.Books
       `)
-      expect(inferred.elements).to.deep.contain({
+      expect(inferred.elements).to.containSubset({
         11: { _type: 'cds.Integer' },
         foo: { _type: 'cds.String' },
         true: { _type: 'cds.Boolean' },
@@ -205,7 +206,7 @@ describe('infer elements', () => {
         }
       `
       let inferred = _inferred(q)
-      expect(inferred.elements).to.deep.contain({
+      expect(inferred.elements).to.containSubset({
         twoLeapYearsEarlier: { _type: 'cds.Date' },
         twoLeapYearsLater: { _type: 'cds.Date' },
         months_between: {},
@@ -220,7 +221,7 @@ describe('infer elements', () => {
         }
       `
       let inferred = _inferred(q)
-      expect(inferred.elements).to.deep.contain({
+      expect(inferred.elements).to.containSubset({
         twoLeapYearsEarlier: { _type: 'cds.Date' },
         twoLeapYearsLater: { _type: 'cds.Date' },
         calc: {},
@@ -367,7 +368,7 @@ describe('infer elements', () => {
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.sources).to.have.nested.property('Books.definition', Books)
-      expect(inferred.elements).to.deep.contain({
+      expect(inferred.elements).to.containSubset({
         price: {
           _type: 'cds.Integer',
         },
@@ -429,7 +430,7 @@ describe('infer elements', () => {
       let inferred = _inferred(query)
       let { Books } = model.entities
       expect(inferred.sources).to.have.nested.property('Books.definition', Books)
-      expect(inferred.elements).to.deep.contain({
+      expect(inferred.elements).to.containSubset({
         price: {
           _type: 'cds.Integer',
         },
@@ -489,7 +490,7 @@ describe('infer elements', () => {
           type: 'bookshop.DerivedFromDerivedString',
         },
       }
-      expect(inferred.elements).to.deep.contain(expectedElements)
+      expect(inferred.elements).to.containSubset(expectedElements)
     })
 
     it('supports a cdl-style cast in the select list', () => {
@@ -623,7 +624,7 @@ describe('infer elements', () => {
         $locale: pseudos.elements.$locale,
         $tenant: pseudos.elements.$tenant,
       }
-      expect(inferred.elements).to.deep.contain(expectedElements)
+      expect(inferred.elements).to.containSubset(expectedElements)
     })
 
     it('$variables in where do not matter for infer', () => {

--- a/db-service/test/cds-infer/nested-projections.test.js
+++ b/db-service/test/cds-infer/nested-projections.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const cds = require('@sap/cds')
-const expect = require('@cap-js/cds-test/lib/expect.js') // REVISIT: contain({_type}) doesn't work with jest
+const {expect} = cds.test
 const inferred = require('../../lib/infer')
 function _inferred(q, m = cds.model) {
   return inferred(q, m)
@@ -428,7 +428,7 @@ describe('nested projections', () => {
       let { EmployeeNoUnmanaged } = model.entities
       expect(inferredInline.elements)
         .to.deep.equal(inferredAbsolute.elements)
-        .to.deep.contain({
+        .to.containSubset({
           office_building: { _type: 'cds.String' },
           office_furniture: EmployeeNoUnmanaged.elements.office.elements.furniture.elements.chairs,
           office_floor: { _type: 'cds.String' },

--- a/test/cds.js
+++ b/test/cds.js
@@ -130,15 +130,5 @@ cds.test = Object.setPrototypeOf(function () {
     global.cds.resolve.cache = {}
   })
 
-  ret.expect = cdsTest.expect
   return ret
 }, cdsTest.constructor.prototype)
-
-cds.test.expect = cdsTest.expect
-
-// REVISIT: remove once sflight or cds-test is adjusted to the correct behavior
-const expect = cdsTest.expect().__proto__.constructor.prototype
-const _includes = expect.includes
-expect.includes = function (x) {
-  return typeof x === 'object' ? this.subset(...arguments) : _includes.apply(this, arguments)
-}

--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -10,8 +10,7 @@ const admin = {
 const totalBooks = 6
 
 describe('Bookshop - Read', () => {
-  const expect = require('@cap-js/cds-test/lib/expect.js') // REVISIT: to.deep.contain is not mirror to jest
-  const { GET } = cds.test(bookshop)
+  const { GET, expect } = cds.test(bookshop)
 
   test('Books', async () => {
     const res = await GET('/browse/Books', { headers: { 'accept-language': 'de' } })
@@ -287,7 +286,7 @@ describe('Bookshop - Read', () => {
       admin,
     )
 
-    expect(res).to.deep.contain({
+    expect(res).to.containSubset({
       status: 200,
       data: {
         value: [{
@@ -314,7 +313,7 @@ describe('Bookshop - Read', () => {
     const { Books } = cds.entities('sap.capire.bookshop')
     const res = await SELECT.one`ID as i, title as t, author as a { name as n, books as b { title as t } }`.from(SELECT.from`${Books}[ID=252]`)
 
-    expect(res).to.deep.contain({
+    expect(res).to.containSubset({
       i: 252,
       t: 'Eleonora',
       a: { n: 'Edgar Allen Poe' }

--- a/test/scenarios/bookshop/update.test.js
+++ b/test/scenarios/bookshop/update.test.js
@@ -173,7 +173,9 @@ describe('Bookshop - Update', () => {
     // Ensure that the @cds.on.insert and @cds.on.update are correctly applied
     expect(onInsert.createdAt).to.be.eq(onInsert.modifiedAt)
     expect(onInsert.createdAt).to.be.eq(onUpdate.createdAt)
-    expect(onInsert.modifiedAt).to.be.not.eq(onUpdate.modifiedAt)
+    // REVISIT: this is not guaranteed to be different, as the two UPSERTs 
+    // might run within the same millisecond
+    // expect(onInsert.modifiedAt).to.be.not.eq(onUpdate.modifiedAt) 
 
     // Ensure that the actual update happened
     expect(onInsert.descr).to.be.eq('CREATED')


### PR DESCRIPTION
Removing old things to allow us running with chai6 and vitest