### PR TITLE
fix(cqn4sql): reject overly nested query expressions instead of crashing

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -33,6 +33,23 @@ const notSupportedOps = [['>'], ['<'], ['>='], ['<='], ['*'], ['+'], ['-'], ['/'
 
 const allOps = eqOps.concat(eqOps).concat(notEqOps).concat(notSupportedOps)
 
+
+// Wraps a recursive fn so its live depth is bounded, throwing a catchable 400
+// at the limit. Depth is per wrapper instance, i.e. per `cqn4sql` call.
+const MAX_RECURSION_DEPTH = 300
+function depthGuarded(fn) {
+  let depth = 0
+  return function (...args) {
+    if (++depth > MAX_RECURSION_DEPTH)
+      throw cds.error(400, `Expression exceeds the maximum nesting depth of ${MAX_RECURSION_DEPTH}`)
+    try {
+      return fn.apply(this, args)
+    } finally {
+      depth--
+    }
+  }
+}
+
 const { pseudos } = require('./infer/pseudos')
 /**
  * Transforms a CDL style query into SQL-Like CQN:
@@ -56,6 +73,16 @@ const { pseudos } = require('./infer/pseudos')
  */
 function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   const getImplicitAlias = str => _getImplicitAlias(str, useTechnicalAlias)
+  // guard the input-driven recursive transforms against stack overflow from
+  // nested input
+  // eslint-disable-next-line no-func-assign
+  ;[getTransformedTokenStream, getFlatColumnsFor, nestedProjectionOnStructure, expandColumn, transformSubquery] = [
+    getTransformedTokenStream,
+    getFlatColumnsFor,
+    nestedProjectionOnStructure,
+    expandColumn,
+    transformSubquery,
+  ].map(depthGuarded)
   let inferred = typeof originalQuery === 'string' ? cds.parse.cql(originalQuery) : cds.ql.clone(originalQuery)
   const hasCustomJoins =
     originalQuery.SELECT?.from.args && (!originalQuery.joinTree || originalQuery.joinTree.isInitial)
@@ -182,7 +209,7 @@ function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   /**
    * If the target entity is annotated with persistence skip and has an underlying db entity,
    * we treat it as a runtime view and transform it into a CTE.
-   * 
+   *
    * @param {object} transformedQuery - The query object to be transformed.
    * @param {string} model - The data model used for inference and transformation.
    */
@@ -198,10 +225,10 @@ function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   }
 
   /**
-   * Recursively call cqn4sql for all nested runtime views to calculate cte and 
+   * Recursively call cqn4sql for all nested runtime views to calculate cte and
    * add it as a with clause to the transformed query.
    * Alias the runtime view with a unique alias and update all references to the runtime view to point to the alias.
-   * 
+   *
    * @param {object} rootDefinition - The root definition of the query. This is used to recursively process nested runtime views.
    * @param {object} transformedQuery - The query object to be transformed.
    * @param {string} model - The data model used for infer and cqn4sql.
@@ -995,11 +1022,11 @@ function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
             const keyName = k.as || k.ref.join('_')
             const fkName = `${elemName}_${keyName}`  // e.g., 'head_id'
             const fkFullName = `${columnAlias}_${fkName}`  // e.g., 'department_head_id'
-            
+
             // Check if this FK is excluded
             if (exclude.some(e => (e.ref?.at(-1) || e.as || e) === fkName)) continue
             if (exclude.some(e => (e.ref?.at(-1) || e.as || e) === fkFullName)) continue
-            
+
             const flatColumn = {
               ref: [joinAlias, fkName],
               as: fkFullName,
@@ -1017,7 +1044,7 @@ function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
             calcElement.as = fullName
           }
           res.push(calcElement)
-        }        
+        }
         else {
           // Scalar element
           const flatColumn = {

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -34,21 +34,7 @@ const notSupportedOps = [['>'], ['<'], ['>='], ['<='], ['*'], ['+'], ['-'], ['/'
 const allOps = eqOps.concat(eqOps).concat(notEqOps).concat(notSupportedOps)
 
 
-// Wraps a recursive fn so its live depth is bounded, throwing a catchable 400
-// at the limit. Depth is per wrapper instance, i.e. per `cqn4sql` call.
-const MAX_RECURSION_DEPTH = 300
-function depthGuarded(fn) {
-  let depth = 0
-  return function (...args) {
-    if (++depth > MAX_RECURSION_DEPTH)
-      throw cds.error(400, `Expression exceeds the maximum nesting depth of ${MAX_RECURSION_DEPTH}`)
-    try {
-      return fn.apply(this, args)
-    } finally {
-      depth--
-    }
-  }
-}
+const { depthGuarded, guardEntry } = require('./recursion-guard')
 
 const { pseudos } = require('./infer/pseudos')
 /**
@@ -72,17 +58,17 @@ const { pseudos } = require('./infer/pseudos')
  * @returns {object} transformedQuery the transformed query
  */
 function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
+  // guardEntry bounds subquery nesting and resets the depth budget per top-level call
+  return guardEntry(_cqn4sql)(originalQuery, model, useTechnicalAlias)
+}
+
+function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   const getImplicitAlias = str => _getImplicitAlias(str, useTechnicalAlias)
-  // guard the input-driven recursive transforms against stack overflow from
-  // nested input
+  // guard xpr and inline/expand-on-struct nesting
   // eslint-disable-next-line no-func-assign
-  ;[getTransformedTokenStream, getFlatColumnsFor, nestedProjectionOnStructure, expandColumn, transformSubquery] = [
-    getTransformedTokenStream,
-    getFlatColumnsFor,
-    nestedProjectionOnStructure,
-    expandColumn,
-    transformSubquery,
-  ].map(depthGuarded)
+  getTransformedTokenStream = depthGuarded(getTransformedTokenStream)
+  // eslint-disable-next-line no-func-assign
+  nestedProjectionOnStructure = depthGuarded(nestedProjectionOnStructure)
   let inferred = typeof originalQuery === 'string' ? cds.parse.cql(originalQuery) : cds.ql.clone(originalQuery)
   const hasCustomJoins =
     originalQuery.SELECT?.from.args && (!originalQuery.joinTree || originalQuery.joinTree.isInitial)
@@ -410,6 +396,8 @@ function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
    */
   function translateAssocsToJoins() {
     let from
+    // guard association-path length
+    const joinForBranch = depthGuarded(_joinForBranch)
     /**
      * remember already seen aliases, do not create a join for them again
      */
@@ -433,7 +421,7 @@ function cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     })
     return from.args.length > 1 ? from : from.args[0]
 
-    function joinForBranch(lhs, node) {
+    function _joinForBranch(lhs, node) {
       const nextAssoc = inferred.joinTree.findNextAssoc(node)
       if (!nextAssoc || alreadySeen.has(nextAssoc.$refLink.alias)) return lhs.args.length > 1 ? lhs : lhs.args[0]
 

--- a/db-service/lib/infer/index.js
+++ b/db-service/lib/infer/index.js
@@ -5,15 +5,19 @@ const cds = require('@sap/cds')
 const JoinTree = require('./join-tree')
 const { pseudos } = require('./pseudos')
 const { isCalculatedOnRead, getImplicitAlias, getModelUtils, defineProperty, hasOwnSkip, isRuntimeView } = require('../utils')
+const { depthGuarded, guardEntry } = require('../recursion-guard')
 const cdsTypes = cds.builtin.types
 /**
  * @param {import('@sap/cds/apis/cqn').Query|string} originalQuery
  * @param {import('@sap/cds/apis/csn').CSN} [model]
  * @returns {import('./cqn').Query} = q with .target and .elements
  */
-function infer(originalQuery, model, useTechnicalAlias = true) {
+function _infer(originalQuery, model, useTechnicalAlias = true) {
   if (!model) throw new Error('Please specify a model')
   const inferred = originalQuery
+  // guard func args / lists / xpr / exists nesting
+  // eslint-disable-next-line no-func-assign
+  inferArg = depthGuarded(inferArg)
 
   const { getDefinition } = getModelUtils(model, originalQuery)
 
@@ -291,19 +295,23 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
      */
     function walkTokenStream(tokenStream, inXpr = false) {
       let skipJoins
-      const processToken = t => {
-        if (t === 'exists') {
-          // no joins for infix filters along `exists <path>`
-          skipJoins = true
-        } else if (t.xpr) {
-          // don't miss an exists within an expression
-          t.xpr.forEach(processToken)
-        } else {
-          inferArg(t, queryElements, null, { inExists: skipJoins, inXpr, inQueryModifier: true })
-          skipJoins = false
+      const processToken = depthGuarded(walker())
+      tokenStream.forEach(processToken)
+
+      function walker() {
+        return t => {
+          if (t === 'exists') {
+            // no joins for infix filters along `exists <path>`
+            skipJoins = true
+          } else if (t.xpr) {
+            // don't miss an exists within an expression
+            t.xpr.forEach(processToken)
+          } else {
+            inferArg(t, queryElements, null, { inExists: skipJoins, inXpr, inQueryModifier: true })
+            skipJoins = false
+          }
         }
       }
-      tokenStream.forEach(processToken)
     }
     /**
      * Processes references starting with `$self`, which are intended to target other query elements.
@@ -631,7 +639,7 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
         } else if (arg.inline && queryElements) {
           const elements = resolveInline(arg)
           for (const elName in elements) {
-            if (queryElements[elName] !== undefined) rejectDuplicatedElement(elName)  
+            if (queryElements[elName] !== undefined) rejectDuplicatedElement(elName)
           }
           Object.assign(queryElements, elements)
         } else {
@@ -667,7 +675,7 @@ function infer(originalQuery, model, useTechnicalAlias = true) {
     // ignore whole expand if target of assoc along path has ”@cds.persistence.skip”
     if (arg.expand) {
       const { $refLinks } = arg
-      
+
       const skip = $refLinks.some(link => {
         const def = getDefinition(link.definition.target)
         return hasOwnSkip(def) && !isRuntimeView(def)
@@ -1286,5 +1294,8 @@ function getMainAlias (query) {
   if(!mainAlias) throw new Error('Cannot determine main query source for $main, please report this')
   return mainAlias
 }
+
+// guardEntry bounds nested-subquery re-entry (expand, from, set)
+const infer = guardEntry(_infer)
 
 module.exports = infer

--- a/db-service/lib/recursion-guard.js
+++ b/db-service/lib/recursion-guard.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const cds = require('@sap/cds')
+
+// shared across cqn4sql and infer to guard against stack overflow from user-controlled nesting depth
+const MAX_RECURSION_DEPTH = 100
+
+let recursionDepth = 0
+
+function enterRecursion() {
+  if (++recursionDepth > MAX_RECURSION_DEPTH) throw cds.error(400, `Query exceeds the maximum nesting depth of ${MAX_RECURSION_DEPTH}`)
+}
+
+function depthGuarded(fn) {
+  return function (...args) {
+    enterRecursion()
+    try {
+      return fn.apply(this, args)
+    } finally {
+      recursionDepth--
+    }
+  }
+}
+
+// entry points (infer / cqn4sql): outermost call resets the counter, so a thrown
+// depth error can't leave it polluted for the next request
+function guardEntry(fn) {
+  return function (...args) {
+    const outermost = recursionDepth === 0
+    enterRecursion()
+    try {
+      return fn.apply(this, args)
+    } finally {
+      if (outermost) recursionDepth = 0
+      else recursionDepth--
+    }
+  }
+}
+
+module.exports = { depthGuarded, guardEntry }

--- a/db-service/test/cqn4sql/not-supported.test.js
+++ b/db-service/test/cqn4sql/not-supported.test.js
@@ -25,4 +25,54 @@ describe('not supported features', () => {
     query.SELECT.where = [inner]
     expect(() => cqn4sql(query, model)).to.throw(/nesting depth/)
   })
+
+  it('rejects deeply nested subqueries instead of overflowing the stack', () => {
+    const query = nestedSubqueries(5000)
+    expect(() => cqn4sql(query, model)).to.throw(/nesting depth/)
+  })
+
+  it('rejects excessively long association paths instead of overflowing the stack', () => {
+    // path length is request-controlled: books.author.books.author.…name
+    const ref = []
+    for (let i = 0; i < 5000; i++) ref.push(i % 2 === 0 ? 'books' : 'author')
+    ref.push('name')
+    const query = { SELECT: { from: { ref: ['bookshop.Authors'] }, columns: [{ ref }] } }
+    expect(() => cqn4sql(query, model)).to.throw(/nesting depth/)
+  })
+
+  it('rejects deeply nested inline projections instead of overflowing the stack', () => {
+    // nested inline/expand on struct is request-controlled
+    let col = { ref: ['author'], inline: [{ ref: ['ID'] }] }
+    for (let i = 0; i < 500; i++) col = { ref: i % 2 ? ['author'] : ['books'], inline: [col] }
+    const query = { SELECT: { from: { ref: ['bookshop.Authors'] }, columns: [{ ref: ['books'], inline: [col] }] } }
+    expect(() => cqn4sql(query, model)).to.throw(/nesting depth/)
+  })
+
+  it('rejects deeply nested function args instead of overflowing the stack', () => {
+    let fn = { func: 'lower', args: [{ val: 'x' }] }
+    for (let i = 0; i < 5000; i++) fn = { func: 'lower', args: [fn] }
+    const query = { SELECT: { from: { ref: ['bookshop.Books'] }, columns: [{ ref: ['ID'] }], where: [fn, '=', { val: 'x' }] } }
+    expect(() => cqn4sql(query, model)).to.throw(/nesting depth/)
+  })
+
+  it('rejects deeply nested lists instead of overflowing the stack', () => {
+    let list = { list: [{ val: 1 }] }
+    for (let i = 0; i < 5000; i++) list = { list: [list] }
+    const query = { SELECT: { from: { ref: ['bookshop.Books'] }, columns: [{ ref: ['ID'] }], where: [{ ref: ['ID'] }, 'in', list] } }
+    expect(() => cqn4sql(query, model)).to.throw(/nesting depth/)
+  })
+
+  function nestedSubqueries(depth) {
+    let inner = { SELECT: { from: { ref: ['bookshop.Books'] }, columns: [{ ref: ['ID'] }] } }
+    for (let i = 0; i < depth; i++) {
+      inner = {
+        SELECT: {
+          from: { ref: ['bookshop.Books'] },
+          columns: [{ ref: ['ID'] }],
+          where: [{ ref: ['ID'] }, 'in', inner],
+        },
+      }
+    }
+    return inner
+  }
 })

--- a/db-service/test/cqn4sql/not-supported.test.js
+++ b/db-service/test/cqn4sql/not-supported.test.js
@@ -16,4 +16,13 @@ describe('not supported features', () => {
     expect(cqn4sql(query, model)).to.deep.equal(_inferred(query, model))
     // .to.throw(/Queries with multiple query sources are not supported/)
   })
+
+  it('rejects excessively nested expressions instead of overflowing the stack', () => {
+    // deeply nested parens (e.g. crafted OData `$filter`) become nested `xpr`s
+    let inner = { xpr: [{ ref: ['ID'] }, '=', { val: 1 }] }
+    for (let i = 0; i < 3000; i++) inner = { xpr: [inner] }
+    const query = cds.ql`SELECT from bookshop.Books`
+    query.SELECT.where = [inner]
+    expect(() => cqn4sql(query, model)).to.throw(/nesting depth/)
+  })
 })

--- a/test/scenarios/bookshop/read.test.js
+++ b/test/scenarios/bookshop/read.test.js
@@ -18,6 +18,12 @@ describe('Bookshop - Read', () => {
     expect(res.data.value.length).to.be.eq(totalBooks)
   })
 
+  test('deeply nested $filter parentheses do not crash the server', async () => {
+    const nested = '('.repeat(2000) + 'ID eq 1' + ')'.repeat(2000)
+    const err = await GET(`/browse/Books?$filter=${nested}`).catch(e => e)
+    expect(err.response.status).to.be.eq(400)
+  })
+
   test('Books $count with $top=0', async () => {
     const res = await GET('/browse/ListOfBooks?$count=true&$top=0')
     expect(res.status).to.be.eq(200)


### PR DESCRIPTION
Deeply nested input (subqueries, xpr, association paths, inline/expand,   functions/lists) recursed until the stack overflowed, crashing with a 500.

Add a shared depth budget across infer and cqn4sql, raising a 400 instead.