### PR TITLE
chore: replace Renovate with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,6 @@ updates:
     ignore:
       - dependency-name: saplabs/hanaexpress
       - dependency-name: amannn/action-semantic-pull-request
-      - dependency-name: martinbeentjes/npm-get-version-action
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /db-service
+      - /sqlite
+      - /postgres
+      - /hana
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 3
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      dependencies-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 3
+    ignore:
+      - dependency-name: saplabs/hanaexpress
+      - dependency-name: amannn/action-semantic-pull-request
+      - dependency-name: martinbeentjes/npm-get-version-action
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":disableDependencyDashboard"],
-  "ignoreDeps": ["saplabs/hanaexpress", "amannn/action-semantic-pull-request", "martinbeentjes/npm-get-version-action"],
-  "minimumReleaseAge": "3 days",
-  "lockFileMaintenance": { "enabled": true }
-}


### PR DESCRIPTION
Switch from Renovate to GitHub's native Dependabot for dependency updates.

Configuration:
- Weekly schedule with 3-day cooldown (matches npm's unpublish window)
- npm: covers root + all 4 workspace packages (db-service, sqlite, postgres, hana)
- github-actions: single block at root
- Grouped PRs: minor+patch in one PR, majors separate, actions in one PR
- Ignored deps carried over from renovate.json: saplabs/hanaexpress, amannn/action-semantic-pull-request, martinbeentjes/npm-get-version-action

Note: Renovate's `lockFileMaintenance` (periodic lock-file-only refreshes) has no Dependabot equivalent. Lock files are still updated on every dep-bump PR.

- [ ] TODO: Uninstall the Renovate GitHub App from the repository settings (Settings > GitHub Apps) to prevent it from continuing to open PRs.