### PR TITLE
chore: update release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,8 @@ jobs:
       postgres-release: ${{ steps.release.outputs.postgres--release_created }}
       hana-release: ${{ steps.release.outputs.hana--release_created }}
     steps:
-      # v4.4.0
-      - uses: googleapis/release-please-action@8bb7a2ed0f90c9802c83129a9488d235a1f31a7c
+      # v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         id: release
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
- Updates `googleapis/release-please-action` from v4.4.0 to [v5.0.0](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0)
- Resolves [a Node.js 20 deprecation warning in CI](https://github.com/cap-js/cds-dbs/actions/runs/25331552280/job/74266234360):

GitHub Actions is deprecating Node.js 20 runners ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Actions will be forced to run with Node.js 24 starting June 2, 2026.

The [v5.0.0 release](https://github.com/googleapis/release-please-action/releases/tag/v5.0.0) of release-please-action upgrades the runtime to Node.js 24. No configuration changes are required — the only breaking change is the runtime version.
