### PR TITLE
chore(ci): remove cds_features_pool=builtin from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
       packages: write
 
     env:
-      cds_features_pool: builtin
       FORCE_COLOR: true
 
     strategy:


### PR DESCRIPTION
No-op since #1537 made builtin the default.