### PR TITLE
fix: prevent SQLite in memory connection from being cleaned up

### DIFF
--- a/sqlite/package.json
+++ b/sqlite/package.json
@@ -55,6 +55,8 @@
         "sqlite": {
           "impl": "@cap-js/sqlite",
           "pool": {
+            "evictionRunIntervalMillis": 0,
+            "min": 1,
             "max": 1
           }
         }


### PR DESCRIPTION
Currently when a CAP application uses `@cap-js/sqlite` and is idle for ~2minutes. The connection pool will destroy the connection. Then the next time a request comes in it will create a new connection, but that new connection is missing all deployed artifacts as the default is `:memory:`.