### PR TITLE
chore: rm redundant decimal test

### DIFF
--- a/test/scenarios/bookshop/insert.test.js
+++ b/test/scenarios/bookshop/insert.test.js
@@ -49,18 +49,4 @@ describe('Bookshop - Insert', () => {
     const res = await SELECT.from(Books, {ID: 344})
     expect(res.genre_ID).to.be.eq(10)
   })
-
-  test('big decimals', async () => {
-    const { Books } = cds.entities('sap.capire.bookshop')
-
-    const entry = { ID: 2348, title: 'Moby Dick', price: '12345678901234567890.12345' }
-    await INSERT(entry).into(Books)
-
-    const written = await SELECT('price').from(Books, { ID: 2348 })
-    if (written.price.indexOf('e+') > -1) {
-      expect(written.price).to.be.eq('1.23456789012346e+19')
-    } else {
-      expect(written.price).to.be.eq(entry.price)
-    }
-  })
 })


### PR DESCRIPTION
test was to strict and broke with https://github.com/cap-js/cds-dbs/pull/1571#issuecomment-4243087832

this can be safely removed, since data types are checked in `test/compliance/CREATE.test.js`, e.g.:

```shell
 Type: number
      ✔ CREATE
      INSERT
        ✔ {"integer8":null}
        ✔ {"integer8":0}
        ✔ {"integer8":255}
        ✔ {"integer16":null}
        ✔ {"integer16":32767}
        ✔ {"integer16":-32768}
        ✔ {"integer32":null}
        ✔ {"integer32":-2147483648}
        ✔ {"integer32":2147483647}
        ✔ {"integer64":null}
        ✔ {"integer64":"9223372036854775806"}
        ✔ {"integer64":"-9223372036854775808"}
        ✔ {"decimal":null}
        ✔ {
              "decimal": 0,
              "=decimal": "0.0000"
            }
        ✔ {
              "decimal": 1,
              "=decimal": "1.0000"
            }
        ✔ {
              "decimal": "3.14153",
              "=decimal": "3.1415"
            }
        ✔ {
              "decimal": 3.14,
              "=decimal": "3.1400"
            }
```