### PR TITLE
perf: do not use ranked search for static values

### DIFF
--- a/db-service/lib/cqn4sql.js
+++ b/db-service/lib/cqn4sql.js
@@ -338,9 +338,11 @@ function _cqn4sql(originalQuery, model, useTechnicalAlias = true) {
     // it would sort by a constant boolean.
     const ranksSearch =
       cds.db?.kind === 'hana' && cds.env.hana?.fuzzy !== false && cds.env.hana?.fuzzy?.ranked_search !== false
-    // count queries do not need ranked search
-    const isCountQuery = columns?.length === 1 && columns[0].func === 'count'
-    const searchRank = ranksSearch && !isCountQuery && inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
+    // count queries or static values do not need ranked search
+    const isCountQuery = columns?.length === 1 && typeof columns[0] === 'object' && (columns[0].func === 'count' || 'val' in columns[0])
+    // a user-provided ORDER BY takes precedence over the search rank — don't inject the ranking then
+    const hasExplicitOrderBy = (orderBy || []).some(o => !o.implicit)
+    const searchRank = ranksSearch && !isCountQuery && !hasExplicitOrderBy && inferred.$searchRank && buildSearchRankOrderBy(inferred.$searchRank)
     if (searchRank) {
       // precedence: user ordering, then rank, then the runtime's implicit key ordering
       const implicitAt = (orderBy || []).findIndex(o => o.implicit)

--- a/db-service/test/cqn4sql/search.test.js
+++ b/db-service/test/cqn4sql/search.test.js
@@ -877,11 +877,11 @@ describe('search ranking order-by precedence', () => {
     expect(res.SELECT.orderBy).to.deep.equal([rankEntry])
   })
 
-  it('rank comes after user-provided ordering', () => {
+  it('user-provided ordering does not add rank', () => {
     const query = cds.ql`SELECT from bookshop.Genres as Genres { ID } order by ID asc`
     query.SELECT.search = [{ val: 'x' }]
     const res = cqn4sql(query, model)
-    expect(res.SELECT.orderBy).to.deep.equal([{ ref: ['ID'], sort: 'asc' }, rankEntry])
+    expect(res.SELECT.orderBy).to.deep.equal([{ ref: ['ID'], sort: 'asc' }])
   })
 
   it('rank comes before the runtime implicit key ordering', () => {
@@ -890,20 +890,5 @@ describe('search ranking order-by precedence', () => {
     query.SELECT.orderBy = [{ ref: ['ID'], sort: 'asc', implicit: true }]
     const res = cqn4sql(query, model)
     expect(res.SELECT.orderBy).to.deep.equal([rankEntry, { ref: ['ID'], sort: 'asc' }])
-  })
-
-  it('rank goes between user ordering and the implicit key ordering', () => {
-    const query = cds.ql`SELECT from bookshop.Genres as Genres { ID, name }`
-    query.SELECT.search = [{ val: 'x' }]
-    query.SELECT.orderBy = [
-      { ref: ['name'], sort: 'desc' }, // user
-      { ref: ['ID'], sort: 'asc', implicit: true }, // runtime key ordering
-    ]
-    const res = cqn4sql(query, model)
-    expect(res.SELECT.orderBy).to.deep.equal([
-      { ref: ['name'], sort: 'desc' },
-      rankEntry,
-      { ref: ['ID'], sort: 'asc' },
-    ])
   })
 })

--- a/hana/test/search-ranking.test.js
+++ b/hana/test/search-ranking.test.js
@@ -51,11 +51,13 @@ describe('search ranking', () => {
     expect(ids[1]).to.eq(20)
   })
 
-  test('user-provided order by takes precedence over the search rank', async () => {
+  test('user-provided order by takes precedence', async () => {
     const { SearchAuthors } = cds.entities('search.ranking')
-    // by name desc: 'Weak' (20) before 'Strong' (10) — the OPPOSITE of the relevance order,
-    // so this only holds if user ordering wins and the rank is applied after it.
-    const res = await SELECT.from(SearchAuthors).columns('ID').search('Cat').orderBy('name desc')
+    const q = SELECT.from(SearchAuthors).columns('ID').search('Cat').orderBy('name desc')
+    const { sql } = cds.db.cqn2sql(q)
+    expect(sql).not.to.match(/ORDER BY .*\(SELECT max\(SCORE\(/i)
+
+    const res = await q
     expect(res.map(r => r.ID)).to.eql([20, 10])
   })
 
@@ -77,6 +79,24 @@ describe('search ranking', () => {
 
     const { sql } = cds.db.cqn2sql(q)
     expect(sql).to.not.match(/ORDER BY/i)
+  })
+
+  test('a search query that only selects static values is not ranked', () => {
+    const { SearchAuthors } = cds.entities('search.ranking')
+    // a single count element collapses all matches into one row -> nothing to rank
+    const q = SELECT.from(SearchAuthors).columns({ val: 1, param: false, as: '1' }).search('Cat')
+
+    const { sql } = cds.db.cqn2sql(q)
+    expect(sql).to.not.match(/ORDER BY/i)
+  })
+
+  test('a search query that selects * is ranked', () => {
+    const { SearchAuthors } = cds.entities('search.ranking')
+    // a single count element collapses all matches into one row -> nothing to rank
+    const q = SELECT.from(SearchAuthors).columns('*').search('Cat')
+
+    const { sql } = cds.db.cqn2sql(q)
+    expect(sql).to.match(/ORDER BY/i)
   })
 
   test('opting out via hana.fuzzy.ranked_search = false skips the ranking', async () => {


### PR DESCRIPTION
perf: if explicit order by is specified, do not add ranked search as a secondary clause
