### PR TITLE
fix: inline numeric val nodes in column expression xpr trees

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -674,11 +674,30 @@ class CQN2SQLRenderer {
    */
   column_expr(x, q) {
     if (x === '*') return '*'
-
-    let sql = x.param !== true && typeof x.val === 'number' ? this.expr({ param: false, __proto__: x }) : this.expr(x)
+    if (x.param !== true && typeof x.val === 'number') x = { param: false, __proto__: x }
+    else if (x.xpr) x = this._xprWithInlineNumericVals(x)
+    let sql = this.expr(x)
     let alias = this.column_alias4(x, q)
     if (alias) sql += ' as ' + this.quote(alias)
     return sql
+  }
+
+  _xprWithInlineNumericVals(x) {
+    let modified = false
+    const xpr = x.xpr.map(el => {
+      if (el && typeof el === 'object') {
+        if (typeof el.val === 'number' && el.param !== true) {
+          modified = true
+          return { param: false, __proto__: el }
+        }
+        if (el.xpr) {
+          const r = this._xprWithInlineNumericVals(el)
+          if (r !== el) { modified = true; return r }
+        }
+      }
+      return el
+    })
+    return modified ? { __proto__: x, xpr } : x
   }
 
   /**

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -668,7 +668,9 @@ class HANAService extends SQLService {
         }
         if (x.element?.type === 'cds.Boolean') hasBooleans = true
         const converter = x.element?.[this.class._convertOutput] || (e => e)
-        const s = x.param !== true && typeof x.val === 'number' ? this.expr({ param: false, __proto__: x }) : this.expr(x)
+        const s = x.param !== true && typeof x.val === 'number'
+          ? this.expr({ param: false, __proto__: x })
+          : x.xpr ? this.expr(this._xprWithInlineNumericVals(x)) : this.expr(x)
         sql.push(`${converter(s, x.element)} as "${columnName.replace(/"/g, '""')}"`)
       }
 

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -257,6 +257,18 @@ describe('SELECT', () => {
       assert.equal(Object.keys(res[0]).length, cqn.SELECT.columns.length)
     })
 
+    test('select case when with numeric vals in xpr', async () => {
+      const { string } = cds.entities('basic.projection')
+      const cqn = cds.ql`SELECT
+        case when string = 'yes' then 1 else 3 end as criticality : cds.Integer
+      FROM ${string}`
+      const res = await cds.run(cqn)
+      assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
+      assert.strictEqual(res[0].criticality, 1)
+      assert.strictEqual(res[1].criticality, 3)
+      assert.strictEqual(res[2].criticality, 3)
+    })
+
     const nulls = length => new Array(length).fill().map((_, i) => ({ as: `null${i}`, val: null }))
     test('select 200 null columns', async () => {
       const { string } = cds.entities('basic.projection')

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -260,8 +260,9 @@ describe('SELECT', () => {
     test('select case when with numeric vals in xpr', async () => {
       const { string } = cds.entities('basic.projection')
       const cqn = cds.ql`SELECT
+        string,
         case when string = 'yes' then 1 else 3 end as criticality : cds.Integer
-      FROM ${string}`
+      FROM ${string} ORDER BY string desc`
       const res = await cds.run(cqn)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
       assert.strictEqual(res[0].criticality, 1)


### PR DESCRIPTION
Numeric val nodes inside xpr trees (e.g. CASE WHEN THEN/ELSE values) used as SELECT column expressions are now rendered as inline SQL literals instead of bound parameters. This fixes "Cannot set parameter at row: 1. Argument must be a string" errors with hdb v2 when calculated elements use CASE WHEN with integer return values.

The existing column_expr() guard only inlined bare numeric val nodes. The new _xprWithInlineNumericVals() helper recursively marks numeric vals inside xpr subtrees with param:false using prototype-based non-mutating wrappers.