### PR TITLE
fix: use integer literals instead of placeholders in xpr

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -1079,6 +1079,8 @@ SELECT ${mixing} FROM JSON_TABLE(SRC.JSON, '$' COLUMNS(${extraction}) ERROR ON E
           }
           sql.push(this.operator(x, i, xpr, top || iscompareStack.length > 1))
         } else if (x.xpr) sql.push(`(${this.xpr(x, iscompareStack.at(-1))})`)
+        // inline numeric literals, HANA cannot infer the type of `?` inside CASE branches
+        else if (x.param !== true && typeof x.val === 'number') sql.push(this.expr({ param: false, __proto__: x }))
         // default
         else sql.push(this.expr(x))
       }

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -337,6 +337,29 @@ describe('SELECT', () => {
     })
   })
 
+  describe('calculated elements', () => {
+    // GH issue #1669 CASE with integer literals in THEN branches fails on HANA
+    // ("Cannot set parameter at row: 1. Argument must be a string.") because the
+    // literals are emitted as `?` parameters with no surrounding type anchor.
+    test('case returning integer literals', async () => {
+      const { dynamic } = cds.entities('complex.computed')
+      await cds.run(INSERT.into(dynamic).entries([{ integer: 0 }, { integer: 1 }, { integer: 2 }]))
+      const res = await cds.run(cds.ql`
+        SELECT integer,
+          case when integer = 0 then 1
+               when integer = 1 then 2
+               else 3
+          end as caseInt
+        FROM ${dynamic}
+        ORDER BY integer
+      `)
+      assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
+      assert.strictEqual(res[0].caseInt, 1, 'integer 0 → caseInt 1')
+      assert.strictEqual(res[1].caseInt, 2, 'integer 1 → caseInt 2')
+      assert.strictEqual(res[2].caseInt, 3, 'integer 2 → caseInt 3 (else branch)')
+    })
+  })
+
   describe('excluding', () => {
     test('without columns', async () => {
       const { string } = cds.entities('basic.literals')

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -354,9 +354,9 @@ describe('SELECT', () => {
         ORDER BY integer
       `)
       assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
-      assert.strictEqual(res[0].caseInt, 1, 'integer 0 → caseInt 1')
-      assert.strictEqual(res[1].caseInt, 2, 'integer 1 → caseInt 2')
-      assert.strictEqual(res[2].caseInt, 3, 'integer 2 → caseInt 3 (else branch)')
+      assert.equal(res[0].caseInt, 1, 'integer 0 → caseInt 1')
+      assert.equal(res[1].caseInt, 2, 'integer 1 → caseInt 2')
+      assert.equal(res[2].caseInt, 3, 'integer 2 → caseInt 3 (else branch)')
     })
   })
 


### PR DESCRIPTION
reported in #1669 → not an issue with draft nor calculated element but with integer literals in case statements in general