### PR TITLE
test(sqlite): use CDS-style SELECT for versioning test

### DIFF
--- a/sqlite/test/versioning.test.js
+++ b/sqlite/test/versioning.test.js
@@ -29,7 +29,9 @@ describe('Versioned table', () => {
     const { versioned } = cds.entities('edge.hana.versioning')
     const { history } = cds.entities('edge.hana.versioning.versioned')
 
-    const sel = SELECT.one`*, history[order by validFrom asc] {*}`.from(versioned)
+    const sel = SELECT.one.from(versioned).columns(c => {
+      c`.*`, c.history`[order by validFrom asc] {*}`
+    })
 
     const ID = cds.utils.uuid()
     await cds.tx(() => INSERT([{ ID, data: 'original' }]).into(versioned))


### PR DESCRIPTION
The cds-compiler v7 forbids expand/inline in SQL-style SELECT
(cap/cds-compiler#14588). Adapt tagged template literal query to
use fluent .from().columns() API instead.