### PR TITLE
chore: ensure legacy_srv_results opt-out is compatible

### DIFF
--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -175,6 +175,6 @@ DatabaseService._always_return_arrays = on_off => {
   DatabaseService._always_returns_arrays = on_off
 }
 DatabaseService._always_returns_arrays = false
-DatabaseService._always_return_arrays (cds.env.features.legacy_srv_results) // TODO: invert default value
+DatabaseService._always_return_arrays (cds.env.features.legacy_srv_results === false) // TODO: invert default value
 DatabaseService.prototype.isDatabaseService = true
 module.exports = DatabaseService


### PR DESCRIPTION
legacy_srv_results: true/undefined is the compatible default which should be switched later on