### PR TITLE
ci: separate release-please from npm publish job (#1592)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,43 +5,54 @@ on:
 name: release-please
 jobs:
   release-please:
-    permissions:
-        contents: write
-        pull-requests: write
-        packages: write
-        id-token: write
     runs-on: ubuntu-latest
-    environment: npm
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      db-service-release: ${{ steps.release.outputs.db-service--release_created }}
+      sqlite-release: ${{ steps.release.outputs.sqlite--release_created }}
+      postgres-release: ${{ steps.release.outputs.postgres--release_created }}
+      hana-release: ${{ steps.release.outputs.hana--release_created }}
     steps:
       # v5.0.0
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         id: release
         with:
           token: ${{secrets.CDS_DBS_TOKEN}}
-          target-branch: release/v2
-      # The logic below handles the npm publication:
+
+  publish:
+    needs: release-please
+    if: >-
+      needs.release-please.outputs.db-service-release ||
+      needs.release-please.outputs.sqlite-release ||
+      needs.release-please.outputs.postgres-release ||
+      needs.release-please.outputs.hana-release
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      ## debug info
-      - run: echo '${{ toJSON(steps.release.outputs) }} '
-
-      # Publish packages
       - name: Publish db-service
-        if: ${{ steps.release.outputs.db-service--release_created }}
-        run: npm publish --workspace db-service --access public --provenance --tag maintenance
+        if: ${{ needs.release-please.outputs.db-service-release }}
+        run: npm publish --workspace db-service --access public --provenance
 
       - name: Publish sqlite
-        if: ${{ steps.release.outputs.sqlite--release_created }}
-        run: npm publish --workspace sqlite --access public --provenance --tag maintenance
+        if: ${{ needs.release-please.outputs.sqlite-release }}
+        run: npm publish --workspace sqlite --access public --provenance
 
       - name: Publish postgres
-        if: ${{ steps.release.outputs.postgres--release_created }}
-        run: npm publish --workspace postgres --access public --provenance --tag maintenance
+        if: ${{ needs.release-please.outputs.postgres-release }}
+        run: npm publish --workspace postgres --access public --provenance
 
       - name: Publish SAP HANA
-        if: ${{ steps.release.outputs.hana--release_created }}
-        run: npm publish --workspace hana --access public --provenance --tag maintenance
+        if: ${{ needs.release-please.outputs.hana-release }}
+        run: npm publish --workspace hana --access public --provenance

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         id: release
         with:
-          token: ${{secrets.CDS_DBS_TOKEN}}
+          token: ${{ github.token }}
 
   publish:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,16 +43,16 @@ jobs:
 
       - name: Publish db-service
         if: ${{ needs.release-please.outputs.db-service-release }}
-        run: npm publish --workspace db-service --access public --provenance
+        run: npm publish --workspace db-service --access public --provenance --tag maintenance
 
       - name: Publish sqlite
         if: ${{ needs.release-please.outputs.sqlite-release }}
-        run: npm publish --workspace sqlite --access public --provenance
+        run: npm publish --workspace sqlite --access public --provenance --tag maintenance
 
       - name: Publish postgres
         if: ${{ needs.release-please.outputs.postgres-release }}
-        run: npm publish --workspace postgres --access public --provenance
+        run: npm publish --workspace postgres --access public --provenance --tag maintenance
 
       - name: Publish SAP HANA
         if: ${{ needs.release-please.outputs.hana-release }}
-        run: npm publish --workspace hana --access public --provenance
+        run: npm publish --workspace hana --access public --provenance --tag maintenance


### PR DESCRIPTION
downport #1592

- Splits the single `release-please` job into two jobs: `release-please` (changelog/PR generation) and `publish` (npm publish)
- The `release-please` job runs on every push to main without requiring approval
- The `publish` job is gated by the `npm` environment review, so only actual releases require manual approval
