### PR TITLE
chore(v2): prepare downport branch

### DIFF
--- a/.github/actions/hxe/action.yml
+++ b/.github/actions/hxe/action.yml
@@ -34,7 +34,7 @@ runs:
         fi;
     - name: Set up Docker Buildx
       if: ${{ steps.find-hxe.outputs.BUILD_HXE == 'true' }}
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
     - name: Build HXE image
       if: ${{ steps.find-hxe.outputs.BUILD_HXE == 'true' }}
       shell: bash

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,14 +1,11 @@
 name: 'Adheres to conventional commit standard'
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
-
-permissions:
-  pull-requests: read
 
 jobs:
   main:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - release/v2
 name: release-please
 jobs:
   release-please:
@@ -18,6 +18,7 @@ jobs:
         id: release
         with:
           token: ${{secrets.CDS_DBS_TOKEN}}
+          target-branch: release/v2
       # The logic below handles the npm publication:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -31,16 +32,16 @@ jobs:
       # Publish packages
       - name: Publish db-service
         if: ${{ steps.release.outputs.db-service--release_created }}
-        run: npm publish --workspace db-service --access public --provenance
+        run: npm publish --workspace db-service --access public --provenance --tag maintenance
 
       - name: Publish sqlite
         if: ${{ steps.release.outputs.sqlite--release_created }}
-        run: npm publish --workspace sqlite --access public --provenance
+        run: npm publish --workspace sqlite --access public --provenance --tag maintenance
 
       - name: Publish postgres
         if: ${{ steps.release.outputs.postgres--release_created }}
-        run: npm publish --workspace postgres --access public --provenance
+        run: npm publish --workspace postgres --access public --provenance --tag maintenance
 
       - name: Publish SAP HANA
         if: ${{ steps.release.outputs.hana--release_created }}
-        run: npm publish --workspace hana --access public --provenance
+        run: npm publish --workspace hana --access public --provenance --tag maintenance

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,8 +20,8 @@ jobs:
           token: ${{secrets.CDS_DBS_TOKEN}}
           target-branch: release/v2
       # The logic below handles the npm publication:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,11 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [release/v2]
   pull_request:
     types: [opened, synchronize, reopened, auto_merge_enabled]
 
-# Allow parallel jobs on `main`, so that each commit is tested. For PRs, run only the latest commit.
+# Allow parallel jobs on `release/v2`, so that each commit is tested. For PRs, run only the latest commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -20,7 +20,6 @@ jobs:
       packages: write
 
     env:
-      cds_features_pool: true # TODO: make it work with Postgres test setup
       FORCE_COLOR: true
 
     strategy:
@@ -29,14 +28,13 @@ jobs:
         node: [22]
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
       - run: npm install -g @sap/cds-dk
-      - run: npm ci
       - run: npm run lint
       - id: hxe
         uses: ./.github/actions/hxe
@@ -47,10 +45,10 @@ jobs:
         env:
           TAG: ${{ steps.hxe.outputs.TAG }}
           IMAGE_ID: ${{ steps.hxe.outputs.IMAGE_ID }}
-      - name: sqlite driver (node:sqlite)
+      - name: sqlite driver (better-sqlite3))
         run: npm test -w sqlite
         env:
-          CDS_REQUIRES_DB_DRIVER: 'node'
+          CDS_REQUIRES_DB_DRIVER: 'better-sqlite3'
       - name: sqlite driver (sql.js)
         run: npm test -w sqlite
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,10 @@ jobs:
         env:
           TAG: ${{ steps.hxe.outputs.TAG }}
           IMAGE_ID: ${{ steps.hxe.outputs.IMAGE_ID }}
-      - name: sqlite driver (better-sqlite3))
+      - name: sqlite driver (node:sqlite))
         run: npm test -w sqlite
         env:
-          CDS_REQUIRES_DB_DRIVER: 'better-sqlite3'
+          CDS_REQUIRES_DB_DRIVER: 'node'
       - name: sqlite driver (sql.js)
         run: npm test -w sqlite
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           TAG: ${{ steps.hxe.outputs.TAG }}
           IMAGE_ID: ${{ steps.hxe.outputs.IMAGE_ID }}
-      - name: sqlite driver (node:sqlite))
+      - name: sqlite driver (node:sqlite)
         run: npm test -w sqlite
         env:
           CDS_REQUIRES_DB_DRIVER: 'node'

--- a/db-service/package.json
+++ b/db-service/package.json
@@ -27,7 +27,7 @@
     "generic-pool": "^3.9.0"
   },
   "peerDependencies": {
-    "@sap/cds": ">=9.8"
+    "@sap/cds": "^9.8"
   },
   "license": "Apache-2.0"
 }

--- a/hana/package.json
+++ b/hana/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "@sap/hana-client": "^2",
-    "@sap/cds": ">=9.8"
+    "@sap/cds": "^9.8"
   },
   "peerDependenciesMeta": {
     "@sap/hana-client": {

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -31,8 +31,8 @@
     "pg": "^8"
   },
   "peerDependencies": {
-    "@sap/cds": ">=9.8",
-    "@sap/cds-dk": ">=9"
+    "@sap/cds": "^9.8",
+    "@sap/cds-dk": "^9"
   },
   "peerDependenciesMeta": {
     "@sap/cds-dk": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "plugins": [
     "node-workspace"
   ],
+  "pull-request-title-pattern": "chore(v2): release downport",
   "packages": {
     "db-service": {},
     "sqlite": {},

--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -30,7 +30,7 @@
     "@cap-js/db-service": "^2.11.0"
   },
   "peerDependencies": {
-    "@sap/cds": ">=9.8",
+    "@sap/cds": "^9.8",
     "sql.js": "^1.13.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Prepare `release/v2` to act as the v2 maintenance line, mirroring the setup we did for `release/v1` last year.

- Retarget `release-please.yml` to `release/v2`; publish all four packages under the `maintenance` npm dist-tag
- Close `@sap/cds` peer-dep ranges to `^9.8` (`@sap/cds-dk` to `^9`)
- Add `pull-request-title-pattern: chore(v2): release downport` so v2 release PRs are distinguishable
- Align `conventional-commits.yml` trigger with `main` (`pull_request_target` → `pull_request`)
