### PR TITLE
fix: resolve nested assoc-into-assoc inline path resolution

### DIFF
--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -707,7 +707,7 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
      *    d. Otherwise, the corresponding `$refLinks` definition is added to the `elements` object.
      * 2. Returns the `elements` object.
      */
-    function resolveInline(col, namePrefix = col.as || col.flatName) {
+    function resolveInline(col, namePrefix = col.as || col.flatName, outerBase = null) {
       const { inline, $refLinks } = col
       const $leafLink = $refLinks[$refLinks.length - 1]
       if (!$leafLink.definition.target && !$leafLink.definition.elements) {
@@ -715,10 +715,13 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
           `Unexpected “inline” on “${col.ref.map(idOnly)}”; can only be used after a reference to a structure, association or table alias`,
         )
       }
+      const effectiveBase = outerBase
+        ? { ref: [...outerBase.ref, ...col.ref], $refLinks: [...outerBase.$refLinks, ...col.$refLinks] }
+        : col
       let elements = {}
       let seenWildcard = false
       inline.forEach(inlineCol => {
-        inferArg(inlineCol, null, $leafLink, { inXpr: true, baseColumn: col })
+        inferArg(inlineCol, null, $leafLink, { inXpr: true, baseColumn: effectiveBase })
         if (inlineCol === '*') {
           if (seenWildcard) throw new Error(`Duplicate wildcard "*" in inline of "${col.as || col.ref.map(idOnly).join('_')}"`)
           seenWildcard = true
@@ -777,7 +780,7 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
           else if (inlineCol.ref) nameParts.push(...inlineCol.ref.map(idOnly))
           const name = nameParts.join('_')
           if (inlineCol.inline) {
-            const inlineElements = resolveInline(inlineCol, name)
+            const inlineElements = resolveInline(inlineCol, name, effectiveBase)
             elements = { ...elements, ...inlineElements }
           } else if (inlineCol.expand) {
             const expandElements = resolveExpand(inlineCol)

--- a/db-service/test/cqn4sql/model/index.cds
+++ b/db-service/test/cqn4sql/model/index.cds
@@ -6,6 +6,7 @@ using from './A2J/TargetSideReferences';
 using from './cap_issue';
 using from './collaborations';
 using from './enums';
+using from './inlineAssoc';
 using from './keyless';
 using from './nestedProjections';
 using from './update';

--- a/db-service/test/cqn4sql/model/inlineAssoc.cds
+++ b/db-service/test/cqn4sql/model/inlineAssoc.cds
@@ -1,0 +1,15 @@
+namespace issue;
+entity Cities {
+  key ID      : Integer;
+      name    : String;
+      country : String;
+}
+entity Addresses {
+  key ID      : Integer;
+      city    : Association to Cities;
+      street  : String;
+}
+entity Authors {
+  key ID      : Integer;
+      address : Association to Addresses;
+}

--- a/db-service/test/cqn4sql/nested-projections.test/inline.spec.js
+++ b/db-service/test/cqn4sql/nested-projections.test/inline.spec.js
@@ -221,6 +221,132 @@ describe('(nested projections) inline', () => {
 
       expectCqn(inlineTransformed).to.equal(expected)
     })
+
+    it('assoc inline into assoc inline - two consecutive association hops', () => {
+      const transformed = cqn4sql(cds.ql`
+        SELECT from issue.Authors as Authors
+        {
+          address.{
+            city.{ name }
+          }
+        }`)
+
+      const expected = cds.ql`
+        SELECT from issue.Authors as Authors
+          left join issue.Addresses as address on address.ID = Authors.address_ID
+          left join issue.Cities as city on city.ID = address.city_ID
+        {
+          city.name as address_city_name
+        }`
+
+      expectCqn(transformed).to.equal(expected)
+    })
+
+    it('assoc inline into assoc inline - infix filter on outer assoc', () => {
+      const transformed = cqn4sql(cds.ql`
+        SELECT from issue.Authors as Authors
+        {
+          address[ID=1].{
+            city.{ name }
+          }
+        }`)
+
+      const expected = cds.ql`
+        SELECT from issue.Authors as Authors
+          left join issue.Addresses as address on address.ID = Authors.address_ID
+            and address.ID = 1
+          left join issue.Cities as city on city.ID = address.city_ID
+        {
+          city.name as address_city_name
+        }`
+
+      expectCqn(transformed).to.equal(expected)
+    })
+
+    it('assoc inline into assoc inline - infix filter on inner assoc', () => {
+      const transformed = cqn4sql(cds.ql`
+        SELECT from issue.Authors as Authors
+        {
+          address.{
+            city[ID=5].{ name }
+          }
+        }`)
+
+      const expected = cds.ql`
+        SELECT from issue.Authors as Authors
+          left join issue.Addresses as address on address.ID = Authors.address_ID
+          left join issue.Cities as city on city.ID = address.city_ID
+            and city.ID = 5
+        {
+          city.name as address_city_name
+        }`
+
+      expectCqn(transformed).to.equal(expected)
+    })
+
+    it('assoc inline into assoc inline - infix filter on both assocs', () => {
+      const transformed = cqn4sql(cds.ql`
+        SELECT from issue.Authors as Authors
+        {
+          address[ID=1].{
+            city[ID=5].{ name }
+          }
+        }`)
+
+      const expected = cds.ql`
+        SELECT from issue.Authors as Authors
+          left join issue.Addresses as address on address.ID = Authors.address_ID
+            and address.ID = 1
+          left join issue.Cities as city on city.ID = address.city_ID
+            and city.ID = 5
+        {
+          city.name as address_city_name
+        }`
+
+      expectCqn(transformed).to.equal(expected)
+    })
+
+    it('assoc inline into assoc inline - FK access only does not join target', () => {
+      const transformed = cqn4sql(cds.ql`
+        SELECT from issue.Authors as Authors
+        {
+          address.{
+            city.{ ID }
+          }
+        }`)
+
+      const expected = cds.ql`
+        SELECT from issue.Authors as Authors
+          left join issue.Addresses as address on address.ID = Authors.address_ID
+        {
+          address.city_ID as address_city_ID
+        }`
+
+      expectCqn(transformed).to.equal(expected)
+    })
+
+    it('assoc inline into assoc inline - mixed scalar and nested assoc inline', () => {
+      const transformed = cqn4sql(cds.ql`
+        SELECT from issue.Authors as Authors
+        {
+          address.{
+            street,
+            city.{ name, country }
+          }
+        }`)
+
+      const expected = cds.ql`
+        SELECT from issue.Authors as Authors
+          left join issue.Addresses as address on address.ID = Authors.address_ID
+          left join issue.Cities as city on city.ID = address.city_ID
+        {
+          address.street as address_street,
+          city.name as address_city_name,
+          city.country as address_city_country
+        }`
+
+      expectCqn(transformed).to.equal(expected)
+    })
   })
 
   describe('mixed structures and associations', () => {


### PR DESCRIPTION
downport #1602

When inlining through consecutive associations (`address.{ city.{ name } }`),
the join tree only registered the first hop because the recursive `resolveInline` lost the outer path context. The inner `mergeColumn` call
couldn't find the query root and silently returned, leaving the second association marked as FK-only access.

Propagate the accumulated base path into recursive `resolveInline` calls so
that inner `colWithBase` refs start from the query source. This allows the
join tree to correctly register non-FK access and produce the required JOINs.