### PR TITLE
fix(hana): align builtin-pool condition with db-service default

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -65,7 +65,7 @@ class HANAService extends SQLService {
           return dbc
         } catch (err) {
           if (isMultitenant) {
-            if (cds.requires.db?.pool?.builtin || cds.env.features.pool === 'builtin') {
+            if (cds.requires.db?.pool?.builtin !== false && cds.env.features.pool !== 'generic-pool') {
               if (err.status === 404 || err.status === 429) {
                 throw new Error(`Pool failed connecting to '${tenant}'`, { cause: err })
               }


### PR DESCRIPTION
PR #1537 made the builtin pool the default in `db-service/lib/common/generic-pool.js`, but `HANAService.js` was not updated to reflect this. This PR aligns both checks.