### PR TITLE
fix: normalize non-UTC DateTimeOffset strings to UTC in val()

### DIFF
--- a/db-service/lib/cqn2sql.js
+++ b/db-service/lib/cqn2sql.js
@@ -1366,6 +1366,14 @@ class CQN2SQLRenderer {
       case 'undefined': val = null
         break
       case 'boolean': return `${val}`
+      case 'string':
+        // Normalize ISO datetime strings with non-UTC offsets to UTC before binding,
+        // so all DB engines receive a consistent Z-string regardless of how the CQN was built.
+        if (val.length > 19 && val[10] === 'T' && /[+-]\d{2}:?\d{2}$/.test(val)) {
+          const d = new Date(val)
+          if (!isNaN(d)) val = d.toJSON()
+        }
+        break
       case 'object':
         if (val !== null) {
           if (val instanceof Date) val = val.toJSON() // returns null if invalid

--- a/sqlite/lib/SQLiteService.js
+++ b/sqlite/lib/SQLiteService.js
@@ -211,12 +211,12 @@ class SQLiteService extends SQLService {
     val(v) {
       if (typeof v.val === 'boolean') v.val = v.val ? 1 : 0
       else if (Buffer.isBuffer(v.val)) v.val = v.val.toString('base64')
-      // intercept DateTime values and convert to Date objects to compare ISO Strings
-      else if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d{1,9})?(Z|[+-]\d{2}(:?\d{2})?)$/.test(v.val)) {
+      // Normalize ISO datetime strings without a timezone offset to ms-precision UTC
+      // so comparisons match what SQLite stores via ISO() (always .000Z).
+      // Offset strings are already handled by super.val().
+      else if (typeof v.val === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d{1,9})?Z$/.test(v.val)) {
         const date = new Date(v.val)
-        if (!Number.isNaN(date.getTime())) {
-          v.val = date
-        }
+        if (!Number.isNaN(date.getTime())) v.val = date
       }
       return super.val(v)
     }

--- a/test/compliance/SELECT.test.js
+++ b/test/compliance/SELECT.test.js
@@ -392,6 +392,21 @@ describe('SELECT', () => {
       expect(await sel.clone().where(`dateTime = `, timestamp.toISOString())).length(1)
     })
 
+    test('compare with DateTime column using non-UTC offset string', async () => {
+      const { dateTime: entity } = cds.entities('basic.literals')
+      const sel = SELECT('dateTime').from(entity)
+      const [{ dateTime }] = await sel.clone()
+      const timestamp = new Date(dateTime)
+      // Build an equivalent ISO string with a non-UTC offset representing the same instant.
+      // e.g. 1970-02-02T10:09:34Z → 1970-02-02T12:09:34+02:00
+      const offsetMs = 2 * 60 * 60 * 1000
+      const shifted = new Date(timestamp.getTime() + offsetMs)
+      const pad = n => String(n).padStart(2, '0')
+      const offsetStr = `${shifted.toISOString().replace('Z', '')}+${pad(2)}:${pad(0)}`
+
+      expect(await sel.clone().where(`dateTime = `, offsetStr)).length(1)
+    })
+
     test('combine expr with nested functions and other compare', async () => {
       const { string } = cds.entities('basic.literals')
       const res = await cds.run(cds.ql`SELECT string FROM ${string} WHERE string != ${'foo'} and contains(tolower(string),tolower(${'bar'}))`)


### PR DESCRIPTION
## Problem

When a CQN WHERE clause contains an ISO datetime string with a non-UTC timezone offset (e.g. `+10:00`), HANA silently drops the offset and compares the bare local time against the UTC-stored value — returning wrong results.

**Example:**
```js
await cds.db.run(
  SELECT.from(Types).where(`timestamp1 >=`, '2026-08-07T00:00:00+10:00',
                           `and timestamp1 <=`, '2026-08-07T23:59:59.999+10:00')
)
```

## Root Cause

Any CQN built directly (custom handlers etc.) skips the normaization in the cds OData layer and the offset string reaches `super.val()` in `cqn2sql.js` unmodified. `val()` had no handling for offset strings — it only knew about `instanceof Date` (which is already UTC via `.toJSON()`).

## Fix

### `db-service/lib/cqn2sql.js` — `super.val()`

Added a `case 'string'` branch that detects ISO datetime strings with a signed offset suffix and normalizes them to UTC before binding:

```js
case 'string':
  if (val.length > 19 && val[10] === 'T' && /[+-]\d{2}:?\d{2}$/.test(val)) {
    const d = new Date(val)
    if (!isNaN(d)) val = d.toJSON()
  }
  break
```

This is the universal fix: all DB engines receive a consistent UTC Z-string regardless of how the CQN was constructed.

### `sqlite/lib/SQLiteService.js` — cleanup

SQLite's `val()` override previously converted *all* ISO datetime strings (including offset strings) to `Date` objects as a side effect. Now that `super.val()` handles offset strings, the SQLite override is narrowed to only Z-suffix strings — the ones that need ms-precision normalization to match what SQLite's `ISO()` function stores:

```js
// before: matched Z, offset, or bare strings
/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d{1,9})?(Z|[+-]\d{2}(:?\d{2})?)$/

// after: Z-suffix only (offset → super.val(), bare strings → must not convert)
/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d{1,9})?Z$/
```

## Tests

Added `compare with DateTime column using non-UTC offset string` to `test/compliance/SELECT.test.js` — runs against all compliance adapters (SQLite, HANA, Postgres). Builds an equivalent `+02:00` offset string for the stored UTC value and asserts it matches exactly one row.