### PR TITLE
Add failing test: managed fields excluded from projection dropped on INSERT

### DIFF
--- a/sqlite/test/general/managed.test.js
+++ b/sqlite/test/general/managed.test.js
@@ -142,4 +142,14 @@ describe('Managed thingies', () => {
       expect(result[0].createdBy).to.equal(result[1].createdBy)
     }
   })
+
+  test('managed fields excluded from projection still reach the INSERT', async () => {
+    const resPost = await POST('/test/Orders', { ID: 1, name: 'first' })
+    expect(resPost.status).to.equal(201)
+
+    const db = await cds.connect.to('db')
+    const row = await db.run(SELECT.one.from('db.Orders').where({ ID: 1 }))
+    expect(row.createdBy).to.equal('anonymous')
+    expect(row.createdAt).to.not.be.null
+  })
 })

--- a/sqlite/test/general/model.cds
+++ b/sqlite/test/general/model.cds
@@ -7,6 +7,11 @@ entity db.fooTemporal : managed, temporal {
   key ID   : Integer;
 }
 
+entity db.Orders : managed {
+  key ID   : Integer;
+      name : String;
+}
+
 @path: '/test'
 service test {
   entity foo : managed {
@@ -34,6 +39,9 @@ service test {
   }
 
   entity fooTemporal as projection on db.fooTemporal;
+
+  // cap/issues#20583: projection does not expose the managed audit fields
+  entity Orders as projection on db.Orders { ID, name };
 
   entity Images {
      key ID   : Integer;


### PR DESCRIPTION
## Summary
- Adds a failing test showing that framework-managed audit fields (`createdBy`, `createdAt`, ...) are silently dropped from the INSERT when a service projection does not expose them.
- Adds the minimal `db.Orders` entity and `test.Orders` projection needed to exercise the case.

## Test plan
- [ ] `npm test -w sqlite -- sqlite/test/general/managed.test.js`