### PR TITLE
chore(!): Always return array-like results

### DIFF
--- a/db-service/lib/InsertResults.js
+++ b/db-service/lib/InsertResults.js
@@ -1,4 +1,3 @@
-const iterator = Symbol.iterator
 
 // eslint-disable-next-line no-unused-vars
 const USAGE_SAMPLE = async () => {
@@ -11,98 +10,87 @@ const USAGE_SAMPLE = async () => {
   ])
 }
 
-module.exports = class InsertResult {
+module.exports = class InsertResult extends Array {
+
   /**
    * @param {import('@sap/cds/apis/cqn').INSERT} query
    * @param {unknown[]} results
    */
-  constructor(query, results) {
-    // Storing query as non-enumerable property to avoid polluting trace output
-    Object.defineProperty(this, 'query', { value: query })
-    this.results = results
-  }
-
-  /**
-   * Lazy access to auto-generated keys.
-   */
-  get [iterator]() {
-    // For INSERT.from(SELECT.from(...)) return a dummy iterator with correct length
-    const { INSERT } = this.query
-    if (INSERT.from || INSERT.as) {
-      return (super[iterator] = function* () {
-        for (let i = 0; i < this.affectedRows; i++) yield {}
-      })
-    }
-
-    const target = this.query._target
-    if (!target?.keys) return (super[iterator] = this.results[iterator])
-    const keys = Object.keys(target.keys),
-      [k1] = keys
-
-    // For INSERT.entries() with generated keys in there return these keys
-    const { entries } = INSERT
-    if (entries && k1 in entries[0]) {
-      return (super[iterator] = function* () {
-        for (const each of entries)
-          yield keys.reduce((p, k) => {
-            p[k] = each[k]
-            return p
-          }, {})
-      })
-    }
-
-    // For INSERT.rows/values() with generated keys in there return these keys
-    const { columns } = INSERT
-    if (columns && columns.includes(k1)) {
-      return (super[iterator] = function* () {
-        const indices = keys.reduce((p, k) => {
-          let i = columns.indexOf(k)
-          if (i >= 0) p[k] = i
-          return p
-        }, {})
-        for (const each of INSERT.rows || [INSERT.values])
-          yield keys.reduce((p, k) => {
-            p[k] = each[indices[k]]
-            return p
-          }, {})
-      })
-    }
-
-    // If no generated keys in entries/rows/values we might have database-generated keys
-    return (super[iterator] = function* () {
-      for (const row of this.results) {
-        const affectedRows = this.affectedRows4(row) - 1
-        const lastInsertRowid = this.insertedRowId4(row)
-        for (let i = lastInsertRowid - affectedRows; i<=lastInsertRowid;i++) yield { [k1]: i }
-      }
+  constructor (query, results) {
+    Object.defineProperties (super(), { // using non-enumerable properties to avoid polluting trace output
+      results: { value: results },
+      query: { value: query },
     })
   }
 
-  /**
-   * the number of inserted (root) entries or the number of affectedRows in case of INSERT into SELECT
-   * @return {number}
+  /** Legacy alias for compatibility */
+  get affectedRows() { return this.affected }
+
+  /** The number of affected rows is determined as follows:
+   * - For INSERTs with entries/rows/values the number of these entries/rows/values is returned
+   * - For other INSERTs the number of affected rows as returned by the database is returned
+   * - For other statements the number of affected rows as returned by the database is returned
    */
-  get affectedRows() {
-    const { INSERT: _ } = this.query
-    if (_.from || _.as) return (super.affectedRows = this.affectedRows4(this.results[0] || this.results))
-    else return (super.affectedRows = _.entries?.length || _.rows?.length || this.results.length || 1)
+  get affected() {
+    const { INSERT } = this.query
+    if (INSERT.from || INSERT.as) return super.affected = this.affectedRows4 (this.results[0] || this.results)
+    else return super.affected = INSERT.entries?.length || INSERT.rows?.length || this.results.length || 1
+  }
+
+  [Symbol.iterator]() {
+    if (!this.length) this.#materialize() // materialize on first access, e.g. for [...results]
+    return super[Symbol.iterator]()
+  }
+
+  toJSON(){
+    if (!this.length) this.#materialize() // ensure materialized keys for JSON.stringify
+    return this
   }
 
   /**
-   * for checks such as res > 2
-   * @return {number}
+   * Lazy materialization of auto-generated keys.
    */
-  valueOf() {
-    return this.affectedRows
-  }
+  #materialize() {
 
-  /**
-   * The last id of the auto incremented key column
-   * @param {unknown[]} result
-   * @returns {number}
-   */
-  insertedRowId4(result) {
-    return result.lastInsertRowid
+    const target = this.query._target
+    if (!target?.keys) {
+      Array.isArray(this.results) ? this.push(...this.results) : this.push(this.results)
+      return this
+    }
+
+    const { INSERT } = this.query
+    const keys = Object.keys(target.keys)
+    const k0 = keys[0]
+
+    // For INSERT.entries() with generated keys in there return these keys
+    if (INSERT.entries && k0 in INSERT.entries[0]) {
+      for (const d of INSERT.entries) {
+        this.push (keys.reduce((p,k) => (p[k] = d[k], p), {}))
+      }
+    }
+
+    // For INSERT.rows/values() with generated keys in there return these keys
+    else if (INSERT.columns && INSERT.columns.includes(k0)) {
+      const indices = keys.reduce((p, k) => {
+        let i = INSERT.columns.indexOf(k)
+        if (i >= 0) p[k] = i
+        return p
+      }, {})
+      for (const d of INSERT.rows || [INSERT.values]) {
+        this.push (keys.reduce((p,k) => (p[k] = d[indices[k]], p), {}))
+      }
+    }
+
+    // If no generated keys in entries/rows/values we might have database-generated keys
+    else for (const row of this.results) {
+      const affectedRows = this.affectedRows4(row) - 1
+      const lastInsertRowid = this.insertedRowId4(row)
+      for (let i = lastInsertRowid - affectedRows; i<=lastInsertRowid;i++) {
+        this.push ({ [k0]: i })
+      }
+    }
+
+    return this
   }
 
   /**
@@ -112,5 +100,20 @@ module.exports = class InsertResult {
    */
   affectedRows4(result) {
     return result.changes
+  }
+
+  /**
+   * The last id of auto-incremented key columns
+   */
+  insertedRowId4(result) {
+    return result.lastInsertRowid
+  }
+
+  /**
+   * for checks such as res > 2
+   * @return {number}
+   */
+  valueOf() {
+    return this.affected
   }
 }

--- a/db-service/lib/SQLService.js
+++ b/db-service/lib/SQLService.js
@@ -202,7 +202,7 @@ class SQLService extends DatabaseService {
     const ps = await this.prepare(sql)
     const results = entries ? await Promise.all(entries.map(e => ps.run(e))) : await ps.run()
     // REVISIT: results isn't an array, when no entries -> how could that work? when do we have no entries?
-    return results.reduce((total, affectedRows) => total + affectedRows.changes, 0)
+    return this._return_affected(results.reduce((total, affectedRows) => total + affectedRows.changes, 0))
   }
 
   /**
@@ -227,7 +227,7 @@ class SQLService extends DatabaseService {
   async onSIMPLE({ query, data }) {
     const { sql, values } = this.cqn2sql(query, data)
     let ps = await this.prepare(sql)
-    return (await ps.run(values)).changes
+    return this._return_affected((await ps.run(values)).changes)
   }
 
   get onDELETE() {
@@ -300,7 +300,7 @@ class SQLService extends DatabaseService {
    * @type {Handler}
    */
   async onEVENT({ event }) {
-    if(DEBUG._debug) DEBUG.debug(event) // in the other cases above DEBUG happens in cqn2sql
+    if (DEBUG._debug) DEBUG.debug(event) // in the other cases above DEBUG happens in cqn2sql
     return await this.exec(event)
   }
 
@@ -310,7 +310,7 @@ class SQLService extends DatabaseService {
    */
   async onPlainSQL({ query, data }, next) {
     if (typeof query === 'string') {
-      if(DEBUG._debug) DEBUG.debug(query, data)
+      if (DEBUG._debug) DEBUG.debug(query, data)
       const ps = await this.prepare(query)
       const exec = this.hasResults(query) ? d => ps.all(d) : d => ps.run(d)
       if (Array.isArray(data) && Array.isArray(data[0])) return await Promise.all(data.map(exec))
@@ -415,7 +415,7 @@ class SQLService extends DatabaseService {
    * @param {import('@sap/cds/apis/cqn').Query} q
    * @returns {import('./infer/cqn').Query}
    */
-  cqn4sql(q, useTechnicalAlias=true) {
+  cqn4sql(q, useTechnicalAlias = true) {
     if (
       !cds.env.features.db_strict &&
       !q.SELECT?.from?.join &&
@@ -517,7 +517,7 @@ const DEBUG_PQL = cds.log('pql')
 if (DEBUG_PQL._debug || cds.repl) {
 
   // Add helper method to convert CQN to PQL, used below...
-  SQLService.prototype.cqn2pql = function cqn2pql (query, values) {
+  SQLService.prototype.cqn2pql = function cqn2pql(query, values) {
     const CQN2PQL = cqn2pql.renderer ??= require('./cqn2pql')
     return new CQN2PQL(this).render(query, values)
   }
@@ -568,7 +568,7 @@ if (DEBUG_PQL._debug || cds.repl) {
      * if no real SQL service is available yet through cds.db. 
      */
     class db extends SQLService {
-      /** @returns {SQLService} */ 
+      /** @returns {SQLService} */
       static get srv() { return cds.db || (this.singleton ??= new this) }
       get factory() { return null }
       get model() { return cds.model }

--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -167,5 +167,14 @@ class DatabaseService extends cds.Service {
   }
 }
 
+const _as_array = changes => Object.assign ([],{ affected: changes })
+const _as_number = changes => changes
+DatabaseService.prototype._return_affected = _as_number
+DatabaseService._always_return_arrays = on_off => {
+  DatabaseService.prototype._return_affected = on_off ? _as_array : _as_number
+  DatabaseService._always_returns_arrays = on_off
+}
+DatabaseService._always_returns_arrays = false
+DatabaseService._always_return_arrays (!cds.env.features.legacy_srv_results)
 DatabaseService.prototype.isDatabaseService = true
 module.exports = DatabaseService

--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -175,6 +175,6 @@ DatabaseService._always_return_arrays = on_off => {
   DatabaseService._always_returns_arrays = on_off
 }
 DatabaseService._always_returns_arrays = false
-DatabaseService._always_return_arrays (!cds.env.features.legacy_srv_results)
+DatabaseService._always_return_arrays (cds.env.features.legacy_srv_results) // TODO: invert default value
 DatabaseService.prototype.isDatabaseService = true
 module.exports = DatabaseService

--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -73,8 +73,8 @@ class HANAService extends SQLService {
               try {
                 await require('@sap/cds-mtxs/lib').xt.serviceManager.get(tenant, { disableCache: true, invalidCredentials: credentials, retryUntil: deadline })
               } catch (smErr) {
-                 smErr.cause = err
-                 throw new Error(`Failed connecting to pool - could not get valid credentials from Service Manager`, { cause: smErr })
+                smErr.cause = err
+                throw new Error(`Failed connecting to pool - could not get valid credentials from Service Manager`, { cause: smErr })
               }
               if (Date.now() < deadline) return create(tenant, start)
               else throw new Error(`Pool exceeded for '${tenant}' within ${acquireTimeoutMillis}ms`, { cause: err })
@@ -162,7 +162,7 @@ class HANAService extends SQLService {
     let sqlScript = isLockQuery || isSimple ? sql : this.wrapTemporary(temporary, withclause, blobs)
     const { hints } = query.SELECT
     if (hints) sqlScript += ` WITH HINT (${hints.join(',')})`
-    
+
     let rows
     if (values?.length || blobs.length > 0 || isStream) {
       const ps = await this.prepare(sqlScript, blobs.length)
@@ -176,20 +176,20 @@ class HANAService extends SQLService {
       const resultQuery = query.clone()
       resultQuery.SELECT.forUpdate = undefined
       resultQuery.SELECT.forShareLock = undefined
-      
+
       const keys = Object.keys(req.target?.keys || {})
-      
+
       if (keys.length && query.SELECT.forUpdate?.ignoreLocked) {
         // Exit early when no row was found in the inital query
         if (rows.length === 0) return isOne ? undefined : []
-        
+
         // Filter for those rows that were locked by the initial query
         const left = { list: keys.map(k => ({ ref: [k] })) }
         const right = { list: rows.map(r => ({ list: keys.map(k => ({ val: r[k.toUpperCase()] })) })) }
         resultQuery.SELECT.limit = undefined
         resultQuery.SELECT.where = [left, 'in', right]
       }
-      
+
       return this.onSELECT({ query: resultQuery, __proto__: req })
     }
 
@@ -603,7 +603,7 @@ class HANAService extends SQLService {
               // if (col.ref?.length === 1) { col.ref.unshift(parent.as) }
               if (col.ref?.length > 1) {
                 const colName = this.column_name(col)
-                
+
                 const isSource = from => {
                   if (from.as === col.ref[0]) return true
                   return from.args?.some(a => {
@@ -1307,7 +1307,7 @@ SELECT ${mixing} FROM JSON_TABLE(SRC.JSON, '$' COLUMNS(${extraction}) ERROR ON E
     const { sql, values } = this.cqn2sql(query, data)
     try {
       let ps = await this.prepare(sql)
-      return (this.ensureDBC() && await ps.run(values)).changes
+      return this._return_affected((this.ensureDBC() && await ps.run(values)).changes)
     } catch (err) {
       // Allow drop to fail when the view or table does not exist
       if (event === 'DROP ENTITY' && (err.code === 259 || err.code === 321)) {

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -183,7 +183,8 @@ class SQLiteService extends SQLService {
     const { sql, values } = this.cqn2sql(query, data)
     let ps = await this.prepare(sql)
     const vals = await this._prepareStreams(values)
-    return (await ps.run(vals)).changes
+    const { changes } = await ps.run(vals)
+    return this._return_affected (changes)
   }
 
   onPlainSQL({ query, data }, next) {


### PR DESCRIPTION
As discussed... 
The implementation for update and delete results is currently demonstrated for SQLite only. 
Would need to be applied to HANA and PostgreSQL as well.
