### PR TITLE
fix: wrong hana single tenant credential connection loop

### DIFF
--- a/hana/lib/HANAService.js
+++ b/hana/lib/HANAService.js
@@ -59,7 +59,11 @@ class HANAService extends SQLService {
         service.server.major = dbc.server.major || service.server.major
         return dbc
       } catch (err) {
-        if (err.code === 10) return // authentication error, see error handler below
+        if (err.code === 10) {
+          // authentication error
+          LOG.debug('connection failed:', err)
+          throw new Error(`Pool failed connecting`, { cause: err })
+        } 
         if (attempt < maxRetries) {
           LOG.debug('connection failed:', err, '- retrying attempt', attempt, 'of', maxRetries)
           return createSingleTenant(tenant, attempt + 1)


### PR DESCRIPTION
Addresses Ticket #1679 

Now auth errors in single tenant hana connections will be logged in the debug log and throw an appropriate error, thereby no longer running into a loop and locking the db user