### PR TITLE
fix: resolve `$self` in infix filters /w path expressions and nested exists

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -1823,6 +1823,17 @@ function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
               continue
             }
             if (token.ref.length > 1 && token.ref[0] === '$self' && !token.$refLinks[0].definition.kind) {
+              if (inferred.outerQueries) {
+                const outerQuery = inferred.outerQueries[0]
+                const stepToFind = token.ref[1]?.id || token.ref[1]
+                const outerAlias = outerQuery.$combinedElements?.[stepToFind]?.[0].index
+                if (outerAlias) {
+                  let result = copy(token)
+                  result.ref = [outerAlias, token.flatName]
+                  transformedTokenStream.push(result)
+                  continue
+                }
+              }
               const dollarSelfReplacement = [calculateDollarSelfColumn(token, true)]
               transformedTokenStream.push(...getTransformedTokenStream(dollarSelfReplacement))
               continue

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -453,7 +453,7 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
           arg.$refLinks.push({ definition: pseudos.elements[id], target: pseudos })
           pseudoPath = true // only first path step must be well defined
           nameSegments.push(id)
-        } else if ($baseLink) {
+        } else if ($baseLink && !firstStepIsSelf) {
           const { definition, target } = $baseLink
           const elements = getDefinition(definition.target)?.elements || definition.elements
           if (elements && id in elements) {
@@ -484,7 +484,15 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
             target: getDefinitionFromSources(sources, id),
           })
         } else if (firstStepIsSelf) {
-          arg.$refLinks.push({ definition: { elements: queryElements }, target: { elements: queryElements } })
+          const nextStep = arg.ref[1]?.id || arg.ref[1]
+          let elements = queryElements
+          if (nextStep && (!queryElements || !(nextStep in queryElements)) && inferred.outerQueries) {
+            const outerQuery = inferred.outerQueries[0]
+            if (outerQuery?.elements && nextStep in outerQuery.elements) {
+              elements = outerQuery.elements
+            }
+          }
+          arg.$refLinks.push({ definition: { elements }, target: { elements } })
         } else if (arg.ref.length > 1 && inferred.outerQueries?.find(outer => id in outer.sources)) {
           // outer query accessed via alias
           const outerAlias = inferred.outerQueries.find(outer => id in outer.sources)

--- a/db-service/test/cqn4sql/table-alias.test.js
+++ b/db-service/test/cqn4sql/table-alias.test.js
@@ -593,6 +593,96 @@ describe('table alias access', () => {
         }`
       expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expectation)
     })
+    it('$self in infix filter alongside path expression', () => {
+      const q = cds.ql`
+        SELECT from bookshop.Books as Books {
+          title,
+          exists author.books[ author.name = title and title = $self.title ] as s
+        }`
+      const transformed = cqn4sql(q, model)
+      const expected = cds.ql`
+        SELECT from bookshop.Books as Books {
+          Books.title,
+          exists (
+            SELECT 1 from bookshop.Authors as $a where $a.ID = Books.author_ID and exists (
+              SELECT 1 from bookshop.Books as $b
+                inner join bookshop.Authors as author on author.ID = $b.author_ID
+                where $b.author_ID = $a.ID and author.name = $b.title and $b.title = Books.title
+            )
+          ) as s
+        }`
+      expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
+    })
+    it('$self in nested exists infix filter', () => {
+      const q = cds.ql`
+        SELECT from bookshop.Books as Books {
+          title,
+          exists author.books[ exists author.books[ title = $self.title ] ] as s
+        }`
+      const transformed = cqn4sql(q, model)
+      const expected = cds.ql`
+        SELECT from bookshop.Books as Books {
+          Books.title,
+          exists (
+            SELECT 1 from bookshop.Authors as $a where $a.ID = Books.author_ID and exists (
+              SELECT 1 from bookshop.Books as $b where $b.author_ID = $a.ID and exists (
+                SELECT 1 from bookshop.Authors as $a2 where $a2.ID = $b.author_ID and exists (
+                  SELECT 1 from bookshop.Books as $b2 where $b2.author_ID = $a2.ID and $b2.title = Books.title
+                )
+              )
+            )
+          ) as s
+        }`
+      expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
+    })
+    it('$self in deeply nested infix filter with multiple path expressions', () => {
+      const q = cds.ql`
+        SELECT from bookshop.Books as Books {
+          title,
+          exists author.books[ author.name = title and exists author.books[ author.name = title and title = $self.title ] ] as s
+        }`
+      const transformed = cqn4sql(q, model)
+      const expected = cds.ql`
+        SELECT from bookshop.Books as Books {
+          Books.title,
+          exists (
+            SELECT 1 from bookshop.Authors as $a where $a.ID = Books.author_ID and exists (
+              SELECT 1 from bookshop.Books as $b
+                inner join bookshop.Authors as author on author.ID = $b.author_ID
+                where $b.author_ID = $a.ID and author.name = $b.title and exists (
+                  SELECT 1 from bookshop.Authors as $a2 where $a2.ID = $b.author_ID and exists (
+                    SELECT 1 from bookshop.Books as $b2
+                      inner join bookshop.Authors as author2 on author2.ID = $b2.author_ID
+                      where $b2.author_ID = $a2.ID and author2.name = $b2.title and $b2.title = Books.title
+                  )
+                )
+            )
+          ) as s
+        }`
+      expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
+    })
+    it('$self in subquery refers to own projection, not outer query', () => {
+      const q = cds.ql`
+        SELECT from bookshop.Authors as Authors {
+          ID,
+          1+1 as foo
+        } where exists (
+          SELECT from bookshop.Books { 2+2 as foo, $self.foo as bar }
+          where author[$self.foo = 4].ID = 42
+        )`
+      const transformed = cqn4sql(q, model)
+      const expected = cds.ql`
+        SELECT from bookshop.Authors as Authors {
+          Authors.ID,
+          1+1 as foo
+        } where exists (
+          SELECT from bookshop.Books as $B
+            left outer join bookshop.Authors as author on author.ID = $B.author_ID and (2+2) = 4
+          { 2+2 as foo, 2+2 as bar }
+          where author.ID = 42
+        )`
+      expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
+    })
   })
 
   describe('in ORDER BY', () => {


### PR DESCRIPTION
downport #1604

When an infix filter contains a path expression or nested exists, `$self` resolution failed because the subquery generated by `transformSubquery` lacks the outer query's elements in its projection.

- Guard `$baseLink` branch so `$self` refs skip it and reach proper resolution
- Fall back to outermost query elements when local `queryElements` don't contain the referenced element
- Resolve `$self` directly to the outer query alias in `getTransformedTokenStream` for subquery contexts