### PR TITLE
test(hana): add failing tests for object-mode expand streaming bugs

### DIFF
--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -1221,6 +1221,60 @@ describe('SELECT', () => {
       for await (const row of cqn.clone()) process.call(aggregate, row)
       expect(aggregate).deep.eq(expected)
     }))
+
+    test('async iterator with to-many expand', () => cds.tx(async () => {
+      const { Authors } = cds.entities('complex.associations')
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors)
+
+      const expected = await cqn.clone()
+
+      const rows = []
+      for await (const row of cqn.clone()) rows.push(row)
+
+      expect(rows).deep.eq(expected)
+      expect(rows[0].books).to.be.an('array')
+      expect(rows[0].books[0].title).to.equal('Wuthering Heights')
+    }))
+
+    test('async iterator with to-one expand', () => cds.tx(async () => {
+      const { Books } = cds.entities('complex.associations')
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books)
+
+      const expected = await cqn.clone()
+
+      const rows = []
+      for await (const row of cqn.clone()) rows.push(row)
+
+      expect(rows).deep.eq(expected)
+      expect(rows[0].author.name).to.equal('Emily')
+    }))
+
+    test('async iterator with a paused consumer', () => cds.tx(async () => {
+      // Regression: the hdb driver eagerly prefetches the next chunk on every
+      // `next()`. If the consumer pauses between rows (e.g. awaiting an async
+      // side-effect like writing each row to storage), the HANA ResultSet can
+      // close mid-stream and the orphaned prefetch promise rejects with
+      // ERR_STREAM_PREMATURE_CLOSE — previously surfacing as an unhandled
+      // rejection. Use an expand query so the hdb rsIterator object-mode path
+      // is active (the affected code path), and introduce a real async pause
+      // between rows to let the underlying ResultSet settle while the consumer
+      // is suspended.
+      const { Authors } = cds.entities('complex.associations')
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors)
+
+      const expected = await cqn.clone()
+
+      const rows = []
+      for await (const row of cqn.clone()) {
+        // Simulate a slow per-row async side-effect (e.g. writing to object storage).
+        // This pauses the async iterator while the HANA ResultSet is still open,
+        // triggering the prefetch orphan on the next read cycle.
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        rows.push(row)
+      }
+
+      expect(rows).deep.eq(expected)
+    }))
   })
 
   describe('pipeline', () => {


### PR DESCRIPTION
  Adds three failing tests that reproduce two bugs crashing the process when a
  deep-expand HANA query is consumed as an async iterable (`for await`).

  **Bug 1** — `TypeError: Cannot read properties of undefined (reading 'push')`
  at `rsNextObjectMode` (lib/drivers/stream.js): `handleLevel` (lib/drivers/base.js)
  deletes `level.expands[property]` then reads the same key back for the pushed
  expand level's `result` — undefined after deletion.

  **Bug 2** — `ERR_STREAM_PREMATURE_CLOSE` (unhandledRejection): `rsIterator`
  (lib/drivers/hdb.js) eagerly fires `this._prefetch = raw.next()` on every
  `next()` call. When the consumer pauses between rows (e.g. awaiting an async
  write per record), the HANA ResultSet closes mid-stream and the orphaned
  prefetch promise rejects. Because it is never awaited in that path, the
  rejection surfaces as an unhandledRejection and crashes the process.

  Tests added to the `foreach` describe in `test/compliance/SELECT.test.js`
  (hardlinked into `hana/test/compliance/compliance/SELECT.test.js`):

  - `async iterator with to-many expand` — `for await` over `Authors { books{*} }` — bug 1
  - `async iterator with to-one expand` — `for await` over `Books { author{*} }` — bug 1
  - `async iterator with a paused consumer` — expand query with a 50ms pause per row
    to reproduce the ResultSet close race while the hdb object-mode path is active — bug 2

All three tests are expected to **fail** on the unpatched driver.

The fix is in the follow-up PR targeting this branch (#1699). Of course the other PR also contains the tests, so this one is just to demonstrate the failing tests and does not need to be merged eventually.

The tests themselves have not been executed against a live HANA yet, I'm waiting for the pipeline to do that.