### PR TITLE
ci: separate release-please from npm publish job

### DIFF
--- a/.github/actions/hxe/action.yml
+++ b/.github/actions/hxe/action.yml
@@ -34,7 +34,7 @@ runs:
         fi;
     - name: Set up Docker Buildx
       if: ${{ steps.find-hxe.outputs.BUILD_HXE == 'true' }}
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
     - name: Build HXE image
       if: ${{ steps.find-hxe.outputs.BUILD_HXE == 'true' }}
       shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,8 +35,8 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,42 +5,54 @@ on:
 name: release-please
 jobs:
   release-please:
-    permissions:
-        contents: write
-        pull-requests: write
-        packages: write
-        id-token: write
     runs-on: ubuntu-latest
-    environment: npm
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      db-service-release: ${{ steps.release.outputs.db-service--release_created }}
+      sqlite-release: ${{ steps.release.outputs.sqlite--release_created }}
+      postgres-release: ${{ steps.release.outputs.postgres--release_created }}
+      hana-release: ${{ steps.release.outputs.hana--release_created }}
     steps:
       # v4.4.0
       - uses: googleapis/release-please-action@8bb7a2ed0f90c9802c83129a9488d235a1f31a7c
         id: release
         with:
           token: ${{secrets.CDS_DBS_TOKEN}}
-      # The logic below handles the npm publication:
+
+  publish:
+    needs: release-please
+    if: >-
+      needs.release-please.outputs.db-service-release ||
+      needs.release-please.outputs.sqlite-release ||
+      needs.release-please.outputs.postgres-release ||
+      needs.release-please.outputs.hana-release
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      ## debug info
-      - run: echo '${{ toJSON(steps.release.outputs) }} '
-
-      # Publish packages
       - name: Publish db-service
-        if: ${{ steps.release.outputs.db-service--release_created }}
+        if: ${{ needs.release-please.outputs.db-service-release }}
         run: npm publish --workspace db-service --access public --provenance
 
       - name: Publish sqlite
-        if: ${{ steps.release.outputs.sqlite--release_created }}
+        if: ${{ needs.release-please.outputs.sqlite-release }}
         run: npm publish --workspace sqlite --access public --provenance
 
       - name: Publish postgres
-        if: ${{ steps.release.outputs.postgres--release_created }}
+        if: ${{ needs.release-please.outputs.postgres-release }}
         run: npm publish --workspace postgres --access public --provenance
 
       - name: Publish SAP HANA
-        if: ${{ steps.release.outputs.hana--release_created }}
+        if: ${{ needs.release-please.outputs.hana-release }}
         run: npm publish --workspace hana --access public --provenance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
         node: [22]
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'


### PR DESCRIPTION
- Splits the single `release-please` job into two jobs: `release-please` (changelog/PR generation) and `publish` (npm publish)
- The `release-please` job runs on every push to main without requiring approval
- The `publish` job is gated by the `npm` environment review, so only actual releases require manual approval

## Motivation
On April 29, 2026, a supply chain attack compromised the repository — an unauthorized actor pushed malicious commits that hijacked the release workflow and triggered unauthorized npm publications. The attacker was able to publish compromised packages because the workflow had publish permissions without any manual approval gate.

By separating the release-please PR/changelog generation from the actual npm publish step and gating the latter behind an environment review, unauthorized pushes can no longer automatically publish to npm. **A human reviewer must explicitly approve every npm release, which would have prevented the attack from reaching end users.**
