### PR TITLE
fix: destroy connections on failed COMMIT/ROLLBACK/BEGIN

### DIFF
--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -99,9 +99,9 @@ class DatabaseService extends cds.Service {
     try {
       await this.send('ROLLBACK')
       this.release()
-    } catch (e) {
+    } catch {
+      // don't re-throw: rollback() is the error handler in .then(commit, rollback)
       await this.destroy()
-      throw e
     }
   }
 

--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -71,7 +71,7 @@ class DatabaseService extends cds.Service {
       await this.set(new SessionContext(ctx))
       await this.send('BEGIN')
     } catch (e) {
-      this.release()
+      await this.destroy() // set()/BEGIN may have left the connection in an unusable state, so don't return it to the pool
       throw e
     }
     return this
@@ -82,8 +82,13 @@ class DatabaseService extends cds.Service {
    */
   async commit() {
     if (!this.dbc) return
-    await this.send('COMMIT')
-    this.release() // only release on successful commit as otherwise released on rollback
+    try {
+      await this.send('COMMIT')
+      this.release() // only release on successful commit as otherwise released on rollback
+    } catch (e) {
+      await this.destroy() // COMMIT may have left the connection in an unusable state, so don't return it to the pool
+      throw e
+    }
   }
 
   /**
@@ -93,8 +98,10 @@ class DatabaseService extends cds.Service {
     if (!this.dbc) return
     try {
       await this.send('ROLLBACK')
-    } finally {
       this.release()
+    } catch (e) {
+      await this.destroy() // ROLLBACK may have left the connection in an unusable state, so don't return it to the pool
+      throw e
     }
   }
 

--- a/db-service/lib/common/DatabaseService.js
+++ b/db-service/lib/common/DatabaseService.js
@@ -71,7 +71,7 @@ class DatabaseService extends cds.Service {
       await this.set(new SessionContext(ctx))
       await this.send('BEGIN')
     } catch (e) {
-      await this.destroy() // set()/BEGIN may have left the connection in an unusable state, so don't return it to the pool
+      await this.destroy()
       throw e
     }
     return this
@@ -84,9 +84,9 @@ class DatabaseService extends cds.Service {
     if (!this.dbc) return
     try {
       await this.send('COMMIT')
-      this.release() // only release on successful commit as otherwise released on rollback
+      this.release()
     } catch (e) {
-      await this.destroy() // COMMIT may have left the connection in an unusable state, so don't return it to the pool
+      await this.destroy()
       throw e
     }
   }
@@ -100,7 +100,7 @@ class DatabaseService extends cds.Service {
       await this.send('ROLLBACK')
       this.release()
     } catch (e) {
-      await this.destroy() // ROLLBACK may have left the connection in an unusable state, so don't return it to the pool
+      await this.destroy()
       throw e
     }
   }


### PR DESCRIPTION
… instead of releasing them, leaking dead connections. This was reported in cap/issues/21051 and I built some regression tests in our MTX HANA test setup (cds-mtxs/pull/1677).