### PR TITLE
fix: usage of expands in object mode streaming

### DIFF
--- a/hana/lib/drivers/base.js
+++ b/hana/lib/drivers/base.js
@@ -221,7 +221,7 @@ const handleLevel = function (levels, path, expands) {
       const property = `${path.slice(level.path.length + 2, -7)}`
       if (property && property in level.expands) {
         const expandValue = level.expands[property]
-        const is2Many = expandValue
+        const is2Many = expandValue?.push  // Readable has .push; resolve functions and null don't
         delete level.expands[property]
         if (level.hasProperties) {
           buffer += ','
@@ -266,10 +266,13 @@ const handleLevel = function (levels, path, expands) {
       }
       if (level.suffix) buffer += level.suffix
       if (level.isExpand) {
-        level.result?.push(null)
+        if (typeof level.result === 'function') level.result(null)  // to-one: resolve with null
+        else level.result?.push(null)                                // to-many: terminate stream
       } else if (level.expands) {
         for (const expand in level.expands) {
-          if (level.expands[expand]?.push) level.expands[expand]?.push(null)
+          const v = level.expands[expand]
+          if (typeof v === 'function') v(null)      // to-one resolver never entered
+          else if (v?.push) v.push(null)            // to-many stream never entered
         }
       }
     }

--- a/hana/lib/drivers/base.js
+++ b/hana/lib/drivers/base.js
@@ -220,7 +220,8 @@ const handleLevel = function (levels, path, expands) {
       // Check if the current row is an expand of the current level
       const property = `${path.slice(level.path.length + 2, -7)}`
       if (property && property in level.expands) {
-        const is2Many = level.expands[property]
+        const expandValue = level.expands[property]
+        const is2Many = expandValue
         delete level.expands[property]
         if (level.hasProperties) {
           buffer += ','
@@ -236,8 +237,9 @@ const handleLevel = function (levels, path, expands) {
           index: 1,
           suffix: is2Many ? ']' : '',
           path: path.slice(0, -6),
-          result: level.expands[property],
+          result: expandValue,
           expands,
+          isExpand: true,
         })
       } else {
         // Current row is on the same level now so incrementing the index
@@ -263,7 +265,9 @@ const handleLevel = function (levels, path, expands) {
         }
       }
       if (level.suffix) buffer += level.suffix
-      if (level.expands) {
+      if (level.isExpand) {
+        level.result?.push(null)
+      } else if (level.expands) {
         for (const expand in level.expands) {
           if (level.expands[expand]?.push) level.expands[expand]?.push(null)
         }

--- a/hana/lib/drivers/base.js
+++ b/hana/lib/drivers/base.js
@@ -239,7 +239,6 @@ const handleLevel = function (levels, path, expands) {
           path: path.slice(0, -6),
           result: expandValue,
           expands,
-          isExpand: true,
         })
       } else {
         // Current row is on the same level now so incrementing the index
@@ -265,14 +264,11 @@ const handleLevel = function (levels, path, expands) {
         }
       }
       if (level.suffix) buffer += level.suffix
-      if (level.isExpand) {
-        if (typeof level.result === 'function') level.result(null)  // to-one: resolve with null
-        else level.result?.push(null)                                // to-many: terminate stream
-      } else if (level.expands) {
+      if (levels.length && level.suffix === ']' && level.result.push) level.result.push(null)
+      if (level.expands) {
         for (const expand in level.expands) {
-          const v = level.expands[expand]
-          if (typeof v === 'function') v(null)      // to-one resolver never entered
-          else if (v?.push) v.push(null)            // to-many stream never entered
+          if (typeof level.expands[expand] === 'function') level.expands[expand](null)
+          else if (level.expands[expand]?.push) level.expands[expand]?.push(null)
         }
       }
     }

--- a/hana/lib/drivers/hdb.js
+++ b/hana/lib/drivers/hdb.js
@@ -202,6 +202,15 @@ async function rsIterator(rs, one, objectMode) {
     next() {
       const ret = this._prefetch || raw.next()
       this._prefetch = raw.next()
+      // The eagerly-started prefetch may never be consumed (e.g. the stream ends
+      // on the current `ret`, or the consumer pauses long enough for the HANA
+      // ResultSet to close mid-stream). In that case its rejection
+      // (ERR_STREAM_PREMATURE_CLOSE) would surface as an unhandledRejection and
+      // crash the process. Attach a no-op catch; the value is re-fetched via
+      // `ret` on the next call when it is actually needed.
+      if (this._prefetch && typeof this._prefetch.catch === 'function') {
+        this._prefetch.catch(() => {})
+      }
       return ret
     },
     done() {

--- a/hana/lib/drivers/stream.js
+++ b/hana/lib/drivers/stream.js
@@ -64,20 +64,38 @@ function rsNextObjectMode(state, next) {
 
   const level = state.levels.at(-1)
 
-  // Expose expanded columns as recursive Readable streams
+  // Expose expanded columns as recursive streams or thenables
   for (const expandName in expands) {
-    level.expands[expandName] = json[expandName] = new Readable({
-      objectMode: true,
-      read() {
-        state.stream.resume()
+    if (expands[expandName] !== null) {
+      // to-many: expose as Readable stream
+      level.expands[expandName] = json[expandName] = new Readable({
+        objectMode: true,
+        read() {
+          state.stream.resume()
+        }
+      })
+    } else {
+      // to-one: expose as lazy thenable that resumes the stream on await
+      let resolve
+      const promise = new Promise(r => { resolve = r })
+      json[expandName] = {
+        then(onFulfilled, onRejected) {
+          state.stream.resume()
+          return promise.then(onFulfilled, onRejected)
+        }
       }
-    })
+      level.expands[expandName] = resolve
+    }
   }
 
-  // Push current
+  // Push current row to its result target
   const resultStream = level.result
-  resultStream.push(json)
-  resultStream._reading--
+  if (typeof resultStream === 'function') {
+    resultStream(json)
+  } else if (resultStream) {
+    resultStream.push(json)
+    resultStream._reading--
+  }
 
   return {
     // Iterator pattern

--- a/hana/lib/drivers/stream.js
+++ b/hana/lib/drivers/stream.js
@@ -67,24 +67,14 @@ function rsNextObjectMode(state, next) {
   // Expose expanded columns as recursive streams or thenables
   for (const expandName in expands) {
     if (expands[expandName] !== null) {
-      // to-many: expose as Readable stream
       level.expands[expandName] = json[expandName] = new Readable({
         objectMode: true,
-        read() {
-          state.stream.resume()
-        }
+        read() { state.stream.resume() }
       })
     } else {
-      // to-one: expose as lazy thenable that resumes the stream on await
-      let resolve
-      const promise = new Promise(r => { resolve = r })
-      json[expandName] = {
-        then(onFulfilled, onRejected) {
-          state.stream.resume()
-          return promise.then(onFulfilled, onRejected)
-        }
-      }
-      level.expands[expandName] = resolve
+      const prom = Promise.withResolvers()
+      json[expandName] = prom.promise
+      level.expands[expandName] = prom.resolve
     }
   }
 

--- a/test/compliance/DELETE.test.js
+++ b/test/compliance/DELETE.test.js
@@ -78,7 +78,7 @@ describe('DELETE', () => {
       const { Authors } = cds.entities('complex.associations')
       await INSERT.into(Authors).entries(new Array(9).fill().map((e, i) => ({ ID: 100 + i, name: 'name' + i })))
       const changes = await cds.run(DELETE.from(Authors))
-      expect(changes | 0).to.be.eq(10, 'Ensure that all rows are affected') // 1 from csv, 9 newly added
+      expect(changes | 0).to.be.eq(12, 'Ensure that all rows are affected') // 3 from csv, 9 newly added
     })
   })
 

--- a/test/compliance/INSERT.test.js
+++ b/test/compliance/INSERT.test.js
@@ -222,8 +222,8 @@ describe('INSERT', () => {
     const insertResult = await cds.db.run(
       INSERT.into('complex.associations.Books').columns('ID').from(
         SELECT.from('complex.associations.Authors').columns`ID + 4711 as ID`))
-    expect(insertResult == 1).to.be.eq(true) // lose comparison as otherwise .valueOf is not invoked
-    expect(insertResult.affected).to.be.eq(1)
+    expect(insertResult == 3).to.be.eq(true) // lose comparison as otherwise .valueOf is not invoked
+    expect(insertResult.affected).to.be.eq(3)
     expect(() => [...insertResult]).to.not.throw // spreadable, but content not yet defined
   })
 

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -725,13 +725,13 @@ describe('SELECT', () => {
     test('navigation with duplicate identifier in path', async () => {
       const { Books } = cds.entities('complex.associations')
       const res = await cds.ql`SELECT name { name } FROM ${Books} GROUP BY name.name`
-      assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
+      assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
 
     test('navigation with duplicate identifier in path and aggregation', async () => {
       const { Books } = cds.entities('complex.associations')
       const res = await cds.ql`SELECT name { name }, count(1) as total FROM ${Books} GROUP BY name.name`
-      assert.strictEqual(res.length, 1, 'Ensure that all rows are coming back')
+      assert.strictEqual(res.length, 3, 'Ensure that all rows are coming back')
     })
   })
 
@@ -1132,9 +1132,9 @@ describe('SELECT', () => {
       const query = SELECT.from('complex.associations.Authors')
       query.SELECT.count = true
       const result = await query
-      assert.strictEqual(result.$count, 1)
+      assert.strictEqual(result.$count, 3)
       const renamed = result.map(row => ({ key: row.ID, fullName: row.name }))
-      assert.strictEqual(renamed.$count, 1)
+      assert.strictEqual(renamed.$count, 3)
     })
   })
 

--- a/test/compliance/resources/db/data/complex.associations.Authors.csv
+++ b/test/compliance/resources/db/data/complex.associations.Authors.csv
@@ -1,2 +1,4 @@
 ID;name
 1;Emily
+2;Jeffry
+3;Bob

--- a/test/compliance/resources/db/data/complex.associations.Books.csv
+++ b/test/compliance/resources/db/data/complex.associations.Books.csv
@@ -1,2 +1,5 @@
 ID;title;author_ID
 1;Wuthering Heights;1
+2;Jeffries Great adventures;2
+3;Jeff Jef and Jeffry;2
+4;Tome of unknown origin;

--- a/test/compliance/stream.test.js
+++ b/test/compliance/stream.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert')
+const cds = require('../cds.js')
+const { text } = require('stream/consumers')
+const { pipeline } = require('stream')
+
+describe('SELECT', () => {
+  const { expect } = cds.test(__dirname + '/resources')
+
+  describe('foreach', () => {
+    const process = function (row) {
+      for (const prop in row) if (row[prop] != null) (this[prop] ??= []).push(row[prop])
+    }
+
+    test('consume to many expand', async () => {
+      const { Authors } = cds.entities('complex.associations')
+      await INSERT.into(Authors).entries({ ID: 2348 })
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
+      const expected =await cqn.clone()
+      const authors = []
+      const books = []
+      await cds.tx(async () => {
+          for await (const row of cqn.clone()) {
+            authors.push(row)
+            for await (const b of row.books) {
+              books.push(b)
+            }
+          }
+      })
+      expect(authors).deep.eq(expected)
+      expect(books).deep.eq(expected[0].books)
+    })
+
+    xtest('consume to one expand through for await', async () => {
+      const { Books } = cds.entities('complex.associations')
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books).orderBy('ID')
+      const expected =await cqn.clone()
+      const authors = []
+      const books = []
+      await cds.tx(async () => {
+          for await (const row of cqn.clone()) {
+            books.push(row)
+            for await (const a of row.author) {
+              authors.push(a)
+            }
+          }
+      })
+      expect(authors).deep.eq(expected)
+      expect(books).deep.eq(expected[0].books)
+    })
+  })
+
+  describe('raw expand streams', () => {
+    xtest('consume to many expand stream', () => cds.tx(async () => {
+      const { Authors } = cds.entities('complex.associations')
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
+      const expected =await cqn.clone()
+      const stream = await cqn.clone().stream()
+      const authors = JSON.parse(await text(stream))
+      expect(authors).deep.eq(expected)
+    }))
+
+    xtest('consume to one expand stream', () => cds.tx(async () => {
+      const { Books } = cds.entities('complex.associations')
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books).orderBy('ID')
+      const expected =await cqn.clone()
+      const stream = await cqn.clone().stream()
+      const authors = JSON.parse(await text(stream))
+      expect(authors).deep.eq(expected)
+    }))
+  })
+})
+

--- a/test/compliance/stream.test.js
+++ b/test/compliance/stream.test.js
@@ -51,9 +51,8 @@ describe('SELECT', () => {
       await cds.tx(async () => {
           for await (const row of cqn.clone()) {
             books.push(row)
-            for await (const a of row.author) {
-              authors.push(a)
-            }
+            const a = await row.author
+            authors.push(a)
           }
       })
       expect(authors).deep.eq([expected[0].author])

--- a/test/compliance/stream.test.js
+++ b/test/compliance/stream.test.js
@@ -26,16 +26,15 @@ describe('SELECT', () => {
             }
           }
       })
-      expect(authors).deep.eq(expected)
+      // expect(authors).deep.eq(expected)
       expect(books).deep.eq(expected[0].books)
     })
 
-    xtest('consume to one expand through for await', async () => {
+    test('consume to one expand', async () => {
       const { Books } = cds.entities('complex.associations')
       const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books).orderBy('ID')
       const expected =await cqn.clone()
       const authors = []
-      const books = []
       await cds.tx(async () => {
           for await (const row of cqn.clone()) {
             books.push(row)
@@ -44,13 +43,12 @@ describe('SELECT', () => {
             }
           }
       })
-      expect(authors).deep.eq(expected)
-      expect(books).deep.eq(expected[0].books)
+      expect(authors).deep.eq([expected[0].author])
     })
   })
 
   describe('raw expand streams', () => {
-    xtest('consume to many expand stream', () => cds.tx(async () => {
+    test('consume to many expand stream', () => cds.tx(async () => {
       const { Authors } = cds.entities('complex.associations')
       const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
       const expected =await cqn.clone()
@@ -59,7 +57,7 @@ describe('SELECT', () => {
       expect(authors).deep.eq(expected)
     }))
 
-    xtest('consume to one expand stream', () => cds.tx(async () => {
+    test('consume to one expand stream', () => cds.tx(async () => {
       const { Books } = cds.entities('complex.associations')
       const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books).orderBy('ID')
       const expected =await cqn.clone()
@@ -69,4 +67,3 @@ describe('SELECT', () => {
     }))
   })
 })
-

--- a/test/compliance/stream.test.js
+++ b/test/compliance/stream.test.js
@@ -1,81 +1,50 @@
 const cds = require('../cds.js')
-const { text } = require('stream/consumers')
+const { json } = require('stream/consumers')
 
 describe('SELECT', () => {
   const { expect, data } = cds.test(__dirname + '/resources')
-  data.autoReset()
 
   describe('foreach', () => {
-    test('consume to many with single row', async () => {
-      const { Authors, Books } = cds.entities('complex.associations')
-      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
-      const expected =await cqn.clone()
+    test('consume to many', async () => {
+      const { Authors } = cds.entities('complex.associations')
+      const cqn = cds.ql`SELECT ID, name, books[order by ID asc]{*} FROM ${Authors} order by ID asc`
       const authors = []
-      const books = []
       await cds.tx(async () => {
-          for await (const row of cqn.clone()) {
-            authors.push(row)
-            for await (const b of row.books) {
-              books.push(b)
-            }
-          }
+        for await (const author of cqn.clone()) {
+          authors.push(author)
+          const books = author.books
+          author.books = []
+          for await (const book of books) author.books.push(book)
+        }
       })
-      expect(books).deep.eq(expected[0].books)
-    })
-
-    test('consume to many expand with multiple rows', async () => {
-      const { Authors, Books } = cds.entities('complex.associations')
-      await INSERT.into(Authors).entries({ ID: 2348 })
-      await INSERT.into(Books).entries([{ ID: 9001, author_ID: 1}, { ID: 9002, author_ID: 1}, { ID: 9003, author_ID: 1}, { ID: 9004, author_ID: 1}, { ID: 9005, author_ID: 1}, { ID: 9006, author_ID: 1}, { ID: 9007, author_ID: 1}])
-      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
-      const expected =await cqn.clone()
-      const authors = []
-      const books = []
-      await cds.tx(async () => {
-          for await (const row of cqn.clone()) {
-            authors.push(row)
-            for await (const b of row.books) {
-              books.push(b)
-            }
-          }
-      })
-      expect(books).deep.eq(expected[0].books)
+      expect(authors).deep.eq(await cqn.clone())
     })
 
     test('consume to one expand', async () => {
       const { Books } = cds.entities('complex.associations')
-      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books).orderBy('ID')
-      const expected =await cqn.clone()
-      const authors = []
+      const cqn = cds.ql`SELECT ID, title, author{*} FROM ${Books} order by ID asc`
       const books = []
       await cds.tx(async () => {
-          for await (const row of cqn.clone()) {
-            books.push(row)
-            const a = await row.author
-            authors.push(a)
-          }
+        for await (const book of cqn.clone()) {
+          book.author = await book.author
+          books.push(book)
+        }
       })
-      expect(authors).deep.eq([expected[0].author])
+      expect(books).deep.eq(await cqn.clone())
     })
   })
 
   describe('raw expand streams', () => {
     test('consume to many expand stream', () => cds.tx(async () => {
       const { Authors } = cds.entities('complex.associations')
-      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
-      const expected =await cqn.clone()
-      const stream = await cqn.clone().stream()
-      const authors = JSON.parse(await text(stream))
-      expect(authors).deep.eq(expected)
+      const cqn = cds.ql`SELECT ID, name, books {*} FROM ${Authors} order by ID asc`
+      expect(await json(await cqn.clone().stream())).deep.eq(await cqn.clone())
     }))
 
     test('consume to one expand stream', () => cds.tx(async () => {
       const { Books } = cds.entities('complex.associations')
-      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books).orderBy('ID')
-      const expected =await cqn.clone()
-      const stream = await cqn.clone().stream()
-      const authors = JSON.parse(await text(stream))
-      expect(authors).deep.eq(expected)
+      const cqn = cds.ql`SELECT ID, title, author {*} FROM ${Books} order by ID asc`
+      expect(await json(await cqn.clone().stream())).deep.eq(await cqn.clone())
     }))
   })
 })

--- a/test/compliance/stream.test.js
+++ b/test/compliance/stream.test.js
@@ -1,19 +1,13 @@
-const assert = require('assert')
 const cds = require('../cds.js')
 const { text } = require('stream/consumers')
-const { pipeline } = require('stream')
 
 describe('SELECT', () => {
-  const { expect } = cds.test(__dirname + '/resources')
+  const { expect, data } = cds.test(__dirname + '/resources')
+  data.autoReset()
 
   describe('foreach', () => {
-    const process = function (row) {
-      for (const prop in row) if (row[prop] != null) (this[prop] ??= []).push(row[prop])
-    }
-
-    test('consume to many expand', async () => {
-      const { Authors } = cds.entities('complex.associations')
-      await INSERT.into(Authors).entries({ ID: 2348 })
+    test('consume to many with single row', async () => {
+      const { Authors, Books } = cds.entities('complex.associations')
       const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
       const expected =await cqn.clone()
       const authors = []
@@ -26,7 +20,25 @@ describe('SELECT', () => {
             }
           }
       })
-      // expect(authors).deep.eq(expected)
+      expect(books).deep.eq(expected[0].books)
+    })
+
+    test('consume to many expand with multiple rows', async () => {
+      const { Authors, Books } = cds.entities('complex.associations')
+      await INSERT.into(Authors).entries({ ID: 2348 })
+      await INSERT.into(Books).entries([{ ID: 9001, author_ID: 1}, { ID: 9002, author_ID: 1}, { ID: 9003, author_ID: 1}, { ID: 9004, author_ID: 1}, { ID: 9005, author_ID: 1}, { ID: 9006, author_ID: 1}, { ID: 9007, author_ID: 1}])
+      const cqn = SELECT([{ ref: ['ID'] }, { ref: ['name'] }, { ref: ['books'], expand: ['*'] }]).from(Authors).orderBy('ID')
+      const expected =await cqn.clone()
+      const authors = []
+      const books = []
+      await cds.tx(async () => {
+          for await (const row of cqn.clone()) {
+            authors.push(row)
+            for await (const b of row.books) {
+              books.push(b)
+            }
+          }
+      })
       expect(books).deep.eq(expected[0].books)
     })
 
@@ -35,6 +47,7 @@ describe('SELECT', () => {
       const cqn = SELECT([{ ref: ['ID'] }, { ref: ['title'] }, { ref: ['author'], expand: ['*'] }]).from(Books).orderBy('ID')
       const expected =await cqn.clone()
       const authors = []
+      const books = []
       await cds.tx(async () => {
           for await (const row of cqn.clone()) {
             books.push(row)


### PR DESCRIPTION
This PR inherits the fixes of #1699 + fixes the object mode streaming using to-one expands on hana.