### PR TITLE
fix: calc element with exists through association

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -956,19 +956,39 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
         mergePathIfNecessary(basePath, arg)
       } else if (arg.xpr || arg.args) {
         const prop = arg.xpr ? 'xpr' : 'args'
+        let inExists = false
         arg[prop].forEach(step => {
+          if (step === 'exists') {
+            inExists = true
+            return
+          }
           let subPath = { $refLinks: [...basePath.$refLinks], ref: [...basePath.ref] }
           if (step.ref) {
-            step.$refLinks.forEach((link, i) => {
-              const { definition } = link
-              if (definition.value) {
-                mergePathsIntoJoinTree(definition.value, subPath)
-              } else {
-                subPath.$refLinks.push(link)
-                subPath.ref.push(step.ref[i])
+            if (inExists) {
+              // refs following `exists` become subqueries in cqn4sql — only the basePath prefix
+              // needs a JOIN (for correlation), the exists-target association itself does not.
+              if (subPath.$refLinks.length > 0) {
+                inferred.joinTree.mergeColumn(subPath, originalQuery.outerQueries)
+                // The exists subquery correlates against the last assoc in basePath,
+                // so it's not just a FK access — force a real JOIN.
+                const lastLink = subPath.$refLinks[subPath.$refLinks.length - 1]
+                if (lastLink.onlyForeignKeyAccess) lastLink.onlyForeignKeyAccess = false
+                if (!calcElement.value.isJoinRelevant)
+                  defineProperty(step, 'isJoinRelevant', true)
               }
-            })
-            mergePathIfNecessary(subPath, step)
+            } else {
+              step.$refLinks.forEach((link, i) => {
+                const { definition } = link
+                if (definition.value) {
+                  mergePathsIntoJoinTree(definition.value, subPath)
+                } else {
+                  subPath.$refLinks.push(link)
+                  subPath.ref.push(step.ref[i])
+                }
+              })
+              mergePathIfNecessary(subPath, step)
+            }
+            inExists = false
           } else if (step.args || step.xpr) {
             const nestedProp = step.xpr ? 'xpr' : 'args'
             step[nestedProp].forEach(a => {
@@ -977,6 +997,9 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
               if (!a.ref) subPath = { $refLinks: [...basePath.$refLinks], ref: [...basePath.ref] }
               mergePathsIntoJoinTree(a, subPath)
             })
+            inExists = false
+          } else {
+            if (step !== 'not') inExists = false
           }
         })
       }
@@ -1014,6 +1037,7 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
       const ref = column.ref[i]
       const link = column.$refLinks[i]
       if (link.definition.on && link.definition.isAssociation) {
+        if (assoc) return true
         if (!column.ref[i + 1]) {
           if (column.expand && assoc) return true
           // if unmanaged assoc is exposed, ignore it

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -1037,7 +1037,6 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
       const ref = column.ref[i]
       const link = column.$refLinks[i]
       if (link.definition.on && link.definition.isAssociation) {
-        if (assoc) return true
         if (!column.ref[i + 1]) {
           if (column.expand && assoc) return true
           // if unmanaged assoc is exposed, ignore it

--- a/db-service/test/cqn4sql/calculated-elements.test.js
+++ b/db-service/test/cqn4sql/calculated-elements.test.js
@@ -3,6 +3,8 @@
 const cqn4sql = require('../../lib/cqn4sql')
 const cds = require('@sap/cds')
 const { expect } = cds.test
+const { loadModel } = require('./helpers/model')
+const { expectCqn } = require('./helpers/expectCqn')
 
 describe('Unfolding calculated elements in select list', () => {
   let model
@@ -1169,6 +1171,48 @@ describe('Unfolding calculated elements and localized', () => {
         ) as __select__
       ) AS __select__2`
     expect(query).to.deep.equal(expected)
+  })
+})
+
+describe('calculated elements with exists accessed through association', () => {
+  let model
+  beforeAll(async () => {
+    model = await loadModel()
+  })
+
+  it('accessing parent calc element with exists through association produces correct JOIN', () => {
+    const transformed = cqn4sql(
+      cds.ql`SELECT from existsInCalcElement.Tasks as Tasks { ID, isUserNotMember }`,
+      model,
+    )
+    const expected = cds.ql`SELECT from existsInCalcElement.Tasks as Tasks
+      left join existsInCalcElement.Projects as project on project.ID = Tasks.project_ID
+      {
+        Tasks.ID,
+        (case when (case when not exists (
+          SELECT 1 from existsInCalcElement.Members as $m
+            where $m.project_ID = project.ID
+            and $m.userID = $user.id
+        ) then true else false end) = true then true else false end) as isUserNotMember
+      }`
+    expectCqn(transformed).to.equal(expected)
+  })
+
+  it('parent calc element with exists directly on entity needs no JOIN', () => {
+    const transformed = cqn4sql(
+      cds.ql`SELECT from existsInCalcElement.Projects as Projects { ID, isUserNotMember }`,
+      model,
+    )
+    const expected = cds.ql`SELECT from existsInCalcElement.Projects as Projects
+      {
+        Projects.ID,
+        (case when not exists (
+          SELECT 1 from existsInCalcElement.Members as $m
+            where $m.project_ID = Projects.ID
+            and $m.userID = $user.id
+        ) then true else false end) as isUserNotMember
+      }`
+    expectCqn(transformed).to.equal(expected)
   })
 })
 

--- a/db-service/test/cqn4sql/model/existsInCalcElement.cds
+++ b/db-service/test/cqn4sql/model/existsInCalcElement.cds
@@ -1,0 +1,26 @@
+namespace existsInCalcElement;
+
+entity Projects {
+  key ID      : UUID;
+      title   : String;
+      members : Composition of many Members
+                  on members.project = $self;
+      tasks   : Composition of many Tasks
+                  on tasks.project = $self;
+      isUserNotMember : Boolean =
+        (not exists members[userID = $user.id] ? true : false);
+}
+
+entity Members {
+  key ID      : UUID;
+      project : Association to one Projects;
+      userID  : String;
+}
+
+entity Tasks {
+  key ID      : UUID;
+      project : Association to one Projects;
+      title   : String;
+      isUserNotMember : Boolean =
+        (project.isUserNotMember = true ? true : false);
+}

--- a/db-service/test/cqn4sql/model/index.cds
+++ b/db-service/test/cqn4sql/model/index.cds
@@ -6,6 +6,7 @@ using from './A2J/TargetSideReferences';
 using from './cap_issue';
 using from './collaborations';
 using from './enums';
+using from './existsInCalcElement';
 using from './inlineAssoc';
 using from './keyless';
 using from './nestedProjections';


### PR DESCRIPTION
When a calculated element containing `exists <assoc>[filter]` is accessed through another association (e.g. `project.isUserNotMember`), the join tree must include a JOIN for the preceding association so the exists subquery can correlate against it.

- mergePathsIntoJoinTree: detect `exists` in xpr and merge only the prefix path as a JOIN, not the exists-target association itself