### PR TITLE
fix: correlate $search ranking ORDER BY to the outer row

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -82,17 +82,9 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
       const { where, having } = transformSearch(searchTerm)
       if (where) inferred.SELECT.where = where
       else if (having) inferred.SELECT.having = having
-      if (searchTerm.func) (inferred.SELECT.orderBy ??= []).unshift({ func: searchTerm.func, args: [...searchTerm.args, true], sort: 'desc' })
-      else if (searchTerm.xpr) {
-        const searchSelect = searchTerm.xpr[2]
-        const searchFunc = searchSelect.SELECT.where[0]
-          ; (inferred.SELECT.orderBy ??= []).unshift({
-            __proto__: SELECT.from(searchSelect.SELECT.from)
-              .columns({ func: searchFunc.func, args: [...searchFunc.args, true] })
-              .where([searchTerm.xpr[0], 'in', { list: searchSelect.SELECT.columns }]), // TODO: <-- ensure that the sub select in the order by is bound to the original query result row
-            sort: 'desc'
-          })
-      }
+      // Defer the ranking ORDER BY to after infer(), where the outer table alias is known and the
+      // deep-search sub-select can be correlated to the outer row (see buildSearchRankOrderBy).
+      defineProperty(inferred, '$searchRank', searchTerm)
     }
   }
   // query modifiers can also be defined in from ref leaf infix filter
@@ -341,9 +333,17 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
 
     // Since all the expressions in the SELECT part of the query have been computed,
     // one can reference aliases of the queries columns in the orderBy clause.
-    if (orderBy) {
-      const transformedOrderBy = getTransformedOrderByGroupBy(orderBy, true)
+    let effectiveOrderBy = orderBy
+    // Rank by $search relevance. Prepended here (post-infer) so the deep-search scalar sub-select
+    // can be correlated to the OUTER row, whose alias is only known now.
+    const searchRank = inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
+    if (searchRank) effectiveOrderBy = [searchRank, ...(orderBy || [])]
+    if (effectiveOrderBy) {
+      const transformedOrderBy = getTransformedOrderByGroupBy(effectiveOrderBy, true)
       if (transformedOrderBy.length) {
+        // correlate the (now transformed) deep-search ranking sub-select to the outer row
+        if (searchRank?.$searchRank && transformedOrderBy[0].SELECT)
+          correlateSearchRank(transformedOrderBy[0], transformedFrom.as)
         transformedQuery.SELECT.orderBy = transformedOrderBy
       }
     }
@@ -2606,6 +2606,73 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
 
     const subquery = SELECT.from(entity).columns(...matchColumns).where(searchFunc)
     return { xpr: [matchColumns.length === 1 ? matchColumns[0] : { list: matchColumns }, 'in', subquery] }
+  }
+
+  /**
+   * Builds the ORDER BY entry ranking rows by $search relevance, sorted desc.
+   *
+   * Flat search: the score is computed on the outer row itself, so the entry is just the
+   * search() func with the numeric flag (`true`) appended.
+   *
+   * Deep search: the score lives in a semi-join sub-select, so we emit a CORRELATED scalar
+   * sub-select that selects the numeric score and binds its inner key(s) to the outer row:
+   *   (SELECT search(<cols>, <val>, true) FROM <same source> WHERE innerKey = <outerAlias>.key) DESC
+   *
+   * The correlation cannot be expressed by pre-qualifying the outer key here: the sub-select's
+   * source is the same entity as the outer query, so infer() would re-resolve an outer-qualified
+   * ref back to the sub-select's own source. Instead we build both sides of each key comparison
+   * unqualified (they resolve to the sub-select's own alias) and mark the entry as `$searchRank`,
+   * so it can be correlated to the outer alias AFTER transformation (see correlateSearchRank) —
+   * the same "rewrite the inner alias to the outer alias" trick used by expand's _correlate.
+   *
+   * @param {object} searchTerm the search term as returned by getSearch (func or xpr shape)
+   * @returns {object|null} an orderBy entry, or null if there is nothing to rank by
+   */
+  function buildSearchRankOrderBy(searchTerm) {
+    if (searchTerm.func) return { func: searchTerm.func, args: [...searchTerm.args, { val: true }], sort: 'desc' }
+    if (!searchTerm.xpr) return null
+
+    const searchSelect = searchTerm.xpr[2]
+    const searchFunc = searchSelect.SELECT.where[0]
+    const innerKeys = searchSelect.SELECT.columns // unqualified pk refs, e.g. [{ ref: ['ID'] }]
+
+    const where = []
+    for (let i = 0; i < innerKeys.length; i++) {
+      if (i) where.push('and')
+      // both sides unqualified -> resolve to the sub-select's own alias; the right-hand side is
+      // rewired to the outer alias post-transform in correlateSearchRank
+      where.push({ ref: [...innerKeys[i].ref] }, '=', { ref: [...innerKeys[i].ref] })
+    }
+
+    const entry = {
+      __proto__: SELECT.from(searchSelect.SELECT.from)
+        // one correlated outer row fans out to many joined child rows -> MAX collapses them to a
+        // single value so the scalar sub-select is well-defined: rank by the best-matching score
+        .columns({ func: 'max', args: [{ func: searchFunc.func, args: [...searchFunc.args, { val: true }] }] })
+        .where(where),
+      sort: 'desc',
+    }
+    defineProperty(entry, '$searchRank', true)
+    return entry
+  }
+
+  /**
+   * Correlates the deep-search ranking sub-select to the outer row, after it has been transformed.
+   *
+   * The transformed sub-select's WHERE is a chain of `innerKey = innerKey` comparisons, both sides
+   * resolved to the sub-select's own leading source alias. This rewrites the right-hand side of each
+   * comparison to `<outerAlias>.<key>`, turning the tautology into a correlation to the outer row.
+   *
+   * @param {object} entry the transformed orderBy entry produced from a `$searchRank` sub-select
+   * @param {string} outerAlias the final table alias of the outer query source
+   */
+  function correlateSearchRank(entry, outerAlias) {
+    const where = entry.SELECT.where
+    // comparisons are laid out as: ref '=' ref ['and' ref '=' ref ...] -> every 3rd token (rhs)
+    for (let i = 2; i < where.length; i += 4) {
+      const rhs = where[i]
+      rhs.ref = [outerAlias, ...rhs.ref.slice(1)]
+    }
   }
 
   /**

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -334,11 +334,12 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     // Since all the expressions in the SELECT part of the query have been computed,
     // one can reference aliases of the queries columns in the orderBy clause.
     let effectiveOrderBy = orderBy
-    // Rank by $search relevance. Only HANA fuzzy search yields a score; without it the ranking
-    // would sort by a constant boolean, so skip it. Prepended here (post-infer) so the deep-search
-    // scalar sub-select can be correlated to the OUTER row, whose alias is only known now.
-    const searchRank =
-      inferred.$searchRank && cds.env.hana?.fuzzy !== false && buildSearchRankOrderBy(inferred.$searchRank)
+    // Rank by $search relevance. Only HANA fuzzy search yields a score; on other DBs (or with
+    // hana.fuzzy === false) search() is a boolean, so ranking would sort by a constant — skip it.
+    // Prepended here (post-infer) so the deep-search scalar sub-select can be correlated to the
+    // OUTER row, whose alias is only known now.
+    const ranksSearch = cds.db?.kind === 'hana' && cds.env.hana?.fuzzy !== false
+    const searchRank = ranksSearch && inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
     if (searchRank) effectiveOrderBy = [searchRank, ...(orderBy || [])]
     if (effectiveOrderBy) {
       const transformedOrderBy = getTransformedOrderByGroupBy(effectiveOrderBy, true)

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -335,18 +335,30 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     // one can reference aliases of the queries columns in the orderBy clause.
     let effectiveOrderBy = orderBy
     // Rank by $search relevance. Only HANA fuzzy search yields a score; on other DBs (or with
-    // hana.fuzzy === false) search() is a boolean, so ranking would sort by a constant — skip it.
-    // Prepended here (post-infer) so the deep-search scalar sub-select can be correlated to the
-    // OUTER row, whose alias is only known now.
-    const ranksSearch = cds.db?.kind === 'hana' && cds.env.hana?.fuzzy !== false
+    // hana.fuzzy === false, or opted out via hana.fuzzy.ranked_search === false) search() is a
+    // boolean, so ranking would sort by a constant — skip it. Built here (post-infer) so the
+    // deep-search scalar sub-select can be correlated to the OUTER row, whose alias is only known now.
+    const ranksSearch =
+      cds.db?.kind === 'hana' && cds.env.hana?.fuzzy !== false && cds.env.hana?.fuzzy?.ranked_search !== false
     const searchRank = ranksSearch && inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
-    if (searchRank) effectiveOrderBy = [searchRank, ...(orderBy || [])]
+    if (searchRank) {
+      // Precedence: user-provided ordering wins, then $search rank, then the runtime's implicit
+      // key ordering (`implicit: true`, added for stable pagination). So insert the rank right
+      // before the first implicit entry (or at the end if there is none).
+      const implicitAt = (orderBy || []).findIndex(o => o.implicit)
+      const at = implicitAt === -1 ? (orderBy?.length ?? 0) : implicitAt
+      effectiveOrderBy = [...(orderBy || [])]
+      effectiveOrderBy.splice(at, 0, searchRank)
+    }
     if (effectiveOrderBy) {
       const transformedOrderBy = getTransformedOrderByGroupBy(effectiveOrderBy, true)
       if (transformedOrderBy.length) {
-        // correlate the (now transformed) deep-search ranking sub-select to the outer row
-        if (searchRank?.$searchRank && transformedOrderBy[0].SELECT)
-          correlateSearchRank(transformedOrderBy[0], transformedFrom.as)
+        // correlate the (now transformed) deep-search ranking sub-select to the outer row; it is
+        // the only order-by entry that is a correlated sub-select
+        if (searchRank?.$searchRank) {
+          const rank = transformedOrderBy.find(o => o.SELECT)
+          if (rank) correlateSearchRank(rank, transformedFrom.as)
+        }
         transformedQuery.SELECT.orderBy = transformedOrderBy
       }
     }

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -2611,19 +2611,15 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   /**
    * Builds the ORDER BY entry ranking rows by $search relevance, sorted desc.
    *
-   * Flat search: the score is computed on the outer row itself, so the entry is just the
-   * search() func with the numeric flag (`true`) appended.
+   * Flat search: the score is on the outer row, so the entry is the search() func with the
+   * numeric flag appended.
    *
-   * Deep search: the score lives in a semi-join sub-select, so we emit a CORRELATED scalar
-   * sub-select that selects the numeric score and binds its inner key(s) to the outer row:
+   * Deep search: the score lives in a semi-join sub-select, so we emit a correlated scalar
+   * sub-select selecting the score, keyed back to the outer row:
    *   (SELECT search(<cols>, <val>, true) FROM <same source> WHERE innerKey = <outerAlias>.key) DESC
-   *
-   * The correlation cannot be expressed by pre-qualifying the outer key here: the sub-select's
-   * source is the same entity as the outer query, so infer() would re-resolve an outer-qualified
-   * ref back to the sub-select's own source. Instead we build both sides of each key comparison
-   * unqualified (they resolve to the sub-select's own alias) and mark the entry as `$searchRank`,
-   * so it can be correlated to the outer alias AFTER transformation (see correlateSearchRank) —
-   * the same "rewrite the inner alias to the outer alias" trick used by expand's _correlate.
+   * Both sides of the key comparison are seeded unqualified so infer() binds them to the
+   * sub-select's own source; the rhs is redirected to the outer alias afterwards, see
+   * correlateSearchRank.
    *
    * @param {object} searchTerm the search term as returned by getSearch (func or xpr shape)
    * @returns {object|null} an orderBy entry, or null if there is nothing to rank by
@@ -2639,8 +2635,7 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     const where = []
     for (let i = 0; i < innerKeys.length; i++) {
       if (i) where.push('and')
-      // both sides unqualified -> resolve to the sub-select's own alias; the right-hand side is
-      // rewired to the outer alias post-transform in correlateSearchRank
+      // seeded unqualified on both sides; correlateSearchRank redirects the rhs to the outer row
       where.push({ ref: [...innerKeys[i].ref] }, '=', { ref: [...innerKeys[i].ref] })
     }
 

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -334,17 +334,13 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     // Since all the expressions in the SELECT part of the query have been computed,
     // one can reference aliases of the queries columns in the orderBy clause.
     let effectiveOrderBy = orderBy
-    // Rank by $search relevance. Only HANA fuzzy search yields a score; on other DBs (or with
-    // hana.fuzzy === false, or opted out via hana.fuzzy.ranked_search === false) search() is a
-    // boolean, so ranking would sort by a constant — skip it. Built here (post-infer) so the
-    // deep-search scalar sub-select can be correlated to the OUTER row, whose alias is only known now.
+    // Rank by $search relevance — only when the score exists (HANA fuzzy, not opted out); else
+    // it would sort by a constant boolean.
     const ranksSearch =
       cds.db?.kind === 'hana' && cds.env.hana?.fuzzy !== false && cds.env.hana?.fuzzy?.ranked_search !== false
     const searchRank = ranksSearch && inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
     if (searchRank) {
-      // Precedence: user-provided ordering wins, then $search rank, then the runtime's implicit
-      // key ordering (`implicit: true`, added for stable pagination). So insert the rank right
-      // before the first implicit entry (or at the end if there is none).
+      // precedence: user ordering, then rank, then the runtime's implicit key ordering
       const implicitAt = (orderBy || []).findIndex(o => o.implicit)
       const at = implicitAt === -1 ? (orderBy?.length ?? 0) : implicitAt
       effectiveOrderBy = [...(orderBy || [])]
@@ -353,8 +349,7 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     if (effectiveOrderBy) {
       const transformedOrderBy = getTransformedOrderByGroupBy(effectiveOrderBy, true)
       if (transformedOrderBy.length) {
-        // correlate the (now transformed) deep-search ranking sub-select to the outer row; it is
-        // the only order-by entry that is a correlated sub-select
+        // the rank is the only order-by entry that is a correlated sub-select
         if (searchRank?.$searchRank) {
           const rank = transformedOrderBy.find(o => o.SELECT)
           if (rank) correlateSearchRank(rank, transformedFrom.as)
@@ -2626,15 +2621,11 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   /**
    * Builds the ORDER BY entry ranking rows by $search relevance, sorted desc.
    *
-   * Flat search: the score is on the outer row, so the entry is the search() func with the
-   * numeric flag appended.
-   *
-   * Deep search: the score lives in a semi-join sub-select, so we emit a correlated scalar
-   * sub-select selecting the score, keyed back to the outer row:
-   *   (SELECT search(<cols>, <val>, true) FROM <same source> WHERE innerKey = <outerAlias>.key) DESC
-   * Both sides of the key comparison are seeded unqualified so infer() binds them to the
-   * sub-select's own source; the rhs is redirected to the outer alias afterwards, see
-   * correlateSearchRank.
+   * Flat search: the score is on the outer row.
+   * Deep search: the score lives in a semi-join, so emit a correlated scalar sub-select
+   *   (SELECT search(…, true) FROM <same source> WHERE innerKey = <outerAlias>.key) DESC.
+   * Key comparisons are seeded unqualified (infer() binds them to the sub-select's own source);
+   * correlateSearchRank redirects the rhs to the outer alias afterwards.
    *
    * @param {object} searchTerm the search term as returned by getSearch (func or xpr shape)
    * @returns {object|null} an orderBy entry, or null if there is nothing to rank by
@@ -2656,8 +2647,7 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
 
     const entry = {
       __proto__: SELECT.from(searchSelect.SELECT.from)
-        // one correlated outer may lead to many joined child rows -> MAX collapses them to a
-        // single value so the scalar sub-select is valid in the context of order by: rank by the best-matching score
+        // the correlated outer row fans out to many child rows -> MAX makes it a single score
         .columns({ func: 'max', args: [{ func: searchFunc.func, args: [...searchFunc.args, { val: true }] }] })
         .where(where),
       sort: 'desc',
@@ -2667,13 +2657,11 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   }
 
   /**
-   * Correlates the deep-search ranking sub-select to the outer row, after it has been transformed.
+   * Correlates the (transformed) deep-search ranking sub-select to the outer row.
    *
-   * `buildSearchRankOrderBy` seeds the sub-select's WHERE as a chain of `innerKey = innerKey`
-   * comparisons (`ref '=' ref ['and' ref '=' ref ...]`), both sides resolved to the sub-select's
-   * own leading source alias. For each such `=` comparison this rewrites the right-hand ref to
-   * `<outerAlias>.<key>`, turning the tautology into a correlation to the outer row. Driven off the
-   * `=` operator (not a fixed stride) so it stays correct regardless of key count.
+   * buildSearchRankOrderBy seeds its WHERE as `ref = ref` comparisons on the sub-select's own
+   * alias; this rewrites each rhs to `<outerAlias>.<key>`. Driven off the `=` operator (not a
+   * fixed stride) so it holds for any key count.
    *
    * @param {object} entry the transformed orderBy entry produced from a `$searchRank` sub-select
    * @param {string} outerAlias the final table alias of the outer query source

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -334,9 +334,11 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     // Since all the expressions in the SELECT part of the query have been computed,
     // one can reference aliases of the queries columns in the orderBy clause.
     let effectiveOrderBy = orderBy
-    // Rank by $search relevance. Prepended here (post-infer) so the deep-search scalar sub-select
-    // can be correlated to the OUTER row, whose alias is only known now.
-    const searchRank = inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
+    // Rank by $search relevance. Only HANA fuzzy search yields a score; without it the ranking
+    // would sort by a constant boolean, so skip it. Prepended here (post-infer) so the deep-search
+    // scalar sub-select can be correlated to the OUTER row, whose alias is only known now.
+    const searchRank =
+      inferred.$searchRank && cds.env.hana?.fuzzy !== false && buildSearchRankOrderBy(inferred.$searchRank)
     if (searchRank) effectiveOrderBy = [searchRank, ...(orderBy || [])]
     if (effectiveOrderBy) {
       const transformedOrderBy = getTransformedOrderByGroupBy(effectiveOrderBy, true)

--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -2646,8 +2646,8 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
 
     const entry = {
       __proto__: SELECT.from(searchSelect.SELECT.from)
-        // one correlated outer row fans out to many joined child rows -> MAX collapses them to a
-        // single value so the scalar sub-select is well-defined: rank by the best-matching score
+        // one correlated outer may lead to many joined child rows -> MAX collapses them to a
+        // single value so the scalar sub-select is valid in the context of order by: rank by the best-matching score
         .columns({ func: 'max', args: [{ func: searchFunc.func, args: [...searchFunc.args, { val: true }] }] })
         .where(where),
       sort: 'desc',
@@ -2659,19 +2659,23 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
   /**
    * Correlates the deep-search ranking sub-select to the outer row, after it has been transformed.
    *
-   * The transformed sub-select's WHERE is a chain of `innerKey = innerKey` comparisons, both sides
-   * resolved to the sub-select's own leading source alias. This rewrites the right-hand side of each
-   * comparison to `<outerAlias>.<key>`, turning the tautology into a correlation to the outer row.
+   * `buildSearchRankOrderBy` seeds the sub-select's WHERE as a chain of `innerKey = innerKey`
+   * comparisons (`ref '=' ref ['and' ref '=' ref ...]`), both sides resolved to the sub-select's
+   * own leading source alias. For each such `=` comparison this rewrites the right-hand ref to
+   * `<outerAlias>.<key>`, turning the tautology into a correlation to the outer row. Driven off the
+   * `=` operator (not a fixed stride) so it stays correct regardless of key count.
    *
    * @param {object} entry the transformed orderBy entry produced from a `$searchRank` sub-select
    * @param {string} outerAlias the final table alias of the outer query source
    */
   function correlateSearchRank(entry, outerAlias) {
     const where = entry.SELECT.where
-    // comparisons are laid out as: ref '=' ref ['and' ref '=' ref ...] -> every 3rd token (rhs)
-    for (let i = 2; i < where.length; i += 4) {
-      const rhs = where[i]
-      rhs.ref = [outerAlias, ...rhs.ref.slice(1)]
+    for (let i = 1; i < where.length; i++) {
+      // seeded comparisons are exactly `<ref> = <ref>`; rewrite the rhs ref to the outer row
+      if (where[i] === '=' && where[i - 1]?.ref && where[i + 1]?.ref) {
+        const rhs = where[i + 1]
+        rhs.ref = [outerAlias, ...rhs.ref.slice(1)]
+      }
     }
   }
 

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -3,6 +3,18 @@ const cqn4sql = require('../../lib/cqn4sql')
 const cds = require('@sap/cds')
 const { expect } = cds.test
 
+// PR #1564 injects an `ORDER BY <search-score> DESC` into every search query so results are
+// ranked by relevance. Each test asserts the full transformed query — including that order-by —
+// as a single cds.ql template, so a regression in the injected ranking is caught.
+//
+// Flat (non-navigation) search: the score is computed on the row itself, so the order-by is just
+// the search() func with the numeric flag `true` appended, sorted desc.
+//
+// Deep (path-expression) search: the where clause is a semi-join `outerKey in (SELECT key FROM
+// <joins> WHERE search(...))`; the order-by is a scalar sub-select over the SAME joins that
+// selects the numeric score (`search(..., true) as search`) and is correlated to the current
+// outer row via `innerKey = outerKey` (AND-chained for structured keys).
+
 describe('Replace attribute search by search predicate', () => {
   let model
   beforeAll(async () => {
@@ -18,7 +30,8 @@ describe('Replace attribute search by search predicate', () => {
     // single val is stored as val directly, not as expr with val
     const expected = cds.ql`
       SELECT from bookshop.WithStructuredKey as wsk { wsk.second }
-      where search(wsk.second, 'x')`
+      where search(wsk.second, 'x')
+      order by search(wsk.second, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -30,7 +43,8 @@ describe('Replace attribute search by search predicate', () => {
     let res = cqn4sql(query, model)
     const expected = cds.ql`
       SELECT from bookshop.WithStructuredKey as wsk { wsk.second }
-      where search(wsk.second, ('x' OR 'y'))`
+      where search(wsk.second, ('x' OR 'y'))
+      order by search(wsk.second, ('x' or 'y'), true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -39,9 +53,11 @@ describe('Replace attribute search by search predicate', () => {
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`SELECT from bookshop.Genres as Genres {
+    const expected = cds.ql`SELECT from bookshop.Genres as Genres {
       Genres.ID
-    } where search((Genres.name, Genres.descr, Genres.code), ('x' OR 'y'))`)
+    } where search((Genres.name, Genres.descr, Genres.code), ('x' OR 'y'))
+      order by search((Genres.name, Genres.descr, Genres.code), ('x' or 'y'), true) desc`
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
   it('with existing WHERE clause', () => {
@@ -52,7 +68,8 @@ describe('Replace attribute search by search predicate', () => {
     const expected = cds.ql`SELECT from bookshop.Genres as Genres {
       Genres.ID
     } where (Genres.ID < 4 or Genres.ID > 5)
-      and search((Genres.name, Genres.descr, Genres.code), ('x' OR 'y'))`
+      and search((Genres.name, Genres.descr, Genres.code), ('x' OR 'y'))
+      order by search((Genres.name, Genres.descr, Genres.code), ('x' or 'y'), true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -81,6 +98,17 @@ describe('Replace attribute search by search predicate', () => {
             func: 'search',
           },
         ],
+        orderBy: [
+          {
+            func: 'search',
+            args: [
+              { list: [{ ref: ['Genres', 'name'] }, { ref: ['Genres', 'descr'] }, { ref: ['Genres', 'code'] }] },
+              { xpr: [{ val: 'x' }, 'or', { val: 'y' }] },
+              { val: true },
+            ],
+            sort: 'desc',
+          },
+        ],
       },
     }
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
@@ -93,7 +121,8 @@ describe('Replace attribute search by search predicate', () => {
     let res = cqn4sql(query, model)
     const expected = cds.ql`SELECT from bookshop.Person as Person {
       Person.ID
-    } where (search((Person.name, Person.placeOfBirth, Person.placeOfDeath, Person.address_street, Person.address_city), ('x' OR 'y')))`
+    } where (search((Person.name, Person.placeOfBirth, Person.placeOfDeath, Person.address_street, Person.address_city), ('x' OR 'y')))
+      order by search((Person.name, Person.placeOfBirth, Person.placeOfDeath, Person.address_street, Person.address_city), ('x' or 'y'), true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -102,6 +131,7 @@ describe('Replace attribute search by search predicate', () => {
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
+    // no searchable string elements → no search predicate and no ranking order-by
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(cds.ql`SELECT from bookshop.Foo as Foo {
       Foo.ID
     }`)
@@ -111,16 +141,16 @@ describe('Replace attribute search by search predicate', () => {
     query.SELECT.search = [{ val: 'x' }, 'or', { val: 'y' }]
 
     let res = cqn4sql(query, model)
-    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(
-      cds.ql`
+    const expected = cds.ql`
       SELECT from bookshop.Books as Books
         left join bookshop.Authors as author on author.ID = Books.author_ID
         left join bookshop.Books as books2 on  books2.author_ID = author.ID
       {
         Books.ID,
         books2.title as authorsBook
-      } where search((Books.createdBy, Books.modifiedBy, Books.anotherText, Books.title, Books.descr, Books.currency_code, Books.dedication_text, Books.dedication_sub_foo, Books.dedication_dedication), ('x' OR 'y'))`,
-    )
+      } where search((Books.createdBy, Books.modifiedBy, Books.anotherText, Books.title, Books.descr, Books.currency_code, Books.dedication_text, Books.dedication_sub_foo, Books.dedication_dedication), ('x' OR 'y'))
+      order by search((Books.createdBy, Books.modifiedBy, Books.anotherText, Books.title, Books.descr, Books.currency_code, Books.dedication_text, Books.dedication_sub_foo, Books.dedication_dedication), ('x' or 'y'), true) desc`
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
   it('Search columns if result is grouped', () => {
     // in this case, we actually search the "title" which comes from the join
@@ -135,7 +165,8 @@ describe('Replace attribute search by search predicate', () => {
     {
       Books.ID,
       books2.title as authorsBook
-    } where search(books2.title, ('x' OR 'y')) group by Books.title `
+    } where search(books2.title, ('x' OR 'y')) group by Books.title
+      order by search(books2.title, ('x' or 'y'), true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
   it('Search on navigation', () => {
@@ -152,7 +183,8 @@ describe('Replace attribute search by search predicate', () => {
           SELECT 1 from bookshop.Authors as $A
           where $A.ID = books.author_ID
         )
-      and search((books.createdBy, books.modifiedBy, books.anotherText, books.title, books.descr, books.currency_code, books.dedication_text, books.dedication_sub_foo, books.dedication_dedication), ('x' OR 'y'))`
+      and search((books.createdBy, books.modifiedBy, books.anotherText, books.title, books.descr, books.currency_code, books.dedication_text, books.dedication_sub_foo, books.dedication_dedication), ('x' OR 'y'))
+      order by search((books.createdBy, books.modifiedBy, books.anotherText, books.title, books.descr, books.currency_code, books.dedication_text, books.dedication_sub_foo, books.dedication_dedication), ('x' or 'y'), true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
   it('Search with aggregated column and groupby must be put into having', () => {
@@ -166,7 +198,8 @@ describe('Replace attribute search by search predicate', () => {
     const expected = cds.ql`
     SELECT from bookshop.Books as Books {
       MIN(Books.title) as firstInAlphabet
-    } group by Books.title having search(MIN(Books.title), 'Cat')`
+    } group by Books.title having search(MIN(Books.title), 'Cat')
+      order by search(MIN(Books.title), 'Cat', true) desc`
     expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(expected)
   })
 
@@ -180,7 +213,8 @@ describe('Replace attribute search by search predicate', () => {
     const expected = cds.ql`
     SELECT from bookshop.Books as Books {
       min(Books.title) as firstInAlphabet
-    } group by Books.title having search(min(Books.title), 'Cat')`
+    } group by Books.title having search(min(Books.title), 'Cat')
+      order by search(min(Books.title), 'Cat', true) desc`
     expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(expected)
   })
 
@@ -197,7 +231,8 @@ describe('Replace attribute search by search predicate', () => {
     SELECT from bookshop.Books as Books {
       Books.title,
       AVG(Books.stock) as searchRelevant,
-    } where search(Books.title, 'x') group by Books.title`
+    } where search(Books.title, 'x') group by Books.title
+      order by search(Books.title, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(expected)
   })
   it('aggregations which are not of type string are not searched', () => {
@@ -210,6 +245,7 @@ describe('Replace attribute search by search predicate', () => {
 
     query.SELECT.search = [{ val: 'x' }]
 
+    // no searchable string column → no search predicate and no ranking order-by
     expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(cds.ql`
       SELECT from bookshop.Books as Books {
         Books.ID,
@@ -231,7 +267,8 @@ describe('Replace attribute search by search predicate', () => {
     SELECT from bookshop.Books as Books {
       Books.ID,
       substring(Books.stock) as searchRelevantViaCast: cds.String,
-    } group by Books.title having search(substring(Books.stock), 'x')`
+    } group by Books.title having search(substring(Books.stock), 'x')
+      order by search(substring(Books.stock), 'x', true) desc`
 
     expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(expected)
   })
@@ -254,6 +291,7 @@ describe('Replace attribute search by search predicate', () => {
       ('1' + '2' + '3') as notSearchRelevant: cds.Integer,
     } group by Books.title
       having search(('very' + 'useful' + 'string'), 'x')
+      order by search(('very' + 'useful' + 'string'), 'x', true) desc
     `
     expect(JSON.parse(JSON.stringify(cqn4sql(query, model)))).to.deep.equal(expected)
   })
@@ -276,11 +314,53 @@ describe('search w/ path expressions', () => {
       BooksSearchAuthorName.ID,
       BooksSearchAuthorName.title
     } where BooksSearchAuthorName.ID in (
-      SELECT from search.BooksSearchAuthorName as $B left join search.Authors as author on author.ID = $B.author_ID 
+      SELECT from search.BooksSearchAuthorName as $B left join search.Authors as author on author.ID = $B.author_ID
       {
         $B.ID
       } where search(author.lastName, 'x')
-    )`
+    )
+    order by (
+      SELECT from search.BooksSearchAuthorName as $B
+        left join search.Authors as author on author.ID = $B.author_ID
+      { max(search(author.lastName, 'x', true)) as max }
+      where $B.ID = BooksSearchAuthorName.ID
+    ) desc`
+    expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
+  })
+
+  // Documents the gap behind the TODO in cqn4sql (PR #1564), per BobdenOs' review note.
+  // For a to-many search path the match score genuinely lives inside a semi-join subquery
+  // (one author matches via many books), not on the outer row. The WHERE clause is correlated
+  // to the outer row through the `ID in (SELECT ...)` pattern. To ALSO rank the outer result
+  // the ORDER BY must carry a subquery that is likewise correlated to the current outer row.
+  // The PR currently reuses the search expression WITHOUT that correlation — this test fails
+  // until cqn4sql binds the order-by sub-select to the outer row.
+  it('deep search along to-many path ranks the outer row by its own correlated score', () => {
+    // @cds.search: {books, books.genre.name}
+    let query = cds.ql`SELECT from search.AuthorSearchBooks as A { ID }`
+    query.SELECT.search = [{ val: 'x' }]
+
+    let res = cqn4sql(query, model)
+
+    const expected = cds.ql`
+    SELECT from search.AuthorSearchBooks as A {
+      A.ID
+    } where A.ID in (
+      SELECT from search.AuthorSearchBooks as $A
+        left join search.Books as books on books.author_ID = $A.ID
+        left join search.Genres as genre on genre.ID = books.genre_ID
+      {
+        $A.ID
+      } where search((books.title, genre.name), 'x')
+    )
+    order by (
+      SELECT from search.AuthorSearchBooks as $A
+        left join search.Books as books on books.author_ID = $A.ID
+        left join search.Genres as genre on genre.ID = books.genre_ID
+      { max(search((books.title, genre.name), 'x', true)) as max }
+      where $A.ID = A.ID
+    ) desc`
+
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -304,7 +384,14 @@ describe('search w/ path expressions', () => {
         $M.toMulti_ID2,
         $M.toMulti_ID3
       } where search(toMulti.text, 'x')
-    )`
+    )
+    order by (
+      SELECT from search.MultipleLeafAssocAsKey as $M
+        left join search.MultipleKeys as toMulti
+          on toMulti.ID1 = $M.toMulti_ID1 and toMulti.ID2 = $M.toMulti_ID2 and toMulti.ID3 = $M.toMulti_ID3
+      { max(search(toMulti.text, 'x', true)) as max }
+      where $M.toMulti_ID1 = M.toMulti_ID1 and $M.toMulti_ID2 = M.toMulti_ID2 and $M.toMulti_ID3 = M.toMulti_ID3
+    ) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -316,7 +403,8 @@ describe('search w/ path expressions', () => {
     const expected = cds.ql`
     SELECT from search.PathInSearchNotProjected as PathInSearchNotProjected {
       PathInSearchNotProjected.title
-    }  where search(PathInSearchNotProjected.title, 'x')`
+    }  where search(PathInSearchNotProjected.title, 'x')
+    order by search(PathInSearchNotProjected.title, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -347,7 +435,13 @@ describe('search w/ path expressions', () => {
       {
         $B.ID
       } where search(($B.title, author.lastName, author.firstName), 'x')
-    )`
+    )
+    order by (
+      SELECT from search.BooksSearchAuthor as $B
+        left join search.Authors as author on author.ID = $B.author_ID
+      { max(search(($B.title, author.lastName, author.firstName), 'x', true)) as max }
+      where $B.ID = Books.ID
+    ) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -368,7 +462,14 @@ describe('search w/ path expressions', () => {
       {
         $B.ID
       } where search(($B.title, authorWithAddress.note, address.city), 'x')
-    )`
+    )
+    order by (
+      SELECT from search.BooksSearchAuthorAndAddress as $B
+        left join search.AuthorsSearchAddresses as authorWithAddress on authorWithAddress.ID = $B.authorWithAddress_ID
+        left join search.Addresses as address on address.ID = authorWithAddress.address_ID
+      { max(search(($B.title, authorWithAddress.note, address.city), 'x', true)) as max }
+      where $B.ID = Books.ID
+    ) desc`
 
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
@@ -388,7 +489,14 @@ describe('search w/ path expressions', () => {
       {
         $A.ID
       } where search((books.title, genre.name), 'x')
-    )`
+    )
+    order by (
+      SELECT from search.AuthorSearchBooks as $A
+        left join search.Books as books on books.author_ID = $A.ID
+        left join search.Genres as genre on genre.ID = books.genre_ID
+      { max(search((books.title, genre.name), 'x', true)) as max }
+      where $A.ID = A.ID
+    ) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -402,7 +510,8 @@ describe('search w/ path expressions', () => {
     {
       BookShelf.ID,
       BookShelf.genre
-    }  where search(BookShelf.genre, 'Harry Plotter')`
+    }  where search(BookShelf.genre, 'Harry Plotter')
+    order by search(BookShelf.genre, 'Harry Plotter', true) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 })
@@ -428,10 +537,20 @@ describe('calculated elements', () => {
         {
           $A.ID
         } where search(
-          ( $A.note, (address.street || ' ' || address.zip || '' || address.city) ), 
+          ( $A.note, (address.street || ' ' || address.zip || '' || address.city) ),
           'x'
         )
-      )`
+      )
+      order by (
+        SELECT from search.AuthorsSearchCalculatedAddress as $A
+          left join search.CalculatedAddresses as address on address.ID = $A.address_ID
+        { max(search(
+          ( $A.note, (address.street || ' ' || address.zip || '' || address.city) ),
+          'x',
+          true
+        )) as max }
+        where $A.ID = Authors.ID
+      ) desc`
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
@@ -444,7 +563,8 @@ describe('calculated elements', () => {
       SELECT from search.CalculatedAddressesWithoutAnno as Address
       {
         Address.ID
-      } where search(Address.city, 'x')`
+      } where search(Address.city, 'x')
+      order by search(Address.city, 'x', true) desc`
 
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
@@ -466,14 +586,20 @@ describe('caching searchable fields', () => {
     {
       Books.ID,
       Books.title
-    } 
+    }
     where Books.ID in (
       SELECT from search.BooksSearchAuthor as $B
         left join search.Authors as author on author.ID = $B.author_ID
       {
         $B.ID
       } where search(($B.title, author.lastName, author.firstName), 'x')
-    )`
+    )
+    order by (
+      SELECT from search.BooksSearchAuthor as $B
+        left join search.Authors as author on author.ID = $B.author_ID
+      { max(search(($B.title, author.lastName, author.firstName), 'x', true)) as max }
+      where $B.ID = Books.ID
+    ) desc`
 
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
     // test caching
@@ -536,8 +662,15 @@ describe('include / exclude logic', () => {
         left join search.Addresses as address on address.ID = authorWithAddress.address_ID
       {
         $B.ID
-      } where search(($B.title, authorWithAddress.note, address.city), 'x') 
-    )`
+      } where search(($B.title, authorWithAddress.note, address.city), 'x')
+    )
+    order by (
+      SELECT from search.BooksSearchAuthorAndAddress as $B
+        left join search.AuthorsSearchAddresses as authorWithAddress on authorWithAddress.ID = $B.authorWithAddress_ID
+        left join search.Addresses as address on address.ID = authorWithAddress.address_ID
+      { max(search(($B.title, authorWithAddress.note, address.city), 'x', true)) as max }
+      where $B.ID = Books.ID
+    ) desc`
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
   })
 
@@ -550,7 +683,8 @@ describe('include / exclude logic', () => {
       Books.ID,
       Books.description,
       Books.title
-    } where search(Books.description, 'x')`
+    } where search(Books.description, 'x')
+    order by search(Books.description, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
   })
 
@@ -566,8 +700,14 @@ describe('include / exclude logic', () => {
         left join search.Books as books on books.author_ID = $A.ID
       {
         $A.ID
-      } where search(books.title, 'x') 
-    )`
+      } where search(books.title, 'x')
+    )
+    order by (
+      SELECT from search.AuthorSearchOnlyBooksTitle as $A
+        left join search.Books as books on books.author_ID = $A.ID
+      { max(search(books.title, 'x', true)) as max }
+      where $A.ID = A.ID
+    ) desc`
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
   })
 
@@ -578,7 +718,8 @@ describe('include / exclude logic', () => {
     const expected = cds.ql`
     SELECT from search.Addresses as Addresses {
       Addresses.ID
-    } where search(Addresses.city, 'x')`
+    } where search(Addresses.city, 'x')
+    order by search(Addresses.city, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
   })
 
@@ -589,7 +730,8 @@ describe('include / exclude logic', () => {
     const expected = cds.ql`
     SELECT from search.BooksIgnoreVirtualElement as Books {
       Books.ID
-    } where search(Books.title, 'x')`
+    } where search(Books.title, 'x')
+    order by search(Books.title, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
   })
 
@@ -600,7 +742,8 @@ describe('include / exclude logic', () => {
     const expected = cds.ql`
     SELECT from search.BooksIgnoreExplicitVirtualElement as Books {
       Books.ID
-    } where search(Books.title, 'x')`
+    } where search(Books.title, 'x')
+    order by search(Books.title, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(transformed))).to.deep.equal(expected)
   })
 
@@ -613,7 +756,8 @@ describe('include / exclude logic', () => {
       SELECT from search.CalculatedAddressesExclude as Address
       {
         Address.ID
-      } where search(Address.city, 'x')`
+      } where search(Address.city, 'x')
+      order by search(Address.city, 'x', true) desc`
 
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
@@ -638,7 +782,8 @@ describe('include / exclude logic', () => {
     SELECT from search.BooksDontSearchAuthor as Books
     {
       Books.ID
-    } where search(Books.title, 'x')`
+    } where search(Books.title, 'x')
+    order by search(Books.title, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(noAuthor))).to.deep.equal(expected)
   })
 })

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -3,8 +3,10 @@ const cqn4sql = require('../../lib/cqn4sql')
 const cds = require('@sap/cds')
 const { expect } = cds.test
 
-// An `ORDER BY <search-score> DESC` is injected into every search query so results are
-// ranked by relevance.
+// An `ORDER BY <search-score> DESC` is injected into search queries so results are ranked by
+// relevance. This is a HANA fuzzy-search feature (other DBs have no relevance score), so it is
+// only emitted when the active db is HANA with fuzzy enabled. The tests below therefore run with
+// a HANA db kind + fuzzy on; the dedicated test at the end asserts it is skipped otherwise.
 //
 // Flat (non-navigation) search: the score is computed on the row itself, so the order-by is just
 // the search() func with the numeric flag `true` appended, sorted desc.
@@ -13,6 +15,20 @@ const { expect } = cds.test
 // <joins> WHERE search(...))`; the order-by is a scalar sub-select over the SAME joins that
 // selects the numeric score (`search(..., true) as search`) and is correlated to the current
 // outer row via `innerKey = outerKey` (AND-chained for structured keys).
+
+let _db, _fuzzy
+beforeAll(() => {
+  // ranking is gated on `cds.db.kind === 'hana' && cds.env.hana.fuzzy !== false`
+  _db = cds.db
+  _fuzzy = cds.env.hana?.fuzzy
+  cds.db = { kind: 'hana' }
+  ;(cds.env.hana ??= {}).fuzzy = true
+})
+afterAll(() => {
+  cds.db = _db
+  if (_fuzzy === undefined) delete cds.env.hana.fuzzy
+  else cds.env.hana.fuzzy = _fuzzy
+})
 
 describe('Replace attribute search by search predicate', () => {
   let model
@@ -781,5 +797,41 @@ describe('include / exclude logic', () => {
     } where search(Books.title, 'x')
     order by search(Books.title, 'x', true) desc`
     expect(JSON.parse(JSON.stringify(noAuthor))).to.deep.equal(expected)
+  })
+})
+
+describe('no search ranking without HANA fuzzy scoring', () => {
+  // ranking is gated on `cds.db.kind === 'hana' && cds.env.hana.fuzzy !== false`; when the active
+  // db has no relevance score the injected order-by would sort by a constant, so it is skipped.
+  let model, _db, _fuzzy
+  beforeAll(async () => {
+    model = cds.model = cds.compile.for.nodejs(await cds.load(`${__dirname}/../bookshop/db/schema`).then(cds.linked))
+    _db = cds.db
+    _fuzzy = cds.env.hana?.fuzzy
+  })
+  afterAll(() => {
+    cds.db = _db
+    if (_fuzzy === undefined) delete cds.env.hana.fuzzy
+    else cds.env.hana.fuzzy = _fuzzy
+  })
+
+  it('non-HANA db does not get a ranking order-by', () => {
+    cds.db = { kind: 'sqlite' }
+    ;(cds.env.hana ??= {}).fuzzy = true // irrelevant for non-HANA
+    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID }`
+    query.SELECT.search = [{ val: 'x' }]
+
+    const res = cqn4sql(query, model)
+    expect(res.SELECT.orderBy).to.be.undefined
+  })
+
+  it('HANA with fuzzy=false does not get a ranking order-by', () => {
+    cds.db = { kind: 'hana' }
+    cds.env.hana.fuzzy = false
+    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID }`
+    query.SELECT.search = [{ val: 'x' }]
+
+    const res = cqn4sql(query, model)
+    expect(res.SELECT.orderBy).to.be.undefined
   })
 })

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -834,4 +834,76 @@ describe('no search ranking without HANA fuzzy scoring', () => {
     const res = cqn4sql(query, model)
     expect(res.SELECT.orderBy).to.be.undefined
   })
+
+  it('opting out via hana.fuzzy.ranked_search = false does not get a ranking order-by', () => {
+    cds.db = { kind: 'hana' }
+    cds.env.hana.fuzzy = { ranked_search: false }
+    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID }`
+    query.SELECT.search = [{ val: 'x' }]
+
+    const res = cqn4sql(query, model)
+    expect(res.SELECT.orderBy).to.be.undefined
+  })
+})
+
+describe('search ranking order-by precedence', () => {
+  // Precedence in the order-by: user-provided ordering first, then the $search relevance rank,
+  // then the runtime's implicit key ordering (entries flagged `implicit: true`, added for stable
+  // pagination — see @sap/cds .../common/generic/sorting.js).
+  let model, _db, _fuzzy
+  beforeAll(async () => {
+    model = cds.model = cds.compile.for.nodejs(await cds.load(`${__dirname}/../bookshop/db/schema`).then(cds.linked))
+    _db = cds.db
+    _fuzzy = cds.env.hana?.fuzzy
+    cds.db = { kind: 'hana' }
+    ;(cds.env.hana ??= {}).fuzzy = true
+  })
+  afterAll(() => {
+    cds.db = _db
+    if (_fuzzy === undefined) delete cds.env.hana.fuzzy
+    else cds.env.hana.fuzzy = _fuzzy
+  })
+
+  const rankEntry = {
+    func: 'search',
+    args: [{ list: [{ ref: ['Genres', 'name'] }, { ref: ['Genres', 'descr'] }, { ref: ['Genres', 'code'] }] }, { val: 'x' }, { val: true }],
+    sort: 'desc',
+  }
+
+  it('rank comes first when there is no user or implicit ordering', () => {
+    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID }`
+    query.SELECT.search = [{ val: 'x' }]
+    const res = cqn4sql(query, model)
+    expect(res.SELECT.orderBy).to.deep.equal([rankEntry])
+  })
+
+  it('rank comes after user-provided ordering', () => {
+    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID } order by ID asc`
+    query.SELECT.search = [{ val: 'x' }]
+    const res = cqn4sql(query, model)
+    expect(res.SELECT.orderBy).to.deep.equal([{ ref: ['ID'], sort: 'asc' }, rankEntry])
+  })
+
+  it('rank comes before the runtime implicit key ordering', () => {
+    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID }`
+    query.SELECT.search = [{ val: 'x' }]
+    query.SELECT.orderBy = [{ ref: ['ID'], sort: 'asc', implicit: true }]
+    const res = cqn4sql(query, model)
+    expect(res.SELECT.orderBy).to.deep.equal([rankEntry, { ref: ['ID'], sort: 'asc' }])
+  })
+
+  it('rank goes between user ordering and the implicit key ordering', () => {
+    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID, name }`
+    query.SELECT.search = [{ val: 'x' }]
+    query.SELECT.orderBy = [
+      { ref: ['name'], sort: 'desc' }, // user
+      { ref: ['ID'], sort: 'asc', implicit: true }, // runtime key ordering
+    ]
+    const res = cqn4sql(query, model)
+    expect(res.SELECT.orderBy).to.deep.equal([
+      { ref: ['name'], sort: 'desc' },
+      rankEntry,
+      { ref: ['ID'], sort: 'asc' },
+    ])
+  })
 })

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -3,9 +3,8 @@ const cqn4sql = require('../../lib/cqn4sql')
 const cds = require('@sap/cds')
 const { expect } = cds.test
 
-// PR #1564 injects an `ORDER BY <search-score> DESC` into every search query so results are
-// ranked by relevance. Each test asserts the full transformed query — including that order-by —
-// as a single cds.ql template, so a regression in the injected ranking is caught.
+// An `ORDER BY <search-score> DESC` is injected into every search query so results are
+// ranked by relevance.
 //
 // Flat (non-navigation) search: the score is computed on the row itself, so the order-by is just
 // the search() func with the numeric flag `true` appended, sorted desc.
@@ -328,13 +327,10 @@ describe('search w/ path expressions', () => {
     expect(JSON.parse(JSON.stringify(res))).to.deep.equal(expected)
   })
 
-  // Documents the gap behind the TODO in cqn4sql (PR #1564), per BobdenOs' review note.
-  // For a to-many search path the match score genuinely lives inside a semi-join subquery
+  // For a to-many search path the match score lives inside a semi-join subquery
   // (one author matches via many books), not on the outer row. The WHERE clause is correlated
   // to the outer row through the `ID in (SELECT ...)` pattern. To ALSO rank the outer result
   // the ORDER BY must carry a subquery that is likewise correlated to the current outer row.
-  // The PR currently reuses the search expression WITHOUT that correlation — this test fails
-  // until cqn4sql binds the order-by sub-select to the outer row.
   it('deep search along to-many path ranks the outer row by its own correlated score', () => {
     // @cds.search: {books, books.genre.name}
     let query = cds.ql`SELECT from search.AuthorSearchBooks as A { ID }`

--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -156,9 +156,10 @@ const StandardFunctions = {
       return `(CASE WHEN (${toString({ xpr })}) THEN TRUE ELSE FALSE END)`
     }
 
-    // fuzziness config; `fuzzy` may be a number (threshold) or an object (e.g. { ranked_search }),
-    // so only take it as the minimal score when it is actually a number
-    const fuzzyIndex = typeof cds.env.hana?.fuzzy === 'number' ? cds.env.hana.fuzzy : 0.7
+    // fuzziness config; `fuzzy` is either the minimal score directly or an object
+    // `{ score, ranked_search }` carrying it as `.score`
+    const fuzzyConfig = cds.env.hana?.fuzzy
+    const fuzzyIndex = (typeof fuzzyConfig === 'object' ? fuzzyConfig.score : fuzzyConfig) || 0.7
 
     const csnElements = ref.list || [ref]
     // if column specific value is provided, the configuration has to be defined on column level

--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -159,7 +159,7 @@ const StandardFunctions = {
     // fuzziness config; `fuzzy` is either the minimal score directly or an object
     // `{ score, ranked_search }` carrying it as `.score`
     const fuzzyConfig = cds.env.hana?.fuzzy
-    const fuzzyIndex = (typeof fuzzyConfig === 'object' ? fuzzyConfig.score : fuzzyConfig) || 0.7
+    const fuzzyIndex = (typeof fuzzyConfig === 'object' ? fuzzyConfig?.score : fuzzyConfig) || 0.7
 
     const csnElements = ref.list || [ref]
     // if column specific value is provided, the configuration has to be defined on column level

--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -156,8 +156,9 @@ const StandardFunctions = {
       return `(CASE WHEN (${toString({ xpr })}) THEN TRUE ELSE FALSE END)`
     }
 
-    // fuzziness config
-    const fuzzyIndex = cds.env.hana?.fuzzy || 0.7
+    // fuzziness config; `fuzzy` may be a number (threshold) or an object (e.g. { ranked_search }),
+    // so only take it as the minimal score when it is actually a number
+    const fuzzyIndex = typeof cds.env.hana?.fuzzy === 'number' ? cds.env.hana.fuzzy : 0.7
 
     const csnElements = ref.list || [ref]
     // if column specific value is provided, the configuration has to be defined on column level

--- a/hana/lib/cql-functions.js
+++ b/hana/lib/cql-functions.js
@@ -184,8 +184,12 @@ const StandardFunctions = {
         }
         fuzzy += ` MINIMAL SCORE ${e.element?.['@Search.fuzzinessThreshold'] || fuzzyIndex} SIMILARITY CALCULATION MODE 'search'`
         // rewrite ref to xpr to mix in search config
-        // ensure in place modification to reuse .toString method that ensures quoting
-        e.xpr = [{ ref: e.ref }, fuzzy]
+        // ensure in place modification to reuse .toString method that ensures quoting.
+        // idempotent: the same search() args may be rendered twice (e.g. WHERE predicate and the
+        // injected ranking ORDER BY), so recover the original ref from a prior rewrite instead of
+        // reading a now-deleted e.ref.
+        const originalRef = e.ref || e.xpr?.[0]?.ref
+        e.xpr = [{ ref: originalRef }, fuzzy]
         delete e.ref
       })
     } else {

--- a/hana/test/fuzzy.test.js
+++ b/hana/test/fuzzy.test.js
@@ -64,8 +64,9 @@ describe('search', () => {
       const { Books } = cds.entities('sap.capire.bookshop')
       const cqn = SELECT.from(Books).search('"autobio"').columns('1')
       const { sql } = cds.db.cqn2sql(cqn)
-      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code
-      expect(sql.match(/(like)/g).length).to.eq(5)
+      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code — once in
+      // the WHERE and once more in the injected ranking ORDER BY (search relevance)
+      expect(sql.match(/(like)/g).length).to.eq(10)
       const res = await cqn
       expect(res.length).to.eq(2) // Eleonora and Jane Eyre
     })
@@ -74,8 +75,8 @@ describe('search', () => {
       const { Books } = cds.entities('sap.capire.bookshop')
       const cqn = SELECT.from(Books).search('"autobio"', '"Jane"').columns('1')
       const { sql, values } = cds.db.cqn2sql(cqn)
-      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code
-      expect(sql.match(/(like)/g).length).to.eq(10)
+      // 5 searched columns × 2 terms, in WHERE and again in the ranking ORDER BY
+      expect(sql.match(/(like)/g).length).to.eq(20)
       expect(values).to.include('%autobio%')
       expect(values).to.include('%jane%')
       const res = await cqn
@@ -86,8 +87,8 @@ describe('search', () => {
       const { Books } = cds.entities('sap.capire.bookshop')
       const cqn = SELECT.from(Books).search('"1847"', '1846', '"\\"Ellis Bell\\""').columns('1')
       const { sql, values } = cds.db.cqn2sql(cqn)
-      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code
-      expect(sql.match(/(like)/g).length).to.eq(15)
+      // 5 searched columns × 3 terms, in WHERE and again in the ranking ORDER BY
+      expect(sql.match(/(like)/g).length).to.eq(30)
       expect(values).to.include('%1847%')
       expect(values).to.include('%1846%')
       expect(values).to.include('%"ellis bell"%')

--- a/hana/test/fuzzy.test.js
+++ b/hana/test/fuzzy.test.js
@@ -35,6 +35,16 @@ describe('search', () => {
       await cqn
     })
 
+    test('global config as object', async () => {
+      // fuzzy may be an object carrying the minimal score as `.score` (alongside `ranked_search`)
+      cds.env.hana.fuzzy = { score: 0.9, ranked_search: false }
+      const { Books } = cds.entities('sap.capire.bookshop')
+      const cqn = SELECT.from(Books).search('"autobio"').columns('1')
+      const { sql } = cds.db.cqn2sql(cqn)
+      expect(sql).to.include('FUZZY MINIMAL SCORE 0.9')
+      await cqn
+    })
+
     test('list of elements - annotations', async () => {
       const { BooksAnnotated } = cds.entities('sap.capire.bookshop')
       const cqn = SELECT.from(BooksAnnotated).search('"first-person"').columns('1')

--- a/hana/test/fuzzy.test.js
+++ b/hana/test/fuzzy.test.js
@@ -64,9 +64,8 @@ describe('search', () => {
       const { Books } = cds.entities('sap.capire.bookshop')
       const cqn = SELECT.from(Books).search('"autobio"').columns('1')
       const { sql } = cds.db.cqn2sql(cqn)
-      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code — once in
-      // the WHERE and once more in the injected ranking ORDER BY (search relevance)
-      expect(sql.match(/(like)/g).length).to.eq(10)
+      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code
+      expect(sql.match(/(like)/g).length).to.eq(5)
       const res = await cqn
       expect(res.length).to.eq(2) // Eleonora and Jane Eyre
     })
@@ -75,8 +74,8 @@ describe('search', () => {
       const { Books } = cds.entities('sap.capire.bookshop')
       const cqn = SELECT.from(Books).search('"autobio"', '"Jane"').columns('1')
       const { sql, values } = cds.db.cqn2sql(cqn)
-      // 5 searched columns × 2 terms, in WHERE and again in the ranking ORDER BY
-      expect(sql.match(/(like)/g).length).to.eq(20)
+      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code
+      expect(sql.match(/(like)/g).length).to.eq(10)
       expect(values).to.include('%autobio%')
       expect(values).to.include('%jane%')
       const res = await cqn
@@ -87,8 +86,8 @@ describe('search', () => {
       const { Books } = cds.entities('sap.capire.bookshop')
       const cqn = SELECT.from(Books).search('"1847"', '1846', '"\\"Ellis Bell\\""').columns('1')
       const { sql, values } = cds.db.cqn2sql(cqn)
-      // 5 searched columns × 3 terms, in WHERE and again in the ranking ORDER BY
-      expect(sql.match(/(like)/g).length).to.eq(30)
+      // 5 columns to be searched createdBy, modifiedBy, title, descr, currency_code
+      expect(sql.match(/(like)/g).length).to.eq(15)
       expect(values).to.include('%1847%')
       expect(values).to.include('%1846%')
       expect(values).to.include('%"ellis bell"%')

--- a/hana/test/search-ranking-odata.test.js
+++ b/hana/test/search-ranking-odata.test.js
@@ -1,0 +1,32 @@
+const cds = require('../../test/cds.js')
+const bookshop = cds.utils.path.resolve(__dirname, '../../test/bookshop')
+
+const admin = { auth: { username: 'alice' } }
+
+// $top makes the runtime add its implicit key ordering for stable pagination; the $search
+// relevance rank must take precedence, with the key ordering only as a secondary criterion.
+describe('search ranking via OData service (e2e, HANA only)', () => {
+  const { expect, GET } = cds.test(bookshop)
+
+  // 'Jane' hits the TITLE of "Jane Eyre" (ID 207) and only the DESCR of "Wuthering Heights"
+  // (ID 201, "...sister Charlotte's novel Jane Eyre...")
+  // Relevance ranks the title hit (207) first; the implicit key ordering (forced by $top) would put 201 first
+  const search = () => GET('/admin/Books?$search=Jane&$top=5&$select=ID,title', admin)
+
+  test('ranked search wins over the implicit key ordering', async () => {
+    const ids = (await search()).data.value.map(b => b.ID)
+    expect(ids.indexOf(207)).to.be.lessThan(ids.indexOf(201))
+  })
+
+  test('without ranking the implicit key ordering decides (same request)', async () => {
+    const _fuzzy = cds.env.hana.fuzzy
+    cds.env.hana.fuzzy = { ranked_search: false }
+    try {
+      const ids = (await search()).data.value.map(b => b.ID)
+      // no rank -> only the implicit key ordering remains, so 201 comes before 207
+      expect(ids.indexOf(201)).to.be.lessThan(ids.indexOf(207))
+    } finally {
+      cds.env.hana.fuzzy = _fuzzy
+    }
+  })
+})

--- a/hana/test/search-ranking-odata.test.js
+++ b/hana/test/search-ranking-odata.test.js
@@ -5,7 +5,7 @@ const admin = { auth: { username: 'alice' } }
 
 // $top makes the runtime add its implicit key ordering for stable pagination; the $search
 // relevance rank must take precedence, with the key ordering only as a secondary criterion.
-describe('search ranking via OData service (e2e, HANA only)', () => {
+describe('search ranking via OData service', () => {
   const { expect, GET } = cds.test(bookshop)
 
   // 'Jane' hits the TITLE of "Jane Eyre" (ID 207) and only the DESCR of "Wuthering Heights"

--- a/hana/test/search-ranking.cds
+++ b/hana/test/search-ranking.cds
@@ -1,0 +1,25 @@
+namespace search.ranking;
+
+entity Genres {
+  key ID   : Integer;
+      name : String;
+}
+
+entity Books {
+  key ID     : Integer;
+      title  : String;
+      author : Association to Authors;
+      genre  : Association to Genres;
+}
+
+entity Authors {
+  key ID    : Integer;
+      name  : String;
+      books : Composition of many Books
+                on books.author = $self;
+}
+
+// to-many searchable path: an author matches via any of its books' title or genre name.
+// The ranking ORDER BY must correlate a MAX(SCORE(...)) sub-select to each author row.
+@cds.search: {books.title, books.genre.name}
+entity SearchAuthors : Authors {}

--- a/hana/test/search-ranking.cds
+++ b/hana/test/search-ranking.cds
@@ -13,7 +13,6 @@ entity Books {
 }
 
 // to-many searchable path: an author matches via any of its books' title or genre name.
-// The ranking ORDER BY must correlate a MAX(SCORE(...)) sub-select to each author row.
 @cds.search: {books.title, books.genre.name}
 entity SearchAuthors {
   key ID    : Integer;

--- a/hana/test/search-ranking.cds
+++ b/hana/test/search-ranking.cds
@@ -8,18 +8,16 @@ entity Genres {
 entity Books {
   key ID     : Integer;
       title  : String;
-      author : Association to Authors;
+      author : Association to SearchAuthors;
       genre  : Association to Genres;
-}
-
-entity Authors {
-  key ID    : Integer;
-      name  : String;
-      books : Composition of many Books
-                on books.author = $self;
 }
 
 // to-many searchable path: an author matches via any of its books' title or genre name.
 // The ranking ORDER BY must correlate a MAX(SCORE(...)) sub-select to each author row.
 @cds.search: {books.title, books.genre.name}
-entity SearchAuthors : Authors {}
+entity SearchAuthors {
+  key ID    : Integer;
+      name  : String;
+      books : Composition of many Books
+                on books.author = $self;
+}

--- a/hana/test/search-ranking.test.js
+++ b/hana/test/search-ranking.test.js
@@ -50,4 +50,12 @@ describe('search ranking (e2e, HANA only)', () => {
     expect(ids[0]).to.eq(10)
     expect(ids[1]).to.eq(20)
   })
+
+  test('user-provided order by takes precedence over the search rank', async () => {
+    const { SearchAuthors } = cds.entities('search.ranking')
+    // by name desc: 'Weak' (20) before 'Strong' (10) — the OPPOSITE of the relevance order,
+    // so this only holds if user ordering wins and the rank is applied after it.
+    const res = await SELECT.from(SearchAuthors).columns('ID').search('Cat').orderBy('name desc')
+    expect(res.map(r => r.ID)).to.eql([20, 10])
+  })
 })

--- a/hana/test/search-ranking.test.js
+++ b/hana/test/search-ranking.test.js
@@ -58,4 +58,23 @@ describe('search ranking (e2e, HANA only)', () => {
     const res = await SELECT.from(SearchAuthors).columns('ID').search('Cat').orderBy('name desc')
     expect(res.map(r => r.ID)).to.eql([20, 10])
   })
+
+  test('opting out via hana.fuzzy.ranked_search = false skips the ranking', async () => {
+    const _fuzzy = cds.env.hana.fuzzy
+    cds.env.hana.fuzzy = { ranked_search: false }
+    try {
+      const { SearchAuthors } = cds.entities('search.ranking')
+      const q = SELECT.from(SearchAuthors).columns('ID').search('Cat')
+
+      // no ranking sub-select is injected ...
+      const { sql } = cds.db.cqn2sql(q)
+      expect(sql).to.not.match(/ORDER BY/i)
+
+      // ... but the search itself still works (both matching authors returned)
+      const ids = (await q).map(r => r.ID)
+      expect(ids).to.have.members([10, 20])
+    } finally {
+      cds.env.hana.fuzzy = _fuzzy
+    }
+  })
 })

--- a/hana/test/search-ranking.test.js
+++ b/hana/test/search-ranking.test.js
@@ -1,0 +1,55 @@
+const cds = require('../../test/cds')
+
+// End-to-end verification of $search relevance ranking on a real HANA (needs SCORE()).
+// A to-many search path (SearchAuthors -> books.title / books.genre.name) makes one author
+// fan out to many joined child rows; the ranking ORDER BY is a correlated MAX(SCORE(...))
+// sub-select. This asserts the actual row order and de-duplication end to end — something
+// SQLite/Postgres cannot validate because they have no relevance score.
+describe('search ranking (e2e, HANA only)', () => {
+  const { expect } = cds.test(__dirname, 'search-ranking.cds')
+
+  beforeAll(async () => {
+    const { SearchAuthors, Books, Genres } = cds.entities('search.ranking')
+    await cds.run([
+      INSERT.into(Genres).entries([
+        { ID: 1, name: 'Fantasy' },
+        { ID: 2, name: 'Catalogue' },
+        { ID: 3, name: 'History' },
+      ]),
+      INSERT.into(SearchAuthors).entries([
+        { ID: 10, name: 'Strong' },
+        { ID: 20, name: 'Weak' },
+        { ID: 30, name: 'None' },
+      ]),
+      INSERT.into(Books).entries([
+        // author 10: an exact title hit for 'Cat' plus an unrelated book -> should rank highest
+        { ID: 100, title: 'Cat', author_ID: 10, genre_ID: 1 },
+        { ID: 101, title: 'Unrelated', author_ID: 10, genre_ID: 1 },
+        // author 20: only a partial/weaker hit via the genre name 'Catalogue'
+        { ID: 200, title: 'Unrelated', author_ID: 20, genre_ID: 2 },
+        // author 30: no match at all
+        { ID: 300, title: 'Unrelated', author_ID: 30, genre_ID: 3 },
+      ]),
+    ])
+  })
+
+  test('deep to-many search ranks by best-matching child score, without duplicates', async () => {
+    const { SearchAuthors } = cds.entities('search.ranking')
+    const q = SELECT.from(SearchAuthors).columns('ID').search('Cat')
+
+    // sanity: the injected order-by is the correlated MAX(SCORE(...)) sub-select
+    const { sql } = cds.db.cqn2sql(q)
+    expect(sql).to.match(/ORDER BY \(SELECT max\(SCORE\(/i)
+
+    const res = await q
+
+    // only the two matching authors come back, each exactly once (semi-join de-dups the fan-out)
+    const ids = res.map(r => r.ID)
+    expect(ids).to.have.members([10, 20])
+    expect(ids.length).to.eq(2)
+
+    // ranked by relevance desc: the exact title match (author 10) outranks the genre-only match (author 20)
+    expect(ids[0]).to.eq(10)
+    expect(ids[1]).to.eq(20)
+  })
+})

--- a/hana/test/search-ranking.test.js
+++ b/hana/test/search-ranking.test.js
@@ -3,7 +3,7 @@ const cds = require('../../test/cds')
 // A to-many search path (SearchAuthors -> books.title / books.genre.name) makes one author
 // fan out to many joined child rows; the ranking ORDER BY is a correlated MAX(SCORE(...))
 // sub-select.
-describe('search ranking (e2e, HANA only)', () => {
+describe('search ranking', () => {
   const { expect } = cds.test(__dirname, 'search-ranking.cds')
 
   beforeAll(async () => {

--- a/hana/test/search-ranking.test.js
+++ b/hana/test/search-ranking.test.js
@@ -1,10 +1,8 @@
 const cds = require('../../test/cds')
 
-// End-to-end verification of $search relevance ranking on a real HANA (needs SCORE()).
 // A to-many search path (SearchAuthors -> books.title / books.genre.name) makes one author
 // fan out to many joined child rows; the ranking ORDER BY is a correlated MAX(SCORE(...))
-// sub-select. This asserts the actual row order and de-duplication end to end — something
-// SQLite/Postgres cannot validate because they have no relevance score.
+// sub-select.
 describe('search ranking (e2e, HANA only)', () => {
   const { expect } = cds.test(__dirname, 'search-ranking.cds')
 


### PR DESCRIPTION
The deep-search ranking ORDER BY reused the search expression without binding it to the outer query row, so the sub-select produced a `key IN (key)` tautology instead of a correlation. By defering the ranking `ORDER BY` to after `infer()`, where the outer alias is known, the score sub-select can be correlated to the outer row post-transform (mirroring expand's _correlate). A deep search may lead to one outer row yielding many joined child rows, so wrap the score in MAX() to keep the scalar sub-select single-valued and rank by the best-matching child.