### PR TITLE
test: managed fields excluded from projection are dropped on INSERT

### DIFF
--- a/sqlite/test/general/managed.test.js
+++ b/sqlite/test/general/managed.test.js
@@ -142,4 +142,21 @@ describe('Managed thingies', () => {
       expect(result[0].createdBy).to.equal(result[1].createdBy)
     }
   })
+
+  // Regression: since @cap-js/db-service@2.9.0, managed fields excluded from a
+  // service projection are silently dropped from the generated INSERT.
+  // See https://github.tools.sap/cap/issues/issues/20583
+  test('managed fields excluded from the projection still reach the INSERT', async () => {
+    const resPost = await POST('/test/fooManagedRestricted', { ID: 99, value: 'test' })
+    expect(resPost.status).to.equal(201)
+
+    // Read the underlying DB entity directly: the managed columns are not
+    // exposed through the restricted projection, so we must query db.fooManaged.
+    const db = await cds.connect.to('db')
+    const row = await db.run(SELECT.one.from('db.fooManaged').where({ ID: 99 }))
+    // On the buggy version the managed columns are NULL because they were
+    // dropped from the INSERT; assert on the whole row for a readable diff.
+    expect(row).to.containSubset({ ID: 99, value: 'test', createdBy: 'anonymous' })
+    expect(typeof row.createdAt).to.eq('string')
+  })
 })

--- a/sqlite/test/general/model.cds
+++ b/sqlite/test/general/model.cds
@@ -7,6 +7,11 @@ entity db.fooTemporal : managed, temporal {
   key ID   : Integer;
 }
 
+entity db.fooManaged : managed {
+  key ID    : Integer;
+      value : String;
+}
+
 @path: '/test'
 service test {
   entity foo : managed {
@@ -34,6 +39,13 @@ service test {
   }
 
   entity fooTemporal as projection on db.fooTemporal;
+
+  // Projection that intentionally excludes the managed fields
+  // (createdBy/createdAt/modifiedBy/modifiedAt) — see issue 20583.
+  entity fooManagedRestricted as projection on db.fooManaged {
+    ID,
+    value
+  };
 
   entity Images {
      key ID   : Integer;


### PR DESCRIPTION
## Repro (failing test) for cds-dbs#1576

Since `@cap-js/db-service@2.9.0`, managed audit fields (`createdBy`/`createdAt`/`modifiedBy`/`modifiedAt`) that are **not exposed** in a service projection are silently dropped from the generated `INSERT` and end up `NULL` in the database — instead of being filled by the default managed handler.

Root cause (per bisect): removal of `resolveView()` from `SQLService.cqn2sql()` in 2.9.0. In `db-service/lib/cqn2sql.js`, `INSERT_entries()` builds its column list from `q.elements` (the service-projection elements) and `managed()` walks that same map, so any managed field the projection omits is invisible to both and never injected.

### What this PR adds
- `sqlite/test/general/model.cds`: base entity `db.fooManaged : managed` + restricted projection `fooManagedRestricted { ID, value }`.
- `sqlite/test/general/managed.test.js`: a test that POSTs through the restricted projection, then reads the underlying `db.fooManaged` row.

### Expected result
The new test **fails on current HEAD** (it documents the bug):

```
expected {
  ID: 99, createdAt: null, createdBy: null,
  modifiedAt: null, modifiedBy: null, value: 'test'
} to contain subset { ID: 99, createdBy: 'anonymous', value: 'test' }
```

Draft — reproduction only, **not a fix**.